### PR TITLE
refactor: createToggleHandler require-existing mode + fold ticket toggles (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.11.3] - 2026-06-21
+
+Internal refactor (unification #7 — toggle require-existing mode) — no behavior change.
+
+### Changed
+
+- `createToggleHandler` gains a `requireExisting` mode (+ an `onEnable` pre-save
+  seed hook): the config row must already exist, replying a `notConfigured`
+  message instead of creating it. Folded the ticket **workflow** and **smart-
+  routing** enable/disable handlers onto it — routing's `resetRoundRobin` rides
+  `onToggled`, workflow seeds default statuses via `onEnable`. Ticket **SLA**
+  stays hand-written (its enable reads command options + formats conditional
+  replies — a config-setter, not a pure toggle). +5 unit tests.
+
 ## [3.11.2] - 2026-06-21
 
 Internal refactor (unification #5 — archive transcript spine) — no behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/ticket/routing.ts
+++ b/src/commands/handlers/ticket/routing.ts
@@ -10,7 +10,15 @@
 import { type CacheType, type ChatInputCommandInteraction, EmbedBuilder, MessageFlags } from 'discord.js';
 import { Ticket } from '../../../typeorm/entities/ticket/Ticket';
 import { TicketConfig } from '../../../typeorm/entities/ticket/TicketConfig';
-import { enhancedLogger, formatLang, guardFeatureAccess, LogCategory, lang, replyEphemeralError } from '../../../utils';
+import {
+  createToggleHandler,
+  enhancedLogger,
+  formatLang,
+  guardFeatureAccess,
+  LogCategory,
+  lang,
+  replyEphemeralError,
+} from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import {
   getStaffWorkload,
@@ -26,6 +34,26 @@ const ticketRepo = lazyRepo(Ticket);
 const MAX_ROUTING_RULES = 25;
 const VALID_STRATEGIES: RoutingStrategy[] = ['round-robin', 'least-load', 'random'];
 
+const routingToggle = createToggleHandler<TicketConfig>({
+  repo: ticketConfigRepo,
+  field: 'smartRoutingEnabled',
+  requireExisting: { notConfigured: lang.ticket.ticketConfigNotFound },
+  messages: {
+    alreadyEnabled: tl.alreadyEnabled,
+    alreadyDisabled: tl.alreadyDisabled,
+    enabled: tl.enabled,
+    disabled: tl.disabled,
+  },
+  // Smart routing rides on the workflow system.
+  canEnable: config => (!config.enableWorkflow ? tl.requiresWorkflow : null),
+  onToggled: (_interaction, guildId, enabled) => {
+    if (!enabled) resetRoundRobin(guildId); // clear round-robin state on disable
+    enhancedLogger.info(`Smart routing ${enabled ? 'enabled' : 'disabled'}`, LogCategory.COMMAND_EXECUTION, {
+      guildId,
+    });
+  },
+});
+
 // ============================================================================
 // /ticket routing-enable
 // ============================================================================
@@ -33,36 +61,7 @@ const VALID_STRATEGIES: RoutingStrategy[] = ['round-robin', 'least-load', 'rando
 export async function routingEnableHandler(interaction: ChatInputCommandInteraction<CacheType>) {
   const guard = await guardFeatureAccess(interaction, 'tickets', 'manage');
   if (!guard.allowed) return;
-
-  const guildId = interaction.guildId!;
-  const config = await ticketConfigRepo.findOneBy({ guildId });
-
-  if (!config) {
-    await replyEphemeralError(interaction, lang.ticket.ticketConfigNotFound);
-    return;
-  }
-
-  if (!config.enableWorkflow) {
-    await replyEphemeralError(interaction, tl.requiresWorkflow);
-    return;
-  }
-
-  if (config.smartRoutingEnabled) {
-    await replyEphemeralError(interaction, tl.alreadyEnabled);
-    return;
-  }
-
-  config.smartRoutingEnabled = true;
-  await ticketConfigRepo.save(config);
-
-  await interaction.reply({
-    content: tl.enabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.info('Smart routing enabled', LogCategory.COMMAND_EXECUTION, {
-    guildId,
-  });
+  await routingToggle.enable(interaction, interaction.guildId!);
 }
 
 // ============================================================================
@@ -72,34 +71,7 @@ export async function routingEnableHandler(interaction: ChatInputCommandInteract
 export async function routingDisableHandler(interaction: ChatInputCommandInteraction<CacheType>) {
   const guard = await guardFeatureAccess(interaction, 'tickets', 'manage');
   if (!guard.allowed) return;
-
-  const guildId = interaction.guildId!;
-  const config = await ticketConfigRepo.findOneBy({ guildId });
-
-  if (!config) {
-    await replyEphemeralError(interaction, lang.ticket.ticketConfigNotFound);
-    return;
-  }
-
-  if (!config.smartRoutingEnabled) {
-    await replyEphemeralError(interaction, tl.alreadyDisabled);
-    return;
-  }
-
-  config.smartRoutingEnabled = false;
-  await ticketConfigRepo.save(config);
-
-  // Clear round-robin state for this guild
-  resetRoundRobin(guildId);
-
-  await interaction.reply({
-    content: tl.disabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.info('Smart routing disabled', LogCategory.COMMAND_EXECUTION, {
-    guildId,
-  });
+  await routingToggle.disable(interaction, interaction.guildId!);
 }
 
 // ============================================================================

--- a/src/commands/handlers/ticket/workflow.ts
+++ b/src/commands/handlers/ticket/workflow.ts
@@ -17,6 +17,7 @@ import type { TicketStatusHistoryEntry } from '../../../typeorm/entities/ticket/
 import { Ticket } from '../../../typeorm/entities/ticket/Ticket';
 import { TicketConfig, type WorkflowStatus } from '../../../typeorm/entities/ticket/TicketConfig';
 import {
+  createToggleHandler,
   DEFAULT_TICKET_STATUSES,
   enhancedLogger,
   formatLang,
@@ -35,6 +36,29 @@ const tl = lang.ticket.workflow;
 const tlInfo = lang.ticket.info;
 const ticketConfigRepo = lazyRepo(TicketConfig);
 const ticketRepo = lazyRepo(Ticket);
+
+const workflowToggle = createToggleHandler<TicketConfig>({
+  repo: ticketConfigRepo,
+  field: 'enableWorkflow',
+  requireExisting: { notConfigured: lang.ticket.ticketConfigNotFound },
+  messages: {
+    alreadyEnabled: tl.alreadyEnabled,
+    alreadyDisabled: tl.alreadyDisabled,
+    enabled: tl.enabled,
+    disabled: tl.disabled,
+  },
+  // Seed the default status set on first enable; preserved across a later disable.
+  onEnable: config => {
+    if (!config.workflowStatuses || config.workflowStatuses.length === 0) {
+      config.workflowStatuses = [...DEFAULT_TICKET_STATUSES];
+    }
+  },
+  onToggled: (_interaction, guildId, enabled) => {
+    enhancedLogger.info(`Ticket workflow ${enabled ? 'enabled' : 'disabled'}`, LogCategory.COMMAND_EXECUTION, {
+      guildId,
+    });
+  },
+});
 
 // ============================================================================
 // Helper: Get ticket config with workflow check
@@ -331,32 +355,7 @@ export async function ticketInfoHandler(interaction: ChatInputCommandInteraction
 export async function workflowEnableHandler(interaction: ChatInputCommandInteraction<CacheType>) {
   const guard = await guardFeatureAccess(interaction, 'tickets', 'manage');
   if (!guard.allowed) return;
-
-  const guildId = interaction.guildId!;
-  const config = await ticketConfigRepo.findOneBy({ guildId });
-
-  if (!config) {
-    await replyEphemeralError(interaction, lang.ticket.ticketConfigNotFound);
-    return;
-  }
-
-  if (config.enableWorkflow) {
-    await replyEphemeralError(interaction, tl.alreadyEnabled);
-    return;
-  }
-
-  config.enableWorkflow = true;
-  if (!config.workflowStatuses || config.workflowStatuses.length === 0) {
-    config.workflowStatuses = [...DEFAULT_TICKET_STATUSES];
-  }
-  await ticketConfigRepo.save(config);
-
-  await interaction.reply({
-    content: tl.enabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.info('Ticket workflow enabled', LogCategory.COMMAND_EXECUTION, { guildId });
+  await workflowToggle.enable(interaction, interaction.guildId!);
 }
 
 // ============================================================================
@@ -366,30 +365,7 @@ export async function workflowEnableHandler(interaction: ChatInputCommandInterac
 export async function workflowDisableHandler(interaction: ChatInputCommandInteraction<CacheType>) {
   const guard = await guardFeatureAccess(interaction, 'tickets', 'manage');
   if (!guard.allowed) return;
-
-  const guildId = interaction.guildId!;
-  const config = await ticketConfigRepo.findOneBy({ guildId });
-
-  if (!config) {
-    await replyEphemeralError(interaction, lang.ticket.ticketConfigNotFound);
-    return;
-  }
-
-  if (!config.enableWorkflow) {
-    await replyEphemeralError(interaction, tl.alreadyDisabled);
-    return;
-  }
-
-  config.enableWorkflow = false;
-  // Don't delete workflowStatuses — preserved for re-enable
-  await ticketConfigRepo.save(config);
-
-  await interaction.reply({
-    content: tl.disabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.info('Ticket workflow disabled', LogCategory.COMMAND_EXECUTION, { guildId });
+  await workflowToggle.disable(interaction, interaction.guildId!);
 }
 
 // ============================================================================

--- a/src/utils/interactions/toggleHandler.ts
+++ b/src/utils/interactions/toggleHandler.ts
@@ -8,12 +8,11 @@
  * the field, the messages, an optional pre-enable guard, and an `onToggled`
  * side effect (where the Phase-B cache `invalidate*` calls plug in).
  *
- * Scope: covers the self-fetching, text-reply toggles whose only difference is
- * the column + messages (+ optional guard/side effect). Toggles that read
- * command options, require a pre-existing row with a bespoke "not configured"
- * path, reply with embeds, or run on a dispatcher-prefetched config are left
- * hand-written — folding them in would need single-use hooks that defeat the
- * point of a thin helper.
+ * Scope: covers the self-fetching, text-reply toggles (find-or-create or
+ * require-existing) whose divergences are the column, the messages, an optional
+ * pre-enable guard/seed, and a side effect. Toggles that read command options,
+ * reply with embeds, or run on a dispatcher-prefetched config are left
+ * hand-written — those need hooks that defeat the point of a thin helper.
  */
 
 import { type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
@@ -41,11 +40,22 @@ export interface ToggleHandlerOptions<T extends { guildId: string }> {
   field: BooleanKeys<T>;
   messages: ToggleMessages;
   /**
+   * When set, the config row must already exist: enable/disable reply
+   * `notConfigured` instead of creating the row (enable) or treating a missing
+   * row as already-off (disable). Omit for the find-or-create default.
+   */
+  requireExisting?: { notConfigured: string };
+  /**
    * Optional pre-enable guard. Return an error message to block enabling (sent
    * ephemerally), or null/undefined to allow it. Runs after the row is
    * found/created but before the already-enabled check.
    */
   canEnable?: (config: T) => string | null | undefined;
+  /**
+   * Mutate the config when enabling, after the flag is set and before save —
+   * e.g. seed dependent defaults. Runs only on enable.
+   */
+  onEnable?: (config: T) => void;
   /**
    * Side effect after a successful toggle — cache invalidation, audit logging,
    * etc. This is where the Phase-B `invalidate*` cache calls plug in.
@@ -66,11 +76,18 @@ export interface ToggleHandlers {
  * it actually changes state.
  */
 export function createToggleHandler<T extends { guildId: string }>(options: ToggleHandlerOptions<T>): ToggleHandlers {
-  const { repo, field, messages, canEnable, onToggled } = options;
+  const { repo, field, messages, requireExisting, canEnable, onEnable, onToggled } = options;
   const where = (guildId: string) => ({ guildId }) as FindOptionsWhere<T>;
 
   async function enable(interaction: ChatInputCommandInteraction, guildId: string): Promise<void> {
-    const config = (await repo.findOneBy(where(guildId))) ?? repo.create({ guildId } as DeepPartial<T>);
+    let config = await repo.findOneBy(where(guildId));
+    if (!config) {
+      if (requireExisting) {
+        await replyEphemeralError(interaction, requireExisting.notConfigured);
+        return;
+      }
+      config = repo.create({ guildId } as DeepPartial<T>);
+    }
 
     const guardError = canEnable?.(config);
     if (guardError) {
@@ -83,6 +100,7 @@ export function createToggleHandler<T extends { guildId: string }>(options: Togg
     }
 
     Object.assign(config, { [field]: true });
+    onEnable?.(config);
     await repo.save(config);
     await onToggled?.(interaction, guildId, true);
 
@@ -91,6 +109,10 @@ export function createToggleHandler<T extends { guildId: string }>(options: Togg
 
   async function disable(interaction: ChatInputCommandInteraction, guildId: string): Promise<void> {
     const config = await repo.findOneBy(where(guildId));
+    if (requireExisting && !config) {
+      await replyEphemeralError(interaction, requireExisting.notConfigured);
+      return;
+    }
     if (!config?.[field]) {
       await replyEphemeralError(interaction, messages.alreadyDisabled);
       return;

--- a/tests/unit/utils/interactions/toggleHandler.test.ts
+++ b/tests/unit/utils/interactions/toggleHandler.test.ts
@@ -204,3 +204,95 @@ describe('createToggleHandler — disable', () => {
     expect(replies.at(-1)?.content).toContain('already off');
   });
 });
+
+describe('createToggleHandler — requireExisting', () => {
+  const requireExisting = { notConfigured: 'set it up first' };
+
+  test('enable on a missing config replies notConfigured and never creates a row', async () => {
+    const r = makeRepo(null);
+    const { enable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      requireExisting,
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await enable(asInteraction(interaction), 'g1');
+
+    expect(r.stored).toBeNull();
+    expect(r.saveCount).toBe(0);
+    expect(replies.at(-1)?.content).toContain('set it up first');
+  });
+
+  test('disable on a missing config replies notConfigured (not alreadyDisabled)', async () => {
+    const r = makeRepo(null);
+    const { disable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      requireExisting,
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await disable(asInteraction(interaction), 'g1');
+
+    expect(r.saveCount).toBe(0);
+    expect(replies.at(-1)?.content).toContain('set it up first');
+  });
+
+  test('enable on an existing config toggles normally', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: false });
+    const { enable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      requireExisting,
+    });
+    const { interaction, replies } = makeInteraction();
+
+    await enable(asInteraction(interaction), 'g1');
+
+    expect(r.stored?.enabled).toBe(true);
+    expect(replies.at(-1)?.content).toBe('turned on');
+  });
+});
+
+describe('createToggleHandler — onEnable', () => {
+  test('mutates the config before save when enabling', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: false });
+    const { enable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      onEnable: config => {
+        if (!config.steps || config.steps.length === 0) config.steps = ['seeded'];
+      },
+    });
+    const { interaction } = makeInteraction();
+
+    await enable(asInteraction(interaction), 'g1');
+
+    expect(r.stored?.enabled).toBe(true);
+    expect(r.stored?.steps).toEqual(['seeded']);
+  });
+
+  test('does not run onEnable on disable', async () => {
+    const r = makeRepo({ guildId: 'g1', enabled: true });
+    let onEnableCalls = 0;
+    const { disable } = createToggleHandler<FakeConfig>({
+      repo: asRepo(r.repo),
+      field: 'enabled',
+      messages,
+      onEnable: () => {
+        onEnableCalls += 1;
+      },
+    });
+    const { interaction } = makeInteraction();
+
+    await disable(asInteraction(interaction), 'g1');
+
+    expect(onEnableCalls).toBe(0);
+    expect(r.stored?.enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Unification #7 (cont.) — `createToggleHandler` require-existing mode

Internal refactor, **no behavior change**. Extends the v3.11.0 toggle helper so the require-existing ticket toggles can fold onto it (the spine they hand-rolled is what `createToggleHandler` exists to absorb).

### What changed
- **`createToggleHandler`** gains two options:
  - `requireExisting: { notConfigured }` — the config row must already exist; enable/disable reply `notConfigured` instead of creating it (enable) or treating a missing row as already-off (disable).
  - `onEnable(config)` — mutate the config when enabling, after the flag is set and before save (e.g. seed dependent defaults).
- **Folded ticket workflow + smart-routing** enable/disable handlers:
  - routing → `requireExisting` + `canEnable` (requires workflow) + `onToggled` (`resetRoundRobin` on disable).
  - workflow → `requireExisting` + `onEnable` (seeds `DEFAULT_TICKET_STATUSES`).
  - `guardFeatureAccess` stays in thin wrappers (the helper isn't responsible for permission gating).

### Left hand-written
- **Ticket SLA** — its enable reads command options (`target-minutes`, `breach-channel`) and formats conditional replies via `formatLang`. That's a config-setter, not a pure toggle.
- **Bait toggle/dmnotify/escalation** — boolean-param shape / dispatcher-prefetched config / embed reply.

### Verification
- Behavior-preserving: same reply strings, idempotent checks, side-effect order (`resetRoundRobin` after save / before reply), and log strings (templated to match the originals). Existing find-or-create consumers (xp/event/onboarding) are unaffected (new options are optional).
- `bun run build` clean · `bun run check` (biome) clean · `bun test` — 1364 pass, 0 fail (**+5** new requireExisting/onEnable tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
