### PR TITLE
test: correct factory test header comment (follow-up to #9)

### DIFF
--- a/tests/unit/commands/builders/factories.test.ts
+++ b/tests/unit/commands/builders/factories.test.ts
@@ -3,9 +3,10 @@
  *
  * The factories are pure over a fresh option builder, so these drive them with
  * standalone option instances and assert on the exact `.toJSON()` shape. The
- * required-presence cases matter most: omitting `required` must leave the field
- * off the JSON (distinct from an explicit `required: false`), since that is what
- * keeps the generated command JSON identical to the hand-written option blocks.
+ * required-presence cases matter most: discord.js serialises an option that
+ * never called setRequired identically to one set to `required: false`, so the
+ * factory omitting `required` reproduces the original bare option blocks and
+ * keeps the generated command JSON unchanged.
  */
 
 import { describe, expect, test } from 'bun:test';


### PR DESCRIPTION
Comment-only follow-up to #9 addressing the CodeRabbit review.

The factory test file header claimed that omitting `required` leaves the field off the JSON (distinct from an explicit `required: false`). That's inaccurate: discord.js serialises an option that never called `setRequired` identically to one set to `required: false` — which is precisely why the factory's omit-vs-false handling reproduces the original hand-written option blocks. Header reworded to match the asserted contract.

Test file only — no behavior, no deployed-artifact change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
