### PR TITLE
fix(ticket): archive namespace isolation + no-ping transcripts (v3.1.42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.42] - 2026-05-31
+
+### Fixed
+
+- **Ticket/application archives could pull the wrong user's thread.** Ticket
+  archives are grouped per user — by `createdBy` for normal tickets, by
+  `emailSender` for email-import tickets. But an email-import ticket's
+  `createdBy` is the importing admin, not the player, so a normal ticket the
+  admin opened could match (and append into) an email-import archive that shared
+  their `createdBy`. `findExistingArchive` now scopes each lookup to its own
+  namespace via the `isEmailTicket` discriminator, so email-import and normal
+  archives can never cross-contaminate. (`src/utils/ticket/closeWorkflow.ts`)
+- **Archived transcripts no longer ping anyone.** Every forum post in the ticket
+  and application archive paths now sends with `allowedMentions: { parse: [] }`,
+  and message content is captured via `cleanContent` (mentions render as
+  readable `@name`/`#name` text, not raw `<@id>` mention syntax). Historical
+  transcript content can never notify users/roles or fire `@everyone`/`@here`.
+  (`closeWorkflow.ts` × 2, `fetchAllMessages.ts`)
+
 ## [3.1.41] - 2026-05-05
 
 Two prod-bug fixes from 2026-05-04/05 incident logs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - **Runtime**: Bun
 - **Deployment**: Docker containers
 - **Branches**: `main` (production)
-- **Version**: 3.1.41
+- **Version**: 3.1.42
 
 ## Critical Rules
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.1.41",
+  "version": "3.1.42",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -77,11 +77,12 @@ export async function archiveAndCloseApplication(
     if (!existingArchive) {
       const newPost = await forumChannel.threads.create({
         name: creatorUser?.username || 'Unknown',
-        message: { content: transcript.header },
+        // allowedMentions parse:[] — historical transcript, never ping anyone.
+        message: { content: transcript.header, allowedMentions: { parse: [] } },
       });
 
       for (const chunk of transcript.chunks) {
-        await newPost.send({ content: chunk });
+        await newPost.send({ content: chunk, allowedMentions: { parse: [] } });
       }
 
       await archivedAppRepo.save(
@@ -94,9 +95,12 @@ export async function archiveAndCloseApplication(
     } else if (existingArchive.messageId) {
       const post = (await forumChannel.threads.fetch(existingArchive.messageId)) as ForumThreadChannel;
       const separator = '\n━━━━━━━━━━━━━━━━━━━━━━━━\n';
-      await post.send({ content: separator + transcript.header });
+      await post.send({
+        content: separator + transcript.header,
+        allowedMentions: { parse: [] },
+      });
       for (const chunk of transcript.chunks) {
-        await post.send({ content: chunk });
+        await post.send({ content: chunk, allowedMentions: { parse: [] } });
       }
     }
   } catch (error) {

--- a/src/utils/fetchAllMessages.ts
+++ b/src/utils/fetchAllMessages.ts
@@ -50,7 +50,11 @@ function toTranscriptMessage(m: Message, byId: Map<string, Message>, botClientId
       id: m.author.id,
       bot: m.author.bot,
     },
-    content: m.content ?? '',
+    // cleanContent resolves <@id>/<@&id>/<#id> mentions to readable @name/#name
+    // text (no raw mention syntax) so the archived transcript shows names, not
+    // pings. Combined with allowedMentions:{parse:[]} on the forum send, the
+    // archive can never notify anyone.
+    content: m.cleanContent ?? m.content ?? '',
     timestamp: m.createdAt,
     attachments: Array.from(m.attachments.values()).map(a => ({
       name: a.name,
@@ -65,7 +69,7 @@ function toTranscriptMessage(m: Message, byId: Map<string, Message>, botClientId
     replyTo: replyTarget
       ? {
           author: replyTarget.author.username,
-          content: replyTarget.content ?? '',
+          content: replyTarget.cleanContent ?? replyTarget.content ?? '',
         }
       : undefined,
     isSystem: m.system === true,

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -106,13 +106,24 @@ async function findExistingArchive(
   guildId: string,
   repo: CloseWorkflowDeps['archivedTicketRepo'],
 ): Promise<ArchivedTicket | null> {
+  // Email-import tickets and normal tickets live in SEPARATE archive
+  // namespaces and must never share a thread. An email-import ticket's
+  // `createdBy` is the importing admin, NOT the player it represents — so
+  // without the `isEmailTicket` discriminator a normal ticket the admin opens
+  // would match (and get appended into) an email-import archive that happens
+  // to share their `createdBy`. Scope each lookup to its own kind.
   if (ticket.isEmailTicket && ticket.emailSender) {
     return repo.findOneBy({
-      emailSender: ticket.emailSender,
       guildId,
+      isEmailTicket: true,
+      emailSender: ticket.emailSender,
     });
   }
-  return repo.findOneBy({ createdBy: ticket.createdBy, guildId });
+  return repo.findOneBy({
+    guildId,
+    isEmailTicket: false,
+    createdBy: ticket.createdBy,
+  });
 }
 
 async function resolveArchiveThreadName(client: Client, ticket: Ticket): Promise<string> {
@@ -196,7 +207,9 @@ export async function archiveAndCloseTicket(
       const threadName = await resolveArchiveThreadName(client, ticket);
       const newPost = await forumChannel.threads.create({
         name: threadName,
-        message: { content: transcript.header },
+        // allowedMentions parse:[] — the transcript is historical content; it
+        // must never ping anyone (@everyone/@here/user/role) when re-posted.
+        message: { content: transcript.header, allowedMentions: { parse: [] } },
       });
 
       if (forumTagIds.length > 0) {
@@ -204,7 +217,7 @@ export async function archiveAndCloseTicket(
       }
 
       for (const chunk of transcript.chunks) {
-        await newPost.send({ content: chunk });
+        await newPost.send({ content: chunk, allowedMentions: { parse: [] } });
       }
 
       await deps.archivedTicketRepo.save(
@@ -228,9 +241,12 @@ export async function archiveAndCloseTicket(
       const post = (await forumChannel.threads.fetch(existingArchive.messageId)) as ForumThreadChannel;
 
       const separator = '\n━━━━━━━━━━━━━━━━━━━━━━━━\n';
-      await post.send({ content: separator + transcript.header });
+      await post.send({
+        content: separator + transcript.header,
+        allowedMentions: { parse: [] },
+      });
       for (const chunk of transcript.chunks) {
-        await post.send({ content: chunk });
+        await post.send({ content: chunk, allowedMentions: { parse: [] } });
       }
 
       if (forumTagIds.length > 0) {

--- a/tests/unit/utils/ticket/closeWorkflow.test.ts
+++ b/tests/unit/utils/ticket/closeWorkflow.test.ts
@@ -380,16 +380,52 @@ describe("archiveAndCloseTicket", () => {
     );
 
     expect(result).toEqual({ success: true, archived: true });
-    // Email ticket lookup uses emailSender, not createdBy
+    // Email ticket lookup is scoped to the EMAIL archive namespace
+    // (isEmailTicket:true + emailSender) — never the createdBy namespace.
     expect(fakeRepo.findOneBy).toHaveBeenCalledWith({
-      emailSender: "alice@example.com",
       guildId: "guild-1",
+      isEmailTicket: true,
+      emailSender: "alice@example.com",
     });
     expect(fakeRepoState.createCalls[0]).toMatchObject({
       isEmailTicket: true,
       emailSender: "alice@example.com",
       emailSenderName: "Alice",
       emailSubject: "Help needed with X",
+    });
+  });
+
+  test("regression: a normal ticket queries the createdBy namespace with isEmailTicket:false (never an email-import archive)", async () => {
+    // The reported prod bug: an email-import archive's createdBy is the
+    // importing admin. A normal ticket the admin opens must NOT match it —
+    // the lookup is scoped to isEmailTicket:false so the two archive
+    // namespaces can never cross-contaminate.
+    fakeBuiltinTypeInfo.mockReturnValue({
+      typeId: "general",
+      displayName: "General",
+      emoji: null,
+    });
+    const client = makeFakeClient(forumChannel, () => ({ username: "admin" }));
+    const channel = makeFakeChannel();
+    const ticket = makeTicket({
+      type: "general",
+      createdBy: "admin-id",
+      isEmailTicket: false,
+    });
+
+    await archiveAndCloseTicket(
+      client,
+      ticket,
+      "guild-1",
+      channel,
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(fakeRepo.findOneBy).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      isEmailTicket: false,
+      createdBy: "admin-id",
     });
   });
 


### PR DESCRIPTION
Two archive bugs reported from prod.

**1. Wrong-user archive (the email-import collision).** Ticket archives group per user — `createdBy` for normal tickets, `emailSender` for email-import tickets. But an email-import ticket's `createdBy` is the importing *admin*, not the player, so a normal ticket the admin opened could match (and append into) an email-import archive sharing their `createdBy` → one user's ticket lands in another's thread. `findExistingArchive` now scopes each lookup to its own namespace via the `isEmailTicket` discriminator, so email-import and normal archives can never cross-contaminate.

**2. Archived transcripts could ping people.** Every forum post in the ticket **and** application archive paths now uses `allowedMentions: { parse: [] }`, and content is captured via `cleanContent` (mentions render as readable `@name`/`#name`, not raw `<@id>`). Historical transcript content can never notify users/roles or fire `@everyone`/`@here`.

Verified: tsc clean, biome clean, `bun test` **1172/0** (closeWorkflow 12/0 incl. a new cross-namespace regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed archive thread lookups to prevent cross-contamination between normal and email-import ticket archives when archiving tickets.
  * Updated transcript archival to disable mention notifications—historical messages now render mentions as readable text instead of pinging users, roles, or triggering `@everyone/`@here alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->