### PR TITLE
refactor: utils/time.ts time primitives (unification A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.1] - 2026-06-21
+
+Internal tidiness (unification Phase A4 — time primitives) — no behavior change.
+
+### Added
+
+- `utils/time.ts` — `sleep(ms)`, `toUnixSeconds(date)`, `nowUnixSeconds()`. +6 unit tests.
+
+### Changed
+
+- Migrated the repeated `Math.floor(date.getTime() / 1000)` unix-seconds
+  conversion (12 sites) and the inline `new Promise(r => setTimeout(r, ms))`
+  sleep (7 sites — including the local `delay`/`sleep` helpers in `mee6Importer`
+  and `apiConnector`) onto the shared primitives. Duration *formatting* is
+  intentionally left with its callers (different units/granularity).
+
 ## [3.11.0] - 2026-06-20
 
 Internal refactor (unification #7 — toggle handler) — no behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/announcement/handler.ts
+++ b/src/commands/handlers/announcement/handler.ts
@@ -31,6 +31,7 @@ import {
   RateLimits,
   replyEphemeralError,
   showAndAwaitModal,
+  toUnixSeconds,
 } from '../../../utils';
 import {
   detectDynamicPlaceholders,
@@ -159,7 +160,7 @@ async function handleTemplateSend(
         // template with an unrendered {time} placeholder.
         const parsed = parseTimeInput(value, timezone);
         if (parsed) {
-          params.time = Math.floor(parsed.getTime() / 1000);
+          params.time = toUnixSeconds(parsed);
         } else {
           const unix = Number.parseInt(value, 10);
           if (!Number.isNaN(unix)) {

--- a/src/commands/handlers/baitChannel/override.ts
+++ b/src/commands/handlers/baitChannel/override.ts
@@ -1,7 +1,7 @@
 import { type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
 import { AppDataSource } from '../../../typeorm';
 import { BaitChannelLog } from '../../../typeorm/entities/bait/BaitChannelLog';
-import { handleInteractionError, lang, replyEphemeralError, safeDbOperation } from '../../../utils';
+import { handleInteractionError, lang, replyEphemeralError, safeDbOperation, toUnixSeconds } from '../../../utils';
 
 const tl = lang.baitChannel;
 
@@ -74,7 +74,7 @@ export async function overrideHandler(_client: Client, interaction: ChatInputCom
         },
         {
           name: tl.override.detectedAt,
-          value: `<t:${Math.floor(recentLog.createdAt.getTime() / 1000)}:R>`,
+          value: `<t:${toUnixSeconds(recentLog.createdAt)}:R>`,
           inline: true,
         },
       );

--- a/src/commands/handlers/baitChannel/raid.ts
+++ b/src/commands/handlers/baitChannel/raid.ts
@@ -7,7 +7,7 @@
  */
 
 import { type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
-import { guardFeatureAccess, handleInteractionError } from '../../../utils';
+import { guardFeatureAccess, handleInteractionError, toUnixSeconds } from '../../../utils';
 import { getRaidModeManager } from '../../../utils/baitChannel/raidModeManager';
 import { Colors } from '../../../utils/colors';
 
@@ -53,7 +53,7 @@ export async function raidHandler(_client: Client, interaction: ChatInputCommand
         if (status.active && status.until) {
           embed.addFields({
             name: 'Auto-release at',
-            value: `<t:${Math.floor(status.until.getTime() / 1000)}:f>`,
+            value: `<t:${toUnixSeconds(status.until)}:f>`,
             inline: false,
           });
         }

--- a/src/commands/handlers/dev/devSuiteWorkflows.ts
+++ b/src/commands/handlers/dev/devSuiteWorkflows.ts
@@ -24,7 +24,7 @@ import { ArchivedTicketConfig } from '../../../typeorm/entities/ticket/ArchivedT
 import { Ticket } from '../../../typeorm/entities/ticket/Ticket';
 import { XPRoleReward } from '../../../typeorm/entities/xp/XPRoleReward';
 import { XPUser } from '../../../typeorm/entities/xp/XPUser';
-import { enhancedLogger, handleInteractionError, LogCategory } from '../../../utils';
+import { enhancedLogger, handleInteractionError, LogCategory, sleep } from '../../../utils';
 import { Colors } from '../../../utils/colors';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
@@ -1102,7 +1102,7 @@ async function timelineSla(
   await interaction.editReply(`SLA Timeline: Step 1/4 - Ticket #${ticket.id} created`);
 
   // Step 2: Wait then backdate past SLA
-  await new Promise(r => setTimeout(r, 5_000));
+  await sleep(5_000);
   ticket.lastActivityAt = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
   await repo.save(ticket);
   steps.push(`Backdated ticket #${ticket.id} to 2 hours ago`);
@@ -1110,7 +1110,7 @@ async function timelineSla(
   await interaction.editReply(`SLA Timeline: Step 2/4 - Ticket backdated past SLA threshold`);
 
   // Step 3: Force SLA breach
-  await new Promise(r => setTimeout(r, 5_000));
+  await sleep(5_000);
   ticket.slaBreached = true;
   ticket.slaBreachNotified = true;
   await repo.save(ticket);
@@ -1119,7 +1119,7 @@ async function timelineSla(
   await interaction.editReply(`SLA Timeline: Step 3/4 - SLA breach triggered`);
 
   // Step 4: Simulate staff response
-  await new Promise(r => setTimeout(r, 5_000));
+  await sleep(5_000);
   ticket.firstResponseAt = new Date();
   ticket.lastActivityAt = new Date();
   await repo.save(ticket);

--- a/src/commands/handlers/event/create.ts
+++ b/src/commands/handlers/event/create.ts
@@ -25,6 +25,7 @@ import {
   parseTimeInput,
   replyEphemeralError,
   sanitizeUserInput,
+  toUnixSeconds,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 
@@ -371,7 +372,7 @@ export async function handleRecurring(
       await createAutoReminder(guildId, scheduledEvent.id, template.title, startDate, config.defaultReminderMinutes);
     }
 
-    const startTimestamp = `<t:${Math.floor(startDate.getTime() / 1000)}:F>`;
+    const startTimestamp = `<t:${toUnixSeconds(startDate)}:F>`;
 
     await interaction.editReply({
       content: formatLang(tl.recurring.success, template.title, pattern, startTimestamp),

--- a/src/commands/handlers/import/csv.ts
+++ b/src/commands/handlers/import/csv.ts
@@ -7,7 +7,7 @@
 
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { EmbedBuilder, MessageFlags } from 'discord.js';
-import { enhancedLogger, formatLang, LogCategory, lang, replyEphemeralError } from '../../../utils';
+import { enhancedLogger, formatLang, LogCategory, lang, replyEphemeralError, toUnixSeconds } from '../../../utils';
 import type { CsvImporter } from '../../../utils/import/csvImporter';
 import { importManager } from '../../../utils/import/importManager';
 
@@ -34,7 +34,7 @@ export async function csvImportHandler(interaction: ChatInputCommandInteraction)
   // Check cooldown
   const cooldownUntil = await importManager.checkCooldown(guildId);
   if (cooldownUntil) {
-    const timestamp = Math.floor(cooldownUntil.getTime() / 1000);
+    const timestamp = toUnixSeconds(cooldownUntil);
     await interaction.reply({
       content: formatLang(tl.importCooldown, `<t:${timestamp}:R>`),
       flags: [MessageFlags.Ephemeral],

--- a/src/commands/handlers/import/mee6.ts
+++ b/src/commands/handlers/import/mee6.ts
@@ -7,7 +7,7 @@
 
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { EmbedBuilder, MessageFlags } from 'discord.js';
-import { enhancedLogger, formatLang, LogCategory, lang, replyEphemeralError } from '../../../utils';
+import { enhancedLogger, formatLang, LogCategory, lang, replyEphemeralError, toUnixSeconds } from '../../../utils';
 import { importManager } from '../../../utils/import/importManager';
 
 const tl = lang.import.commands;
@@ -26,7 +26,7 @@ export async function mee6ImportHandler(interaction: ChatInputCommandInteraction
   // Check cooldown
   const cooldownUntil = await importManager.checkCooldown(guildId);
   if (cooldownUntil) {
-    const timestamp = Math.floor(cooldownUntil.getTime() / 1000);
+    const timestamp = toUnixSeconds(cooldownUntil);
     await interaction.reply({
       content: formatLang(tl.importCooldown, `<t:${timestamp}:R>`),
       flags: [MessageFlags.Ephemeral],

--- a/src/commands/handlers/import/status.ts
+++ b/src/commands/handlers/import/status.ts
@@ -8,7 +8,7 @@
 
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { EmbedBuilder, MessageFlags } from 'discord.js';
-import { lang, replyEphemeralError } from '../../../utils';
+import { lang, replyEphemeralError, toUnixSeconds } from '../../../utils';
 import { importManager } from '../../../utils/import/importManager';
 
 const tl = lang.import.commands;
@@ -61,7 +61,7 @@ export async function importStatusHandler(interaction: ChatInputCommandInteracti
                 : '\u23f3';
 
         const duration = log.durationMs ? `${(log.durationMs / 1000).toFixed(1)}s` : 'N/A';
-        const timestamp = Math.floor(log.startedAt.getTime() / 1000);
+        const timestamp = toUnixSeconds(log.startedAt);
 
         embed.addFields({
           name: `${statusEmoji} ${log.source} (${log.dataType})`,

--- a/src/utils/announcement/templateEngine.ts
+++ b/src/utils/announcement/templateEngine.ts
@@ -7,6 +7,7 @@
 
 import { EmbedBuilder, type Guild, type User } from 'discord.js';
 import type { AnnouncementTemplate } from '../../typeorm/entities/announcement/AnnouncementTemplate';
+import { nowUnixSeconds } from '../time';
 import { sanitizeUserInput } from '../validation/inputSanitizer';
 
 // ============================================================================
@@ -218,7 +219,7 @@ export function renderPreview(
   user: User | null,
   roleId?: string | null,
 ): RenderedAnnouncement {
-  const now = Math.floor(Date.now() / 1000);
+  const now = nowUnixSeconds();
   const exampleParams: TemplatePlaceholderParams = {
     version: '1.0.0',
     duration: '5-10 minutes',

--- a/src/utils/apiConnector.ts
+++ b/src/utils/apiConnector.ts
@@ -13,6 +13,7 @@
 import type { Client } from 'discord.js';
 import { version } from '../../package.json';
 import { enhancedLogger, LogCategory } from './monitoring/enhancedLogger';
+import { sleep } from './time';
 
 /**
  * Bot stats data sent to API (v1.3.0 format)
@@ -203,7 +204,7 @@ export class APIConnector {
           LogCategory.API,
         );
 
-        await this.sleep(delay);
+        await sleep(delay);
         return this.makeRequestWithRetry(requestFn, retryCount + 1);
       }
 
@@ -245,10 +246,6 @@ export class APIConnector {
     );
     const jitter = Math.random() * 0.3 * delay;
     return Math.floor(delay + jitter);
-  }
-
-  private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   private recordSuccess(): void {

--- a/src/utils/baitChannel/appealToken.ts
+++ b/src/utils/baitChannel/appealToken.ts
@@ -22,6 +22,7 @@
 
 import { Buffer } from 'node:buffer';
 import { createHmac, timingSafeEqual } from 'node:crypto';
+import { nowUnixSeconds } from '../time';
 
 const ISSUER_NAME = 'cogworks';
 const DEFAULT_EXP_HOURS = 7 * 24; // 7 days — long enough for most ban-appeal workflows
@@ -85,7 +86,7 @@ function getSecret(): string {
 }
 
 export function signAppealToken(input: SignAppealTokenInput): string {
-  const now = Math.floor(Date.now() / 1000);
+  const now = nowUnixSeconds();
   const exp = now + (input.expiresInHours ?? DEFAULT_EXP_HOURS) * 3600;
   const payload: AppealTokenPayload = {
     guildId: input.guildId,

--- a/src/utils/baitChannel/baitChannelManager.ts
+++ b/src/utils/baitChannel/baitChannelManager.ts
@@ -25,6 +25,7 @@ import { CACHE_TTL, INTERVALS } from '../constants';
 import { createTtlCache } from '../database/configCache';
 import { ErrorCategory, ErrorSeverity, logError } from '../errorHandler';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+import { toUnixSeconds } from '../time';
 import { buildAppealUrl } from './appealToken';
 import { buildAuditReason, flagsTriggered } from './auditReason';
 import { type BanExecutorAction, type BanExecutorResult, executeBanAction } from './banExecutor';
@@ -1553,7 +1554,7 @@ export class BaitChannelManager {
       if (repeatOffenderResult && repeatOffenderResult.matchCount > 0) {
         const matchList = repeatOffenderResult.matchingUsers
           .slice(0, 10) // Cap display at 10
-          .map(u => `• <@${u.userId}> — joined <t:${Math.floor(u.joinedAt.getTime() / 1000)}:R>`)
+          .map(u => `• <@${u.userId}> — joined <t:${toUnixSeconds(u.joinedAt)}:R>`)
           .join('\n');
         embed.addFields({
           name: '🚨 Possible Coordinated Raid',

--- a/src/utils/baitChannel/banExecutor.ts
+++ b/src/utils/baitChannel/banExecutor.ts
@@ -30,6 +30,7 @@ import type { Repository } from 'typeorm';
 import type { IdempotencyKey } from '../../typeorm/entities/bait/IdempotencyKey';
 import { ErrorCategory, ErrorSeverity, logError } from '../errorHandler';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+import { sleep } from '../time';
 
 export type BanExecutorAction = 'ban' | 'softban' | 'kick' | 'timeout' | 'log-only';
 
@@ -246,7 +247,7 @@ export async function executeBanAction(
         });
         // Brief delay so Discord finishes the message-purge step before we
         // lift the ban.
-        await new Promise(r => setTimeout(r, softbanDelayMs));
+        await sleep(softbanDelayMs);
         try {
           await guild.bans.remove(userId, 'Softban complete — user may rejoin');
         } catch (removeError) {

--- a/src/utils/baitChannel/raidModeManager.ts
+++ b/src/utils/baitChannel/raidModeManager.ts
@@ -33,6 +33,7 @@ import type { BaitChannelLog } from '../../typeorm/entities/bait/BaitChannelLog'
 import { Colors } from '../colors';
 import { ErrorCategory, ErrorSeverity, logError } from '../errorHandler';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+import { toUnixSeconds } from '../time';
 
 /** Maximum duration of an auto-entered raid lockdown — admin must release earlier or wait. */
 const RAID_MODE_MAX_DURATION_MS = 4 * 60 * 60 * 1000; // 4 hours
@@ -385,7 +386,7 @@ export class RaidModeManager {
         `Detected **${triggers.length} bait triggers** within ` +
           `**${config.raidModeWindowSeconds}s** — exceeded threshold of ` +
           `${config.raidModeThreshold}. Server is locked down until ` +
-          `<t:${Math.floor(until.getTime() / 1000)}:f>.`,
+          `<t:${toUnixSeconds(until)}:f>.`,
       )
       .addFields(
         {

--- a/src/utils/forumTagManager.ts
+++ b/src/utils/forumTagManager.ts
@@ -1,5 +1,6 @@
 import type { ForumChannel, GuildForumTag } from 'discord.js';
 import { enhancedLogger, LogCategory } from './monitoring/enhancedLogger';
+import { sleep } from './time';
 
 /**
  * Creates or finds a forum tag based on custom ticket type properties.
@@ -72,7 +73,7 @@ export async function ensureForumTag(
     await forumChannel.setAvailableTags(updatedTags);
 
     // Wait a moment for Discord to process the change
-    await new Promise(resolve => setTimeout(resolve, 500));
+    await sleep(500);
 
     // Fetch the created tag ID (it's the last one added)
     const refreshedChannel = (await forumChannel.fetch()) as ForumChannel;

--- a/src/utils/import/mee6Importer.ts
+++ b/src/utils/import/mee6Importer.ts
@@ -6,6 +6,7 @@
  */
 
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+import { sleep } from '../time';
 import type { BotImporter, ImportOptions, ImportResult, RawXpRecord } from './types';
 
 const MEE6_API_BASE = 'https://mee6.xyz/api/plugins/levels/leaderboard';
@@ -24,13 +25,6 @@ interface Mee6Player {
 interface Mee6LeaderboardResponse {
   players: Mee6Player[];
   page: number;
-}
-
-/**
- * Delay execution for a given number of milliseconds
- */
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 export class Mee6Importer implements BotImporter {
@@ -166,7 +160,7 @@ export class Mee6Importer implements BotImporter {
         } else {
           page++;
           // Rate limit: wait between requests
-          await delay(REQUEST_DELAY_MS);
+          await sleep(REQUEST_DELAY_MS);
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -49,6 +49,8 @@ export * from './security/rateLimiter';
 export * from './setup';
 // Status utilities
 export * from './status';
+// Time primitives
+export * from './time';
 export * from './types';
 // Validation utilities
 export * from './validation/inputSanitizer';

--- a/src/utils/ticket/transcriptBuilder.ts
+++ b/src/utils/ticket/transcriptBuilder.ts
@@ -15,6 +15,7 @@
  */
 
 import { TEXT_LIMITS } from '../constants';
+import { toUnixSeconds } from '../time';
 
 /** Per-message shape the fetcher hands to the builder. */
 export interface TranscriptMessage {
@@ -82,7 +83,7 @@ const CHUNK_HARD_LIMIT = TEXT_LIMITS.TRANSCRIPT_CHUNK_HARD;
 
 /** `<t:unix:f>` — Discord renders this in the viewer's local timezone. */
 function formatDiscordTimestamp(date: Date): string {
-  return `<t:${Math.floor(date.getTime() / 1000)}:f>`;
+  return `<t:${toUnixSeconds(date)}:f>`;
 }
 
 /** Minutes-granularity duration for `2h 14m` / `3d 5h` / `47m` strings. */

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,27 @@
+/**
+ * Small time primitives (unification roadmap, Phase A4).
+ *
+ * Consolidates two idioms repeated across the codebase:
+ *   - the `new Promise(resolve => setTimeout(resolve, ms))` sleep, and
+ *   - the `Math.floor(date.getTime() / 1000)` unix-seconds conversion that feeds
+ *     Discord `<t:unix:style>` timestamps, cooldown stamps, and backoff delays.
+ *
+ * Duration *formatting* deliberately stays with its callers (transcript, ping,
+ * status, healthMonitor, rateLimiter) — those take different input units and
+ * granularity, so merging them would be lossy rather than DRY.
+ */
+
+/** Resolve after `ms` milliseconds. */
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/** Whole unix seconds for a `Date` — the value Discord `<t:…>` timestamps expect. */
+export function toUnixSeconds(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
+/** Current time in whole unix seconds. */
+export function nowUnixSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}

--- a/tests/unit/utils/time.test.ts
+++ b/tests/unit/utils/time.test.ts
@@ -1,0 +1,44 @@
+/**
+ * time primitive unit tests.
+ *
+ * toUnixSeconds / nowUnixSeconds are pure and exact; sleep is verified to
+ * actually delay (loose lower bound to avoid timer flake).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { nowUnixSeconds, sleep, toUnixSeconds } from '../../../src/utils/time';
+
+describe('toUnixSeconds', () => {
+  test('converts epoch to 0', () => {
+    expect(toUnixSeconds(new Date(0))).toBe(0);
+  });
+
+  test('converts a known millisecond timestamp to whole seconds', () => {
+    expect(toUnixSeconds(new Date(1_700_000_000_000))).toBe(1_700_000_000);
+  });
+
+  test('floors sub-second milliseconds (does not round up)', () => {
+    expect(toUnixSeconds(new Date(1_999))).toBe(1);
+  });
+});
+
+describe('nowUnixSeconds', () => {
+  test('matches Math.floor(Date.now() / 1000) within a second', () => {
+    const expected = Math.floor(Date.now() / 1000);
+    const actual = nowUnixSeconds();
+    expect(actual).toBeGreaterThanOrEqual(expected - 1);
+    expect(actual).toBeLessThanOrEqual(expected + 1);
+  });
+});
+
+describe('sleep', () => {
+  test('resolves after roughly the requested delay', async () => {
+    const start = Date.now();
+    await sleep(30);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(10);
+  });
+
+  test('resolves to undefined', async () => {
+    expect(await sleep(1)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Phase A4 — `utils/time.ts` (time primitives)

Internal tidiness, **no behavior change**. Completes Phase A of the unification roadmap.

### What changed
- **New `src/utils/time.ts`**: `sleep(ms)`, `toUnixSeconds(date)`, `nowUnixSeconds()`. +6 unit tests.
- **Migrated 19 sites** onto the shared primitives:
  - 12 `Math.floor(date.getTime() / 1000)` unix-seconds conversions (10 `getTime()`, 2 `Date.now()`), including 5 embedded in `<t:…>` Discord timestamps.
  - 7 inline `new Promise(r => setTimeout(r, ms))` sleeps — including the local `delay`/`sleep` helpers in `mee6Importer` and `apiConnector`, which are now removed in favor of the shared one.
- **Deliberately left alone**: duration formatting (`formatDurationShort`, ping/status/healthMonitor/rateLimiter). Those take different input units and granularity, so merging them would be lossy rather than DRY.

### Verification
- Behavior-preserving by construction: `toUnixSeconds(x) === Math.floor(x.getTime() / 1000)`, and `sleep` is the same `setTimeout` promise.
- `bun run build` clean · `bun run check` (biome) clean · `bun test` — 1356 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated internal time-related utilities for improved code maintainability.

* **Tests**
  * Added unit tests for newly introduced time utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->