### PR TITLE
refactor: postTranscriptToThread spine (unification #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.2] - 2026-06-21
+
+Internal refactor (unification #5 — archive transcript spine) — no behavior change.
+
+### Added
+
+- `utils/ticket/transcriptPoster.ts` — `postTranscriptToThread(thread, chunks, ctx)`,
+  the shared chunk-posting spine of the ticket and application close workflows
+  (near-mirror archive paths). Kept out of the pure `transcriptBuilder` so that
+  module stays Discord-client-free. +3 unit tests.
+
+### Changed
+
+- `ticket/closeWorkflow` and `application/closeWorkflow` drop their duplicate
+  local `sendTranscriptChunks` and call the shared spine (a `label` keeps each
+  side's log line). Left hand-written: the divergent archive bodies (ticket tags
+  / custom types / email fields vs application) — parametrizing those would be lossy.
+
 ## [3.11.1] - 2026-06-21
 
 Internal tidiness (unification Phase A4 — time primitives) — no behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -18,6 +18,7 @@ import { verifiedChannelDelete } from '../discord/verifiedDelete';
 import { fetchMessagesAsTranscript } from '../fetchAllMessages';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { buildTranscript, type TicketMetadata, type TranscriptMessage } from '../ticket/transcriptBuilder';
+import { postTranscriptToThread } from '../ticket/transcriptPoster';
 
 const archivedAppRepo = lazyRepo(ArchivedApplication);
 
@@ -46,31 +47,6 @@ const defaultDeps: CloseApplicationWorkflowDeps = {
   verifiedChannelDelete,
   archivedAppRepo,
 };
-
-/**
- * Post each transcript chunk to the thread. Never pings (historical content),
- * and attributes a failed send to its chunk index. Rethrows so the caller marks
- * the archive failed.
- */
-async function sendTranscriptChunks(
-  thread: ForumThreadChannel,
-  chunks: string[],
-  ctx: { guildId: string; channelId: string },
-): Promise<void> {
-  for (let i = 0; i < chunks.length; i++) {
-    try {
-      await thread.send({ content: chunks[i], allowedMentions: { parse: [] } });
-    } catch (error) {
-      enhancedLogger.error(
-        `Application transcript chunk ${i + 1}/${chunks.length} failed to post`,
-        error as Error,
-        LogCategory.SYSTEM,
-        ctx,
-      );
-      throw error;
-    }
-  }
-}
 
 /**
  * Archive an application to the forum channel and clean up.
@@ -139,7 +115,7 @@ export async function archiveAndCloseApplication(
         }),
       );
 
-      await sendTranscriptChunks(newPost, transcript.chunks, { guildId, channelId });
+      await postTranscriptToThread(newPost, transcript.chunks, { guildId, channelId, label: 'Application transcript' });
     } else if (existingArchive.messageId) {
       // Re-close: reuse the archive thread, but it may have been deleted out
       // from under us. force:true bypasses the cache; catch ONLY 10003 (Unknown
@@ -160,14 +136,18 @@ export async function archiveAndCloseApplication(
         // Repoint + persist BEFORE chunks so a chunk failure can't orphan it.
         existingArchive.messageId = newPost.id;
         await deps.archivedAppRepo.save(existingArchive);
-        await sendTranscriptChunks(newPost, transcript.chunks, { guildId, channelId });
+        await postTranscriptToThread(newPost, transcript.chunks, {
+          guildId,
+          channelId,
+          label: 'Application transcript',
+        });
       } else {
         const separator = '\n━━━━━━━━━━━━━━━━━━━━━━━━\n';
         await post.send({
           content: separator + transcript.header,
           allowedMentions: { parse: [] },
         });
-        await sendTranscriptChunks(post, transcript.chunks, { guildId, channelId });
+        await postTranscriptToThread(post, transcript.chunks, { guildId, channelId, label: 'Application transcript' });
       }
     }
   } catch (error) {

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -19,6 +19,7 @@ import { applyForumTags, ensureForumTag } from '../forumTagManager';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { builtinTypeInfo, resolveTicketType } from './builtinTypes';
 import { buildTranscript, type TicketMetadata, type TranscriptMessage } from './transcriptBuilder';
+import { postTranscriptToThread } from './transcriptPoster';
 
 const archivedTicketRepo = lazyRepo(ArchivedTicket);
 
@@ -134,31 +135,6 @@ async function resolveArchiveThreadName(client: Client, ticket: Ticket): Promise
   return user?.username || 'Unknown';
 }
 
-/**
- * Post each transcript chunk to the thread. Never pings (historical content),
- * and attributes a failed send to its chunk index so a partial-archive failure
- * is diagnosable. Rethrows so the caller marks the archive failed.
- */
-async function sendTranscriptChunks(
-  thread: ForumThreadChannel,
-  chunks: string[],
-  ctx: { guildId: string; channelId: string },
-): Promise<void> {
-  for (let i = 0; i < chunks.length; i++) {
-    try {
-      await thread.send({ content: chunks[i], allowedMentions: { parse: [] } });
-    } catch (error) {
-      enhancedLogger.error(
-        `Transcript chunk ${i + 1}/${chunks.length} failed to post`,
-        error as Error,
-        LogCategory.SYSTEM,
-        ctx,
-      );
-      throw error;
-    }
-  }
-}
-
 /** Union of existing + incoming forum tag ids, order-preserving, deduped. */
 function mergeForumTags(existing: string[] | null | undefined, incoming: string[]): string[] {
   const merged = [...(existing ?? [])];
@@ -269,7 +245,7 @@ export async function archiveAndCloseTicket(
         }),
       );
 
-      await sendTranscriptChunks(newPost, transcript.chunks, {
+      await postTranscriptToThread(newPost, transcript.chunks, {
         guildId,
         channelId,
       });
@@ -310,7 +286,7 @@ export async function archiveAndCloseTicket(
         existingArchive.messageId = newPost.id;
         existingArchive.forumTagIds = mergedTags;
         await deps.archivedTicketRepo.save(existingArchive);
-        await sendTranscriptChunks(newPost, transcript.chunks, {
+        await postTranscriptToThread(newPost, transcript.chunks, {
           guildId,
           channelId,
         });
@@ -322,7 +298,7 @@ export async function archiveAndCloseTicket(
           content: separator + transcript.header,
           allowedMentions: { parse: [] },
         });
-        await sendTranscriptChunks(post, transcript.chunks, {
+        await postTranscriptToThread(post, transcript.chunks, {
           guildId,
           channelId,
         });

--- a/src/utils/ticket/transcriptPoster.ts
+++ b/src/utils/ticket/transcriptPoster.ts
@@ -1,0 +1,39 @@
+/**
+ * Posts a built transcript's chunks into a forum archive thread.
+ *
+ * Shared spine of the ticket and application close workflows (near-mirror
+ * archive paths). Kept separate from the pure `transcriptBuilder` so that
+ * module stays Discord-client-free. Never pings (historical content),
+ * attributes a failed send to its chunk index so a partial-archive failure is
+ * diagnosable, and rethrows so the caller marks the archive failed.
+ */
+import type { ForumThreadChannel } from 'discord.js';
+import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+
+export interface TranscriptPostContext {
+  guildId: string;
+  channelId: string;
+  /** Log-label prefix for chunk-failure errors. Defaults to 'Transcript'. */
+  label?: string;
+}
+
+export async function postTranscriptToThread(
+  thread: ForumThreadChannel,
+  chunks: string[],
+  ctx: TranscriptPostContext,
+): Promise<void> {
+  const label = ctx.label ?? 'Transcript';
+  for (let i = 0; i < chunks.length; i++) {
+    try {
+      await thread.send({ content: chunks[i], allowedMentions: { parse: [] } });
+    } catch (error) {
+      enhancedLogger.error(
+        `${label} chunk ${i + 1}/${chunks.length} failed to post`,
+        error as Error,
+        LogCategory.SYSTEM,
+        { guildId: ctx.guildId, channelId: ctx.channelId },
+      );
+      throw error;
+    }
+  }
+}

--- a/tests/unit/utils/ticket/transcriptPoster.test.ts
+++ b/tests/unit/utils/ticket/transcriptPoster.test.ts
@@ -1,0 +1,46 @@
+/**
+ * postTranscriptToThread unit tests.
+ *
+ * Drives the shared archive spine with a fake thread that records sends and can
+ * be made to throw, covering the post-every-chunk, no-ping, and rethrow-on-
+ * failure behavior both close workflows rely on.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { postTranscriptToThread } from '../../../../src/utils/ticket/transcriptPoster';
+
+function makeThread(opts: { failAt?: number } = {}) {
+  const calls: Array<{ content: string; allowedMentions: unknown }> = [];
+  const thread = {
+    send: async (payload: { content: string; allowedMentions: unknown }) => {
+      if (opts.failAt !== undefined && calls.length === opts.failAt) throw new Error('send failed');
+      calls.push(payload);
+      return {};
+    },
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: minimal ForumThreadChannel test double
+  return { thread: thread as any, calls };
+}
+
+const ctx = { guildId: 'g1', channelId: 'c1' };
+
+describe('postTranscriptToThread', () => {
+  test('sends every chunk in order and never pings', async () => {
+    const { thread, calls } = makeThread();
+    await postTranscriptToThread(thread, ['a', 'b', 'c'], ctx);
+    expect(calls.map(c => c.content)).toEqual(['a', 'b', 'c']);
+    expect(calls.every(c => JSON.stringify(c.allowedMentions) === JSON.stringify({ parse: [] }))).toBe(true);
+  });
+
+  test('rethrows and stops at the first chunk that fails to send', async () => {
+    const { thread, calls } = makeThread({ failAt: 1 });
+    await expect(postTranscriptToThread(thread, ['a', 'b', 'c'], ctx)).rejects.toThrow('send failed');
+    expect(calls.map(c => c.content)).toEqual(['a']);
+  });
+
+  test('no sends for an empty chunk list', async () => {
+    const { thread, calls } = makeThread();
+    await postTranscriptToThread(thread, [], ctx);
+    expect(calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Unification #5 — `postTranscriptToThread` spine

Internal refactor, **no behavior change**. Extracts the chunk-posting logic that the ticket and application close workflows each hand-rolled identically. Thin spine only — **not** the full `archiveAndCloseEntity` parametrization (the divergent archive bodies make that lossy).

### What changed
- **New `src/utils/ticket/transcriptPoster.ts`**: `postTranscriptToThread(thread, chunks, ctx)` — loops the transcript chunks, posts each with `allowedMentions: { parse: [] }` (never pings historical content), attributes a failed send to its chunk index, and rethrows so the caller marks the archive failed. Kept in a new module so the pure `transcriptBuilder` stays Discord-client-free. **+3 unit tests** (fake thread).
- **`ticket/closeWorkflow` + `application/closeWorkflow`** drop their duplicate local `sendTranscriptChunks` and call the shared spine. A `label` (default `'Transcript'`; application overrides to `'Application transcript'`) keeps each side's error-log strings **byte-identical** to before.

### Deliberately left hand-written
The divergent archive bodies — ticket forum-tag accumulation / custom-type resolution / email-ticket fields vs. application (which has none of those, and a different archive schema). Parametrizing those into one function would be lossy, not DRY.

### Verification
- Behavior-preserving by construction (same `thread.send` payload, per-chunk error attribution, rethrow; log strings preserved via `label`).
- `bun run build` clean · `bun run check` (biome) clean · `bun test` — 1359 pass, 0 fail (incl. the existing v3.1.8 transcript + close-workflow suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
