### PR TITLE
refactor: builder option factories (unification Phase D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.0] - 2026-06-20
+
+Internal refactor (unification Phase D — builder factories) — no behavior change.
+
+### Added
+
+- `commands/builders/factories.ts` — `createTextChannelOption`,
+  `createForumChannelOption`, and `createActionOption` collapse the repeated
+  channel-option and `action`-choice scaffolding shared across command builders.
+  +7 unit tests.
+
+### Changed
+
+- Migrated 24 channel options (15 GuildText, 9 GuildForum) and 4 `action`
+  options onto the factories across 10 builders (starboard, ticketSetup,
+  applicationSetup, memorySetup, memory, baitChannel, xpSetup, reactionRole,
+  rulesSetup, event). Generated command JSON is byte-identical
+  (`commands.map(c => c.toJSON())` verified pre/post), so every registered
+  command shape is unchanged.
+
 ## [3.9.0] - 2026-06-20
 
 Internal refactor (unification Phase C complete) — no behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/builders/applicationSetup.ts
+++ b/src/commands/builders/applicationSetup.ts
@@ -1,5 +1,6 @@
 import { ChannelType, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
 import { lang } from '../../utils';
+import { createForumChannelOption, createTextChannelOption } from './factories';
 
 const tl = lang.application.setup;
 
@@ -8,19 +9,9 @@ export const applicationSetup = new SlashCommandBuilder()
   .setName('application-setup')
   .setDescription(tl.cmdDescrp)
   .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
+  .addChannelOption(option => createTextChannelOption(option, { description: tl.options.channel, required: false }))
   .addChannelOption(option =>
-    option
-      .setName('channel')
-      .setDescription(tl.options.channel)
-      .setRequired(false)
-      .addChannelTypes(ChannelType.GuildText),
-  )
-  .addChannelOption(option =>
-    option
-      .setName('archive')
-      .setDescription(tl.options.archive)
-      .setRequired(false)
-      .addChannelTypes(ChannelType.GuildForum),
+    createForumChannelOption(option, { name: 'archive', description: tl.options.archive, required: false }),
   )
   .addChannelOption(option =>
     option

--- a/src/commands/builders/baitChannel.ts
+++ b/src/commands/builders/baitChannel.ts
@@ -1,5 +1,6 @@
-import { ChannelType, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
 import { lang } from '../../utils';
+import { createActionOption, createTextChannelOption } from './factories';
 
 const tl = lang.baitChannel.builder;
 
@@ -18,11 +19,7 @@ export const baitChannelCommand = new SlashCommandBuilder()
           .setName('setup')
           .setDescription(tl.setup.descrp)
           .addChannelOption(option =>
-            option
-              .setName('channel')
-              .setDescription(tl.setup.channel)
-              .addChannelTypes(ChannelType.GuildText)
-              .setRequired(true),
+            createTextChannelOption(option, { description: tl.setup.channel, required: true }),
           )
           .addIntegerOption(option =>
             option
@@ -33,19 +30,18 @@ export const baitChannelCommand = new SlashCommandBuilder()
               .setRequired(true),
           )
           .addStringOption(option =>
-            option
-              .setName('action')
-              .setDescription(tl.setup.action)
-              .addChoices(
+            createActionOption(option, {
+              description: tl.setup.action,
+              choices: [
                 { name: tl.setup.actionBan, value: 'ban' },
                 { name: tl.setup.actionKick, value: 'kick' },
                 { name: tl.setup.actionTimeout, value: 'timeout' },
                 { name: tl.setup.actionLogOnly, value: 'log-only' },
-              )
-              .setRequired(true),
+              ],
+            }),
           )
           .addChannelOption(option =>
-            option.setName('log_channel').setDescription(tl.setup.logChannel).addChannelTypes(ChannelType.GuildText),
+            createTextChannelOption(option, { name: 'log_channel', description: tl.setup.logChannel }),
           ),
       )
       .addSubcommand(subcommand =>
@@ -59,11 +55,7 @@ export const baitChannelCommand = new SlashCommandBuilder()
           .setName('add-channel')
           .setDescription(tl.addChannel.descrp)
           .addChannelOption(option =>
-            option
-              .setName('channel')
-              .setDescription(tl.addChannel.channel)
-              .addChannelTypes(ChannelType.GuildText)
-              .setRequired(true),
+            createTextChannelOption(option, { description: tl.addChannel.channel, required: true }),
           ),
       )
       .addSubcommand(subcommand =>
@@ -71,11 +63,7 @@ export const baitChannelCommand = new SlashCommandBuilder()
           .setName('remove-channel')
           .setDescription(tl.removeChannel.descrp)
           .addChannelOption(option =>
-            option
-              .setName('channel')
-              .setDescription(tl.removeChannel.channel)
-              .addChannelTypes(ChannelType.GuildText)
-              .setRequired(true),
+            createTextChannelOption(option, { description: tl.removeChannel.channel, required: true }),
           ),
       )
       .addSubcommand(subcommand => subcommand.setName('status').setDescription(tl.status.descrp)),
@@ -137,15 +125,14 @@ export const baitChannelCommand = new SlashCommandBuilder()
           .setName('whitelist')
           .setDescription(tl.whitelist.descrp)
           .addStringOption(option =>
-            option
-              .setName('action')
-              .setDescription(tl.whitelist.action)
-              .addChoices(
+            createActionOption(option, {
+              description: tl.whitelist.action,
+              choices: [
                 { name: tl.whitelist.actionAdd, value: 'add' },
                 { name: tl.whitelist.actionRemove, value: 'remove' },
                 { name: tl.whitelist.actionList, value: 'list' },
-              )
-              .setRequired(true),
+              ],
+            }),
           )
           .addRoleOption(option => option.setName('role').setDescription(tl.whitelist.role))
           .addUserOption(option => option.setName('user').setDescription(tl.whitelist.user)),
@@ -155,16 +142,15 @@ export const baitChannelCommand = new SlashCommandBuilder()
           .setName('keywords')
           .setDescription(tl.keywords.descrp)
           .addStringOption(option =>
-            option
-              .setName('action')
-              .setDescription(tl.keywords.action)
-              .addChoices(
+            createActionOption(option, {
+              description: tl.keywords.action,
+              choices: [
                 { name: 'Add keyword', value: 'add' },
                 { name: 'Remove keyword', value: 'remove' },
                 { name: 'List keywords', value: 'list' },
                 { name: 'Reset to defaults', value: 'reset' },
-              )
-              .setRequired(true),
+              ],
+            }),
           )
           .addStringOption(option =>
             option.setName('keyword').setDescription(tl.keywords.keyword).setMaxLength(100).setAutocomplete(true),
@@ -244,9 +230,7 @@ export const baitChannelCommand = new SlashCommandBuilder()
           .setName('summary')
           .setDescription(tl.summary.descrp)
           .addBooleanOption(option => option.setName('enabled').setDescription(tl.summary.enabled).setRequired(true))
-          .addChannelOption(option =>
-            option.setName('channel').setDescription(tl.summary.channel).addChannelTypes(ChannelType.GuildText),
-          ),
+          .addChannelOption(option => createTextChannelOption(option, { description: tl.summary.channel })),
       )
       .addSubcommand(subcommand =>
         subcommand

--- a/src/commands/builders/event.ts
+++ b/src/commands/builders/event.ts
@@ -7,6 +7,7 @@ import {
 } from 'discord.js';
 
 import eventLang from '../../lang/en/event.json';
+import { createTextChannelOption } from './factories';
 
 const tl = eventLang.builder;
 
@@ -119,11 +120,7 @@ const setupGroup = new SlashCommandSubcommandGroupBuilder()
       .setName('reminder-channel')
       .setDescription(tl.setup.reminderChannel)
       .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tl.setup.channelOption)
-          .setRequired(true)
-          .addChannelTypes(ChannelType.GuildText),
+        createTextChannelOption(option, { description: tl.setup.channelOption, required: true }),
       ),
   )
   .addSubcommand(sub =>
@@ -131,11 +128,7 @@ const setupGroup = new SlashCommandSubcommandGroupBuilder()
       .setName('summary-channel')
       .setDescription(tl.setup.summaryChannel)
       .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tl.setup.channelOption)
-          .setRequired(true)
-          .addChannelTypes(ChannelType.GuildText),
+        createTextChannelOption(option, { description: tl.setup.channelOption, required: true }),
       ),
   )
   .addSubcommand(sub =>

--- a/src/commands/builders/factories.ts
+++ b/src/commands/builders/factories.ts
@@ -1,0 +1,68 @@
+/**
+ * Builder option factories
+ *
+ * Collapse the repeated channel-option and action-choice scaffolding shared
+ * across command builders. Each helper sets only the fields the call sites
+ * actually varied (name/description/required, choices), so the generated
+ * command JSON is byte-identical to the hand-written option blocks they replace.
+ */
+import { ChannelType, type SlashCommandChannelOption, type SlashCommandStringOption } from 'discord.js';
+
+interface ChannelOptionConfig {
+  /** Option name — defaults to 'channel'. */
+  name?: string;
+  description: string;
+  /**
+   * Only emitted when defined. Omitting it leaves `required` off the option
+   * (matching a bare `.addChannelTypes(...)` block), which is distinct JSON
+   * from an explicit `.setRequired(false)`.
+   */
+  required?: boolean;
+}
+
+function applyChannelOption(
+  option: SlashCommandChannelOption,
+  type: ChannelType.GuildText | ChannelType.GuildForum,
+  { name = 'channel', description, required }: ChannelOptionConfig,
+): SlashCommandChannelOption {
+  option.setName(name).setDescription(description).addChannelTypes(type);
+  if (required !== undefined) {
+    option.setRequired(required);
+  }
+  return option;
+}
+
+/** A `GuildText` channel option. */
+export function createTextChannelOption(
+  option: SlashCommandChannelOption,
+  config: ChannelOptionConfig,
+): SlashCommandChannelOption {
+  return applyChannelOption(option, ChannelType.GuildText, config);
+}
+
+/** A `GuildForum` channel option. */
+export function createForumChannelOption(
+  option: SlashCommandChannelOption,
+  config: ChannelOptionConfig,
+): SlashCommandChannelOption {
+  return applyChannelOption(option, ChannelType.GuildForum, config);
+}
+
+interface ActionOptionConfig {
+  description: string;
+  choices: { name: string; value: string }[];
+  /** Defaults to true — every current action option is required. */
+  required?: boolean;
+}
+
+/** A required `action` string option carrying a fixed choice set. */
+export function createActionOption(
+  option: SlashCommandStringOption,
+  { description, choices, required = true }: ActionOptionConfig,
+): SlashCommandStringOption {
+  return option
+    .setName('action')
+    .setDescription(description)
+    .addChoices(...choices)
+    .setRequired(required);
+}

--- a/src/commands/builders/memory.ts
+++ b/src/commands/builders/memory.ts
@@ -1,5 +1,6 @@
 import { PermissionsBitField, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
 import { lang } from '../../utils';
+import { createActionOption } from './factories';
 
 const tl = lang.memory.builder;
 
@@ -42,16 +43,15 @@ const tags = new SlashCommandSubcommandBuilder()
   .setName('tags')
   .setDescription(tl.tags.descrp)
   .addStringOption(option =>
-    option
-      .setName('action')
-      .setDescription(tl.tags.action)
-      .setRequired(true)
-      .addChoices(
+    createActionOption(option, {
+      description: tl.tags.action,
+      choices: [
         { name: tl.tags.actionAdd, value: 'add' },
         { name: tl.tags.actionEdit, value: 'edit' },
         { name: tl.tags.actionRemove, value: 'remove' },
         { name: tl.tags.actionList, value: 'list' },
-      ),
+      ],
+    }),
   );
 
 /* main slash command */

--- a/src/commands/builders/memorySetup.ts
+++ b/src/commands/builders/memorySetup.ts
@@ -1,6 +1,7 @@
-import { ChannelType, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
+import { PermissionsBitField, SlashCommandBuilder } from 'discord.js';
 import { lang } from '../../lang';
 import { MAX } from '../../utils/constants';
+import { createForumChannelOption } from './factories';
 
 const tl = lang.memory.setup;
 const tb = lang.memory.setupBuilder;
@@ -13,13 +14,7 @@ export const memorySetup = new SlashCommandBuilder()
     sub
       .setName('setup')
       .setDescription(tl.cmdDescrp)
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tl.channelOption)
-          .addChannelTypes(ChannelType.GuildForum)
-          .setRequired(false),
-      )
+      .addChannelOption(option => createForumChannelOption(option, { description: tl.channelOption, required: false }))
       .addStringOption(option =>
         option.setName('channel-name').setDescription(tl.channelNameOption).setRequired(false).setMaxLength(100),
       ),
@@ -28,13 +23,7 @@ export const memorySetup = new SlashCommandBuilder()
     sub
       .setName('add-channel')
       .setDescription(tl.addChannelDescrp)
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tl.channelOption)
-          .addChannelTypes(ChannelType.GuildForum)
-          .setRequired(true),
-      )
+      .addChannelOption(option => createForumChannelOption(option, { description: tl.channelOption, required: true }))
       .addStringOption(option =>
         option.setName('channel-name').setDescription(tl.channelNameOption).setRequired(false).setMaxLength(100),
       ),
@@ -56,13 +45,7 @@ export const memorySetup = new SlashCommandBuilder()
           .addChoices({ name: 'Category', value: 'category' }, { name: 'Status', value: 'status' }),
       )
       .addStringOption(option => option.setName('emoji').setDescription(tb.tagEmoji).setRequired(false))
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tb.channelOption)
-          .addChannelTypes(ChannelType.GuildForum)
-          .setRequired(false),
-      ),
+      .addChannelOption(option => createForumChannelOption(option, { description: tb.channelOption, required: false })),
   )
   .addSubcommand(sub =>
     sub
@@ -71,13 +54,7 @@ export const memorySetup = new SlashCommandBuilder()
       .addStringOption(option =>
         option.setName('tag').setDescription(tb.tagOption).setRequired(true).setAutocomplete(true),
       )
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tb.channelOption)
-          .addChannelTypes(ChannelType.GuildForum)
-          .setRequired(false),
-      ),
+      .addChannelOption(option => createForumChannelOption(option, { description: tb.channelOption, required: false })),
   )
   .addSubcommand(sub =>
     sub
@@ -94,36 +71,18 @@ export const memorySetup = new SlashCommandBuilder()
           .setMaxLength(MAX.MEMORY_TAG_NAME_LENGTH),
       )
       .addStringOption(option => option.setName('emoji').setDescription(tb.tagEmoji).setRequired(false))
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tb.channelOption)
-          .addChannelTypes(ChannelType.GuildForum)
-          .setRequired(false),
-      ),
+      .addChannelOption(option => createForumChannelOption(option, { description: tb.channelOption, required: false })),
   )
   .addSubcommand(sub =>
     sub
       .setName('tag-list')
       .setDescription(tb.tagList)
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tb.channelOption)
-          .addChannelTypes(ChannelType.GuildForum)
-          .setRequired(false),
-      ),
+      .addChannelOption(option => createForumChannelOption(option, { description: tb.channelOption, required: false })),
   )
   .addSubcommand(sub =>
     sub
       .setName('tag-reset')
       .setDescription(tb.tagReset)
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tb.channelOption)
-          .addChannelTypes(ChannelType.GuildForum)
-          .setRequired(false),
-      ),
+      .addChannelOption(option => createForumChannelOption(option, { description: tb.channelOption, required: false })),
   )
   .toJSON();

--- a/src/commands/builders/reactionRole.ts
+++ b/src/commands/builders/reactionRole.ts
@@ -1,18 +1,13 @@
-import { ChannelType, PermissionsBitField, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
+import { PermissionsBitField, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
 import { lang } from '../../utils';
+import { createTextChannelOption } from './factories';
 
 const tl = lang.reactionRole.builder;
 
 const create = new SlashCommandSubcommandBuilder()
   .setName('create')
   .setDescription(tl.create.descrp)
-  .addChannelOption(option =>
-    option
-      .setName('channel')
-      .setDescription(tl.create.channel)
-      .setRequired(true)
-      .addChannelTypes(ChannelType.GuildText),
-  )
+  .addChannelOption(option => createTextChannelOption(option, { description: tl.create.channel, required: true }))
   .addStringOption(option => option.setName('name').setDescription(tl.create.name).setRequired(true).setMaxLength(255))
   .addStringOption(option =>
     option.setName('description').setDescription(tl.create.description).setRequired(false).setMaxLength(4000),

--- a/src/commands/builders/rulesSetup.ts
+++ b/src/commands/builders/rulesSetup.ts
@@ -1,14 +1,13 @@
-import { ChannelType, PermissionsBitField, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
+import { PermissionsBitField, SlashCommandBuilder, SlashCommandSubcommandBuilder } from 'discord.js';
 import { lang } from '../../utils';
+import { createTextChannelOption } from './factories';
 
 const tl = lang.rules.builder;
 
 const setup = new SlashCommandSubcommandBuilder()
   .setName('setup')
   .setDescription(tl.setup.descrp)
-  .addChannelOption(option =>
-    option.setName('channel').setDescription(tl.setup.channel).setRequired(true).addChannelTypes(ChannelType.GuildText),
-  )
+  .addChannelOption(option => createTextChannelOption(option, { description: tl.setup.channel, required: true }))
   .addRoleOption(option => option.setName('role').setDescription(tl.setup.role).setRequired(true))
   .addStringOption(option =>
     option.setName('message').setDescription(tl.setup.message).setRequired(false).setMaxLength(1800),

--- a/src/commands/builders/starboard.ts
+++ b/src/commands/builders/starboard.ts
@@ -1,5 +1,6 @@
-import { ChannelType, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
+import { PermissionsBitField, SlashCommandBuilder } from 'discord.js';
 import { lang } from '../../lang';
+import { createTextChannelOption } from './factories';
 
 const tl = lang.starboard.builder;
 
@@ -11,13 +12,7 @@ export const starboard = new SlashCommandBuilder()
     sub
       .setName('setup')
       .setDescription(tl.setup.descrp)
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tl.setup.channel)
-          .addChannelTypes(ChannelType.GuildText)
-          .setRequired(true),
-      )
+      .addChannelOption(option => createTextChannelOption(option, { description: tl.setup.channel, required: true }))
       .addStringOption(option => option.setName('emoji').setDescription(tl.setup.emoji).setRequired(false))
       .addIntegerOption(option =>
         option
@@ -51,24 +46,14 @@ export const starboard = new SlashCommandBuilder()
     sub
       .setName('ignore')
       .setDescription(tl.ignore.descrp)
-      .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tl.ignore.channel)
-          .addChannelTypes(ChannelType.GuildText)
-          .setRequired(true),
-      ),
+      .addChannelOption(option => createTextChannelOption(option, { description: tl.ignore.channel, required: true })),
   )
   .addSubcommand(sub =>
     sub
       .setName('unignore')
       .setDescription(tl.unignore.descrp)
       .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription(tl.unignore.channel)
-          .addChannelTypes(ChannelType.GuildText)
-          .setRequired(true),
+        createTextChannelOption(option, { description: tl.unignore.channel, required: true }),
       ),
   )
   .addSubcommand(sub => sub.setName('stats').setDescription(tl.stats.descrp))

--- a/src/commands/builders/ticketSetup.ts
+++ b/src/commands/builders/ticketSetup.ts
@@ -1,5 +1,6 @@
 import { ChannelType, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
 import { lang } from '../../utils';
+import { createForumChannelOption, createTextChannelOption } from './factories';
 
 const tl = lang.ticketSetup;
 
@@ -8,19 +9,9 @@ export const ticketSetup = new SlashCommandBuilder()
   .setName('ticket-setup')
   .setDescription(tl.cmdDescrp)
   .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
+  .addChannelOption(option => createTextChannelOption(option, { description: tl.options.channel, required: false }))
   .addChannelOption(option =>
-    option
-      .setName('channel')
-      .setDescription(tl.options.channel)
-      .setRequired(false)
-      .addChannelTypes(ChannelType.GuildText),
-  )
-  .addChannelOption(option =>
-    option
-      .setName('archive')
-      .setDescription(tl.options.archive)
-      .setRequired(false)
-      .addChannelTypes(ChannelType.GuildForum),
+    createForumChannelOption(option, { name: 'archive', description: tl.options.archive, required: false }),
   )
   .addChannelOption(option =>
     option

--- a/src/commands/builders/xpSetup.ts
+++ b/src/commands/builders/xpSetup.ts
@@ -1,4 +1,5 @@
 import { ChannelType, PermissionsBitField, SlashCommandBuilder } from 'discord.js';
+import { createTextChannelOption } from './factories';
 
 /**
  * /xp-setup — Configure the XP & leveling system
@@ -41,11 +42,7 @@ export const xpSetup = new SlashCommandBuilder()
         option.setName('value').setDescription('The new value for the setting').setRequired(false),
       )
       .addChannelOption(option =>
-        option
-          .setName('channel')
-          .setDescription('Channel (for level-up-channel setting)')
-          .addChannelTypes(ChannelType.GuildText)
-          .setRequired(false),
+        createTextChannelOption(option, { description: 'Channel (for level-up-channel setting)', required: false }),
       ),
   )
   // role-reward add

--- a/tests/unit/commands/builders/factories.test.ts
+++ b/tests/unit/commands/builders/factories.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Builder option factory unit tests.
+ *
+ * The factories are pure over a fresh option builder, so these drive them with
+ * standalone option instances and assert on the exact `.toJSON()` shape. The
+ * required-presence cases matter most: omitting `required` must leave the field
+ * off the JSON (distinct from an explicit `required: false`), since that is what
+ * keeps the generated command JSON identical to the hand-written option blocks.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { ChannelType, SlashCommandChannelOption, SlashCommandStringOption } from 'discord.js';
+import {
+  createActionOption,
+  createForumChannelOption,
+  createTextChannelOption,
+} from '../../../../src/commands/builders/factories';
+
+describe('createTextChannelOption', () => {
+  test('defaults the name to "channel" and restricts to GuildText', () => {
+    const json = createTextChannelOption(new SlashCommandChannelOption(), {
+      description: 'desc',
+      required: true,
+    }).toJSON();
+    expect(json.name).toBe('channel');
+    expect(json.description).toBe('desc');
+    expect(json.required).toBe(true);
+    expect(json.channel_types).toEqual([ChannelType.GuildText]);
+  });
+
+  test('honours a custom option name', () => {
+    const json = createTextChannelOption(new SlashCommandChannelOption(), {
+      name: 'log_channel',
+      description: 'd',
+    }).toJSON();
+    expect(json.name).toBe('log_channel');
+  });
+
+  test('leaves setRequired uncalled when not provided, matching a bare option block', () => {
+    // discord.js serialises an option that never called setRequired the same as
+    // one set to false, so omitting `required` reproduces the original bare
+    // `.addChannelTypes(...)` blocks (e.g. bait log_channel / summary channel).
+    const omitted = createTextChannelOption(new SlashCommandChannelOption(), { description: 'd' }).toJSON();
+    const explicitFalse = createTextChannelOption(new SlashCommandChannelOption(), {
+      description: 'd',
+      required: false,
+    }).toJSON();
+    expect(omitted).toEqual(explicitFalse);
+  });
+
+  test('emits required:true when explicitly true', () => {
+    const json = createTextChannelOption(new SlashCommandChannelOption(), {
+      description: 'd',
+      required: true,
+    }).toJSON();
+    expect(json.required).toBe(true);
+  });
+});
+
+describe('createForumChannelOption', () => {
+  test('restricts to GuildForum', () => {
+    const json = createForumChannelOption(new SlashCommandChannelOption(), {
+      name: 'archive',
+      description: 'd',
+      required: false,
+    }).toJSON();
+    expect(json.name).toBe('archive');
+    expect(json.channel_types).toEqual([ChannelType.GuildForum]);
+    expect(json.required).toBe(false);
+  });
+});
+
+describe('createActionOption', () => {
+  test('builds a required "action" option with the given choices', () => {
+    const json = createActionOption(new SlashCommandStringOption(), {
+      description: 'pick one',
+      choices: [
+        { name: 'Add', value: 'add' },
+        { name: 'Remove', value: 'remove' },
+        { name: 'List', value: 'list' },
+      ],
+    }).toJSON();
+    expect(json.name).toBe('action');
+    expect(json.description).toBe('pick one');
+    expect(json.required).toBe(true);
+    expect(json.choices).toEqual([
+      { name: 'Add', value: 'add' },
+      { name: 'Remove', value: 'remove' },
+      { name: 'List', value: 'list' },
+    ]);
+  });
+
+  test('required defaults to true but can be overridden', () => {
+    const json = createActionOption(new SlashCommandStringOption(), {
+      description: 'd',
+      choices: [{ name: 'A', value: 'a' }],
+      required: false,
+    }).toJSON();
+    expect(json.required).toBe(false);
+  });
+});


### PR DESCRIPTION
## Phase D — builder option factories (unification roadmap, target #3)

Internal refactor, **no behavior change**. Adds `src/commands/builders/factories.ts` and migrates the duplicated channel-option / action-choice scaffolding across command builders onto it.

### What changed
- **New `factories.ts`** with three helpers:
  - `createTextChannelOption(option, { name?, description, required? })` — a `GuildText` channel option (name defaults to `channel`).
  - `createForumChannelOption(option, { name?, description, required? })` — a `GuildForum` channel option.
  - `createActionOption(option, { description, choices, required? })` — a required `action` string option carrying a fixed choice set.
- **Migrated 24 channel options** (15 `GuildText`, 9 `GuildForum`) and **4 `action` options** across 10 builders: `starboard`, `ticketSetup`, `applicationSetup`, `memorySetup`, `memory`, `baitChannel`, `xpSetup`, `reactionRole`, `rulesSetup`, `event`.
- **+7 unit tests** for the factory contract (`tests/unit/commands/builders/factories.test.ts`).

### Safety gate
The registered command names/shapes must not change. `commands.map(c => c.toJSON())` was snapshotted (`RELEASE=dev`, all 39 commands) before and after — the diff is **empty / byte-identical**.

### Scope notes (surface re-verified — roadmap counts/claims were stale)
- The roadmap's "shared `addChoices` sets → `choices.ts`" premise was false, like its `automod == baitChannel` claim. The three action-choice sets have **different values and name sources** (lang-sourced vs hardcoded), so there is no genuinely-shared array to centralize — that would just be single-use constants. Instead the shared *scaffolding* (`action` option name + required + choices) is deduped via `createActionOption`, which also covers the bait setup-action selector (4 sites total).
- Out of scope (left as-is): `GuildCategory`, `GuildText + GuildVoice`, `GuildVoice + GuildStageVoice`, and bare (no channel-type) options.

### Verification
- `bun run build` — clean
- `bun run check` (biome) — clean
- `bun test` — 1343 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated repeated configuration patterns across multiple command builders to improve code organization and reduce duplication. All command functionality remains unchanged and has been verified to produce identical output.

* **Tests**
  * Added 7 unit tests to ensure command builder refactoring maintains expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->