### PR TITLE
refactor: createToggleHandler helper (unification #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.0] - 2026-06-20
+
+Internal refactor (unification #7 — toggle handler) — no behavior change.
+
+### Added
+
+- `createToggleHandler({ repo, field, messages, canEnable?, onToggled? })`
+  (`utils/interactions/toggleHandler.ts`) — binds the enable/disable spine
+  (find-or-create → idempotent check → flip flag → save → side effect → reply)
+  to a guild-config flag. Its `onToggled` hook is where the Phase-B cache
+  `invalidate*` calls plug in. +7 unit tests.
+
+### Changed
+
+- Migrated the xp, event, and onboarding enable/disable handlers onto it
+  (6 handlers, ~40 fewer lines). onboarding keeps its "needs steps" pre-enable
+  guard via `canEnable`; xp keeps its `invalidateXPConfigCache` via `onToggled`.
+  Left hand-written (not a thin fit): ticket workflow/sla/routing (option reads,
+  workflow prechecks, round-robin reset), bait toggle/dmnotify/escalation
+  (boolean-param or dispatcher-prefetched config, embed reply), and insights
+  (its plain-reply already-enabled path differs from the standard error style).
+
 ## [3.10.0] - 2026-06-20
 
 Internal refactor (unification Phase D — builder factories) — no behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/event/setup.ts
+++ b/src/commands/handlers/event/setup.ts
@@ -8,6 +8,7 @@ import { type CacheType, type ChatInputCommandInteraction, type Client, MessageF
 import eventLang from '../../../lang/en/event.json';
 import { EventConfig } from '../../../typeorm/entities/event/EventConfig';
 import {
+  createToggleHandler,
   enhancedLogger,
   formatLang,
   guardFeatureRateLimit,
@@ -20,6 +21,19 @@ import { lazyRepo } from '../../../utils/database/lazyRepo';
 
 const eventConfigRepo = lazyRepo(EventConfig);
 const tl = eventLang.setup;
+
+const eventToggle = createToggleHandler({
+  repo: eventConfigRepo,
+  field: 'enabled',
+  messages: {
+    alreadyEnabled: tl.alreadyEnabled,
+    alreadyDisabled: tl.alreadyDisabled,
+    enabled: tl.enableSuccess,
+    disabled: tl.disableSuccess,
+  },
+  onToggled: (interaction, guildId, enabled) =>
+    enhancedLogger.command(`Event system ${enabled ? 'enabled' : 'disabled'}`, interaction.user.id, guildId),
+});
 
 export async function eventSetupHandler(_client: Client, interaction: ChatInputCommandInteraction<CacheType>) {
   const guard = await guardFeatureRateLimit(interaction, 'events', 'manage', {
@@ -34,40 +48,16 @@ export async function eventSetupHandler(_client: Client, interaction: ChatInputC
   const subcommand = interaction.options.getSubcommand();
 
   try {
-    let config = await eventConfigRepo.findOneBy({ guildId });
+    const config = await eventConfigRepo.findOneBy({ guildId });
 
     switch (subcommand) {
       case 'enable': {
-        if (config?.enabled) {
-          await replyEphemeralError(interaction, tl.alreadyEnabled);
-          return;
-        }
-        if (!config) {
-          config = eventConfigRepo.create({ guildId, enabled: true });
-        } else {
-          config.enabled = true;
-        }
-        await eventConfigRepo.save(config);
-        await interaction.reply({
-          content: tl.enableSuccess,
-          flags: [MessageFlags.Ephemeral],
-        });
-        enhancedLogger.command('Event system enabled', interaction.user.id, guildId);
+        await eventToggle.enable(interaction, guildId);
         break;
       }
 
       case 'disable': {
-        if (!config?.enabled) {
-          await replyEphemeralError(interaction, tl.alreadyDisabled);
-          return;
-        }
-        config.enabled = false;
-        await eventConfigRepo.save(config);
-        await interaction.reply({
-          content: tl.disableSuccess,
-          flags: [MessageFlags.Ephemeral],
-        });
-        enhancedLogger.command('Event system disabled', interaction.user.id, guildId);
+        await eventToggle.disable(interaction, guildId);
         break;
       }
 

--- a/src/commands/handlers/onboarding/setup.ts
+++ b/src/commands/handlers/onboarding/setup.ts
@@ -1,68 +1,39 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
 import onboardingLang from '../../../lang/en/onboarding.json';
 import { OnboardingConfig } from '../../../typeorm/entities/onboarding/OnboardingConfig';
-import { enhancedLogger, formatLang, replyEphemeralError } from '../../../utils';
+import { createToggleHandler, enhancedLogger, formatLang } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 
 const configRepo = lazyRepo(OnboardingConfig);
 const tl = onboardingLang;
 
+const onboardingToggle = createToggleHandler({
+  repo: configRepo,
+  field: 'enabled',
+  messages: {
+    alreadyEnabled: tl.setup.alreadyEnabled,
+    alreadyDisabled: tl.setup.alreadyDisabled,
+    enabled: tl.setup.enabled,
+    disabled: tl.setup.disabled,
+  },
+  // Cannot enable onboarding until at least one step is configured.
+  canEnable: config => (!config.steps || config.steps.length === 0 ? tl.setup.noSteps : null),
+  onToggled: (interaction, guildId, enabled) =>
+    enhancedLogger.command(`Onboarding ${enabled ? 'enabled' : 'disabled'}`, interaction.user.id, guildId),
+});
+
 /**
  * Enable the onboarding flow.
  */
 export async function enableHandler(_client: Client, interaction: ChatInputCommandInteraction<CacheType>) {
-  const guildId = interaction.guildId!;
-
-  let config = await configRepo.findOneBy({ guildId });
-
-  if (!config) {
-    config = configRepo.create({ guildId });
-  }
-
-  // Cannot enable if no steps are configured
-  if (!config.steps || config.steps.length === 0) {
-    await replyEphemeralError(interaction, tl.setup.noSteps);
-    return;
-  }
-
-  if (config.enabled) {
-    await replyEphemeralError(interaction, tl.setup.alreadyEnabled);
-    return;
-  }
-
-  config.enabled = true;
-  await configRepo.save(config);
-
-  await interaction.reply({
-    content: tl.setup.enabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.command('Onboarding enabled', interaction.user.id, guildId);
+  await onboardingToggle.enable(interaction, interaction.guildId!);
 }
 
 /**
  * Disable the onboarding flow.
  */
 export async function disableHandler(_client: Client, interaction: ChatInputCommandInteraction<CacheType>) {
-  const guildId = interaction.guildId!;
-
-  const config = await configRepo.findOneBy({ guildId });
-
-  if (!config?.enabled) {
-    await replyEphemeralError(interaction, tl.setup.alreadyDisabled);
-    return;
-  }
-
-  config.enabled = false;
-  await configRepo.save(config);
-
-  await interaction.reply({
-    content: tl.setup.disabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.command('Onboarding disabled', interaction.user.id, guildId);
+  await onboardingToggle.disable(interaction, interaction.guildId!);
 }
 
 /**

--- a/src/commands/handlers/xp/setup.ts
+++ b/src/commands/handlers/xp/setup.ts
@@ -2,13 +2,37 @@ import { type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFla
 import xpLang from '../../../lang/en/xp.json';
 import { XPConfig } from '../../../typeorm/entities/xp/XPConfig';
 import { XPRoleReward } from '../../../typeorm/entities/xp/XPRoleReward';
-import { enhancedLogger, handleInteractionError, LogCategory, replyEphemeralError } from '../../../utils';
+import {
+  createToggleHandler,
+  enhancedLogger,
+  handleInteractionError,
+  LogCategory,
+  replyEphemeralError,
+} from '../../../utils';
 import { Colors } from '../../../utils/colors';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { invalidateXPConfigCache } from '../../../utils/xp/configCache';
 
 const configRepo = lazyRepo(XPConfig);
 const rewardRepo = lazyRepo(XPRoleReward);
+
+const xpToggle = createToggleHandler({
+  repo: configRepo,
+  field: 'enabled',
+  messages: {
+    alreadyEnabled: xpLang.setup.alreadyEnabled,
+    alreadyDisabled: xpLang.setup.alreadyDisabled,
+    enabled: xpLang.setup.enabled,
+    disabled: xpLang.setup.disabled,
+  },
+  onToggled: (_interaction, guildId, enabled) => {
+    invalidateXPConfigCache(guildId);
+    enhancedLogger.info(
+      `XP system ${enabled ? 'enabled' : 'disabled'} for guild ${guildId}`,
+      LogCategory.COMMAND_EXECUTION,
+    );
+  },
+});
 
 export async function xpSetupHandler(_client: Client, interaction: ChatInputCommandInteraction) {
   try {
@@ -19,10 +43,10 @@ export async function xpSetupHandler(_client: Client, interaction: ChatInputComm
 
     switch (subcommand) {
       case 'enable':
-        await handleEnable(interaction, guildId);
+        await xpToggle.enable(interaction, guildId);
         break;
       case 'disable':
-        await handleDisable(interaction, guildId);
+        await xpToggle.disable(interaction, guildId);
         break;
       case 'config':
         await handleConfig(interaction, guildId);
@@ -63,40 +87,6 @@ async function getOrCreateConfig(guildId: string): Promise<XPConfig> {
     config = await configRepo.save(config);
   }
   return config;
-}
-
-async function handleEnable(interaction: ChatInputCommandInteraction, guildId: string) {
-  const config = await getOrCreateConfig(guildId);
-  if (config.enabled) {
-    await replyEphemeralError(interaction, xpLang.setup.alreadyEnabled);
-    return;
-  }
-  config.enabled = true;
-  await configRepo.save(config);
-  invalidateXPConfigCache(guildId);
-
-  enhancedLogger.info(`XP system enabled for guild ${guildId}`, LogCategory.COMMAND_EXECUTION);
-  await interaction.reply({
-    content: xpLang.setup.enabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-}
-
-async function handleDisable(interaction: ChatInputCommandInteraction, guildId: string) {
-  const config = await configRepo.findOne({ where: { guildId } });
-  if (!config?.enabled) {
-    await replyEphemeralError(interaction, xpLang.setup.alreadyDisabled);
-    return;
-  }
-  config.enabled = false;
-  await configRepo.save(config);
-  invalidateXPConfigCache(guildId);
-
-  enhancedLogger.info(`XP system disabled for guild ${guildId}`, LogCategory.COMMAND_EXECUTION);
-  await interaction.reply({
-    content: xpLang.setup.disabled,
-    flags: [MessageFlags.Ephemeral],
-  });
 }
 
 async function handleConfig(interaction: ChatInputCommandInteraction, guildId: string) {

--- a/src/utils/interactions/index.ts
+++ b/src/utils/interactions/index.ts
@@ -17,3 +17,9 @@ export {
   showAndAwaitModal,
 } from './modalHelper';
 export { type EphemeralErrorOptions, replyEphemeralError } from './replyHelper';
+export {
+  createToggleHandler,
+  type ToggleHandlerOptions,
+  type ToggleHandlers,
+  type ToggleMessages,
+} from './toggleHandler';

--- a/src/utils/interactions/toggleHandler.ts
+++ b/src/utils/interactions/toggleHandler.ts
@@ -1,0 +1,107 @@
+/**
+ * Enable/disable toggle handler factory (unification roadmap target #7).
+ *
+ * Several guild-config systems hand-roll the same enable/disable spine:
+ * find(-or-create) the config row, run an idempotent "already enabled/disabled"
+ * check, flip a boolean column, save, fire a side effect, and reply ephemerally.
+ * This binds that spine to a config so callers only declare what diverges —
+ * the field, the messages, an optional pre-enable guard, and an `onToggled`
+ * side effect (where the Phase-B cache `invalidate*` calls plug in).
+ *
+ * Scope: covers the self-fetching, text-reply toggles whose only difference is
+ * the column + messages (+ optional guard/side effect). Toggles that read
+ * command options, require a pre-existing row with a bespoke "not configured"
+ * path, reply with embeds, or run on a dispatcher-prefetched config are left
+ * hand-written — folding them in would need single-use hooks that defeat the
+ * point of a thin helper.
+ */
+
+import { type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
+import type { DeepPartial, FindOptionsWhere, Repository } from 'typeorm';
+import { replyEphemeralError } from './replyHelper';
+
+/** Keys of `T` whose value is a boolean — the columns this helper can toggle. */
+type BooleanKeys<T> = { [K in keyof T]-?: T[K] extends boolean ? K : never }[keyof T];
+
+export interface ToggleMessages {
+  /** Reply when enable is requested but the flag is already on. */
+  alreadyEnabled: string;
+  /** Reply when disable is requested but the flag is already off. */
+  alreadyDisabled: string;
+  /** Success reply for enable. */
+  enabled: string;
+  /** Success reply for disable. */
+  disabled: string;
+}
+
+export interface ToggleHandlerOptions<T extends { guildId: string }> {
+  /** Guild-scoped config repository (e.g. from `lazyRepo`). */
+  repo: Pick<Repository<T>, 'findOneBy' | 'create' | 'save'>;
+  /** The boolean column to toggle. */
+  field: BooleanKeys<T>;
+  messages: ToggleMessages;
+  /**
+   * Optional pre-enable guard. Return an error message to block enabling (sent
+   * ephemerally), or null/undefined to allow it. Runs after the row is
+   * found/created but before the already-enabled check.
+   */
+  canEnable?: (config: T) => string | null | undefined;
+  /**
+   * Side effect after a successful toggle — cache invalidation, audit logging,
+   * etc. This is where the Phase-B `invalidate*` cache calls plug in.
+   */
+  onToggled?: (interaction: ChatInputCommandInteraction, guildId: string, enabled: boolean) => void | Promise<void>;
+}
+
+export interface ToggleHandlers {
+  enable: (interaction: ChatInputCommandInteraction, guildId: string) => Promise<void>;
+  disable: (interaction: ChatInputCommandInteraction, guildId: string) => Promise<void>;
+}
+
+/**
+ * Build `{ enable, disable }` handlers for a guild-scoped boolean config flag.
+ *
+ * Enable finds-or-creates the config row; disable finds it (a missing row counts
+ * as already-disabled, so disabling never creates). Both flip the flag only when
+ * it actually changes state.
+ */
+export function createToggleHandler<T extends { guildId: string }>(options: ToggleHandlerOptions<T>): ToggleHandlers {
+  const { repo, field, messages, canEnable, onToggled } = options;
+  const where = (guildId: string) => ({ guildId }) as FindOptionsWhere<T>;
+
+  async function enable(interaction: ChatInputCommandInteraction, guildId: string): Promise<void> {
+    const config = (await repo.findOneBy(where(guildId))) ?? repo.create({ guildId } as DeepPartial<T>);
+
+    const guardError = canEnable?.(config);
+    if (guardError) {
+      await replyEphemeralError(interaction, guardError);
+      return;
+    }
+    if (config[field]) {
+      await replyEphemeralError(interaction, messages.alreadyEnabled);
+      return;
+    }
+
+    Object.assign(config, { [field]: true });
+    await repo.save(config);
+    await onToggled?.(interaction, guildId, true);
+
+    await interaction.reply({ content: messages.enabled, flags: [MessageFlags.Ephemeral] });
+  }
+
+  async function disable(interaction: ChatInputCommandInteraction, guildId: string): Promise<void> {
+    const config = await repo.findOneBy(where(guildId));
+    if (!config?.[field]) {
+      await replyEphemeralError(interaction, messages.alreadyDisabled);
+      return;
+    }
+
+    Object.assign(config, { [field]: false });
+    await repo.save(config);
+    await onToggled?.(interaction, guildId, false);
+
+    await interaction.reply({ content: messages.disabled, flags: [MessageFlags.Ephemeral] });
+  }
+
+  return { enable, disable };
+}

--- a/tests/unit/utils/interactions/toggleHandler.test.ts
+++ b/tests/unit/utils/interactions/toggleHandler.test.ts
@@ -1,0 +1,206 @@
+/**
+ * createToggleHandler unit tests.
+ *
+ * Drives the helper with a hand-rolled in-memory repo and a fake interaction
+ * that records replies, exercising the full spine: find-or-create on enable,
+ * find-only on disable, idempotent guards, the canEnable pre-guard, and the
+ * onToggled side effect.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { createToggleHandler } from '../../../../src/utils/interactions/toggleHandler';
+
+interface FakeConfig {
+  guildId: string;
+  enabled: boolean;
+  steps?: string[];
+}
+
+function makeRepo(initial: FakeConfig | null) {
+  let stored = initial;
+  let saveCount = 0;
+  const repo = {
+    findOneBy: async () => stored,
+    create: (partial: Partial<FakeConfig>) => ({ enabled: false, ...partial }) as FakeConfig,
+    save: async (entity: FakeConfig) => {
+      stored = entity;
+      saveCount += 1;
+      return entity;
+    },
+  };
+  return {
+    repo,
+    get stored() {
+      return stored;
+    },
+    get saveCount() {
+      return saveCount;
+    },
+  };
+}
+
+function makeInteraction() {
+  const replies: Array<{ content?: string }> = [];
+  const interaction = {
+    deferred: false,
+    replied: false,
+    user: { id: 'user-1' },
+    reply: async (opts: { content?: string }) => {
+      replies.push(opts);
+    },
+    editReply: async (opts: { content?: string }) => {
+      replies.push(opts);
+    },
+    followUp: async (opts: { content?: string }) => {
+      replies.push(opts);
+    },
+  };
+  return { interaction, replies };
+}
+
+const messages = {
+  alreadyEnabled: 'already on',
+  alreadyDisabled: 'already off',
+  enabled: 'turned on',
+  disabled: 'turned off',
+};
+
+// Cast helpers — the fakes implement just the slice the helper touches.
+// biome-ignore lint/suspicious/noExplicitAny: test doubles for a narrow repo/interaction slice
+const asRepo = (r: ReturnType<typeof makeRepo>['repo']) => r as any;
+// biome-ignore lint/suspicious/noExplicitAny: test doubles for a narrow repo/interaction slice
+const asInteraction = (i: ReturnType<typeof makeInteraction>['interaction']) => i as any;
+
+describe('createToggleHandler — enable', () => {
+  test('creates the config when missing, flips the flag, saves, fires onToggled, replies success', async () => {
+    const r = makeRepo(null);
+    const toggled: Array<boolean> = [];
+    const { enable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      onToggled: (_i, _g, enabled) => {
+        toggled.push(enabled);
+      },
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await enable(asInteraction(interaction), 'g1');
+
+    expect(r.stored).toEqual({ guildId: 'g1', enabled: true });
+    expect(r.saveCount).toBe(1);
+    expect(toggled).toEqual([true]);
+    expect(replies.at(-1)?.content).toBe('turned on');
+  });
+
+  test('is idempotent — already enabled replies the alreadyEnabled message and does not save', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: true });
+    let toggledCalls = 0;
+    const { enable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      onToggled: () => {
+        toggledCalls += 1;
+      },
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await enable(asInteraction(interaction), 'g1');
+
+    expect(r.saveCount).toBe(0);
+    expect(toggledCalls).toBe(0);
+    expect(replies.at(-1)?.content).toContain('already on');
+  });
+
+  test('canEnable guard blocks enabling — replies the guard message, no save, no onToggled', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: false });
+    let toggledCalls = 0;
+    const { enable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      canEnable: config => (!config.steps || config.steps.length === 0 ? 'configure steps first' : null),
+      onToggled: () => {
+        toggledCalls += 1;
+      },
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await enable(asInteraction(interaction), 'g1');
+
+    expect(r.saveCount).toBe(0);
+    expect(toggledCalls).toBe(0);
+    expect(replies.at(-1)?.content).toContain('configure steps first');
+  });
+
+  test('canEnable guard allows enabling when satisfied', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: false, steps: ['welcome'] });
+    const { enable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      canEnable: config => (!config.steps || config.steps.length === 0 ? 'configure steps first' : null),
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await enable(asInteraction(interaction), 'g1');
+
+    expect(r.stored?.enabled).toBe(true);
+    expect(replies.at(-1)?.content).toBe('turned on');
+  });
+});
+
+describe('createToggleHandler — disable', () => {
+  test('flips the flag off, saves, fires onToggled, replies success', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: true });
+    const toggled: Array<boolean> = [];
+    const { disable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      onToggled: (_i, _g, enabled) => {
+        toggled.push(enabled);
+      },
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await disable(asInteraction(interaction), 'g1');
+
+    expect(r.stored?.enabled).toBe(false);
+    expect(r.saveCount).toBe(1);
+    expect(toggled).toEqual([false]);
+    expect(replies.at(-1)?.content).toBe('turned off');
+  });
+
+  test('never creates a row — disabling a missing config replies alreadyDisabled and does not save', async () => {
+    const r = makeRepo(null);
+    const { disable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await disable(asInteraction(interaction), 'g1');
+
+    expect(r.stored).toBeNull();
+    expect(r.saveCount).toBe(0);
+    expect(replies.at(-1)?.content).toContain('already off');
+  });
+
+  test('is idempotent — already disabled replies alreadyDisabled and does not save', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: false });
+    const { disable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await disable(asInteraction(interaction), 'g1');
+
+    expect(r.saveCount).toBe(0);
+    expect(replies.at(-1)?.content).toContain('already off');
+  });
+});


### PR DESCRIPTION
## Unification #7 — `createToggleHandler`

Internal refactor, **no behavior change**. Adds a thin helper for the enable/disable spine that several guild-config systems hand-roll, and migrates the cleanest consumers onto it.

### What changed
- **New `utils/interactions/toggleHandler.ts`** — `createToggleHandler({ repo, field, messages, canEnable?, onToggled? })` returns `{ enable, disable }`. The spine: enable finds-or-creates the config row, disable finds it (a missing row counts as already-disabled); both run the idempotent already-on/off check, flip the boolean column, save, fire `onToggled`, and reply ephemerally. `canEnable` is the optional pre-enable guard; **`onToggled` is where the Phase-B cache `invalidate*` calls plug in**.
- **Migrated 6 handlers** across 3 systems:
  - **xp** — `onToggled` runs `invalidateXPConfigCache` + log.
  - **onboarding** — `canEnable` enforces the "needs steps configured" guard; `onToggled` logs.
  - **event** — `onToggled` logs (enable/disable switch branches now delegate).
- **+7 unit tests** (`tests/unit/utils/interactions/toggleHandler.test.ts`) covering find-or-create, idempotent guards, the `canEnable` block/allow paths, and the disable never-creates rule.

### Left hand-written (kept the helper thin)
Folding these in would require single-use hooks that defeat the point of a thin helper:
- **ticket workflow/sla/routing** — read command options, run workflow prechecks, `formatLang` argument-templated replies, `resetRoundRobin` side effect.
- **bait toggle/dmnotify/escalation** — boolean-param shape or dispatcher-prefetched config; escalation replies with an embed.
- **insights** — its already-enabled/disabled paths use a plain `interaction.reply` (no error emoji), so migrating would change the reply strings — not behavior-preserving.

### Verification
- `bun run build` — clean
- `bun run check` (biome) — clean
- `bun test` — 1350 pass, 0 fail

Behavior-preserving: the migrated paths perform the same DB operations as the shipped originals, validated by tsc + the new unit tests. No live-DB run was needed here (unlike Phase C's novel upsert path) — these are extractions of existing, in-prod operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
