### PR TITLE
feat: awaitSelectMenuChoice select-menu helper (proof-of-fit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2026-06-21
+
+New shared interaction primitive (unification — select-menu helper).
+
+### Added
+
+- `awaitSelectMenuChoice(interaction, response, { userId, customId, timeout? })`
+  (`utils/interactions/selectMenuHelper.ts`) — awaits a single string-select
+  choice, returning the interaction or `null` on timeout (clearing the menu with
+  the standard timeout message). New `TIMEOUTS.SELECT_MENU` (30s). +3 unit tests.
+
+### Changed
+
+- `memory/channelPicker` migrated onto it as proof-of-fit (drops the hand-rolled
+  `awaitMessageComponent` + try/catch + hardcoded `30000`). The other ~4
+  await-one sites (memorySetup, botSetup/systemFlows, botReset, automod/backup)
+  are the documented follow-up; stateful multi-step flows keep the event-based
+  collectors in `utils/collectors.ts`.
+
 ## [3.11.3] - 2026-06-21
 
 Internal refactor (unification #7 — toggle require-existing mode) — no behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.11.3",
+  "version": "3.12.0",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/memory/channelPicker.ts
+++ b/src/commands/handlers/memory/channelPicker.ts
@@ -1,6 +1,6 @@
 import { ActionRowBuilder, type ChatInputCommandInteraction, MessageFlags, StringSelectMenuBuilder } from 'discord.js';
 import { MemoryConfig } from '../../../typeorm/entities/memory';
-import { E, lang, replyEphemeralError } from '../../../utils';
+import { awaitSelectMenuChoice, E, lang, replyEphemeralError } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 
 const tl = lang.memory;
@@ -43,28 +43,16 @@ export async function resolveMemoryConfig(
     flags: [MessageFlags.Ephemeral],
   });
 
-  try {
-    const i = await response.awaitMessageComponent({
-      filter: i => i.user.id === interaction.user.id && i.customId === 'memory_channel_picker',
-      time: 30000,
-    });
+  const choice = await awaitSelectMenuChoice(interaction, response, {
+    userId: interaction.user.id,
+    customId: 'memory_channel_picker',
+  });
+  if (!choice) return null;
 
-    if (i.isStringSelectMenu()) {
-      const selectedId = Number.parseInt(i.values[0], 10);
-      const config = configs.find(c => c.id === selectedId);
-
-      await i.update({ content: `${E.loading} Processing...`, components: [] });
-
-      return config || null;
-    }
-  } catch {
-    await interaction.editReply({
-      content: lang.errors.timeout,
-      components: [],
-    });
-  }
-
-  return null;
+  const selectedId = Number.parseInt(choice.values[0], 10);
+  const config = configs.find(c => c.id === selectedId);
+  await choice.update({ content: `${E.loading} Processing...`, components: [] });
+  return config || null;
 }
 
 export async function resolveConfigFromThread(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -220,6 +220,8 @@ export const TIMEOUTS = {
   MODAL: 300_000,
   /** Confirm/cancel button timeout: 30 seconds */
   CONFIRMATION: 30_000,
+  /** Single select-menu choice timeout: 30 seconds */
+  SELECT_MENU: 30_000,
   /** General component collection timeout: 60 seconds */
   COMPONENT: 60_000,
   /** Long-lived dashboards/wizards: 5 minutes */

--- a/src/utils/interactions/index.ts
+++ b/src/utils/interactions/index.ts
@@ -17,6 +17,7 @@ export {
   showAndAwaitModal,
 } from './modalHelper';
 export { type EphemeralErrorOptions, replyEphemeralError } from './replyHelper';
+export { awaitSelectMenuChoice, type SelectMenuChoiceOptions } from './selectMenuHelper';
 export {
   createToggleHandler,
   type ToggleHandlerOptions,

--- a/src/utils/interactions/selectMenuHelper.ts
+++ b/src/utils/interactions/selectMenuHelper.ts
@@ -1,0 +1,49 @@
+/**
+ * Await a single string-select choice from an already-sent ephemeral message.
+ *
+ * Collapses the repeated `response.awaitMessageComponent({ filter, time })`
+ * plus the surrounding try/catch that several handlers hand-roll for a
+ * one-shot picker. Returns the select interaction (the caller reads `.values`
+ * and issues its own `.update`), or `null` when the user makes no choice before
+ * the timeout — in which case the original reply is edited with the standard
+ * timeout message.
+ *
+ * For stateful multi-step component flows (live-updating menus, confirm chains)
+ * use the event-based collectors in `utils/collectors.ts` instead — this is the
+ * one-and-done case only.
+ */
+import type {
+  ChatInputCommandInteraction,
+  InteractionResponse,
+  Message,
+  StringSelectMenuInteraction,
+} from 'discord.js';
+import { lang } from '../../lang';
+import { TIMEOUTS } from '../constants';
+
+export interface SelectMenuChoiceOptions {
+  /** Only this user may resolve the menu. */
+  userId: string;
+  /** The select menu's customId to filter on. */
+  customId: string;
+  /** Await timeout in ms. Defaults to {@link TIMEOUTS.SELECT_MENU}. */
+  timeout?: number;
+}
+
+export async function awaitSelectMenuChoice(
+  interaction: ChatInputCommandInteraction,
+  response: Message | InteractionResponse,
+  { userId, customId, timeout = TIMEOUTS.SELECT_MENU }: SelectMenuChoiceOptions,
+): Promise<StringSelectMenuInteraction | null> {
+  try {
+    const picked = await response.awaitMessageComponent({
+      filter: i => i.user.id === userId && i.customId === customId,
+      time: timeout,
+    });
+    return picked.isStringSelectMenu() ? picked : null;
+  } catch {
+    // Timed out (or the interaction expired). Best-effort clear the menu.
+    await interaction.editReply({ content: lang.errors.timeout, components: [] }).catch(() => null);
+    return null;
+  }
+}

--- a/tests/unit/utils/interactions/selectMenuHelper.test.ts
+++ b/tests/unit/utils/interactions/selectMenuHelper.test.ts
@@ -1,0 +1,66 @@
+/**
+ * awaitSelectMenuChoice unit tests.
+ *
+ * Drives the helper with a fake response whose awaitMessageComponent resolves
+ * (a select / a non-select) or rejects (timeout), and a fake interaction that
+ * records editReply calls.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { awaitSelectMenuChoice } from '../../../../src/utils/interactions/selectMenuHelper';
+
+function makeResponse(behavior: { resolve?: unknown; reject?: boolean }) {
+  return {
+    awaitMessageComponent: async () => {
+      if (behavior.reject) throw new Error('timeout');
+      return behavior.resolve;
+    },
+  };
+}
+
+function makeInteraction() {
+  const edits: Array<{ content?: string; components?: unknown[] }> = [];
+  return {
+    interaction: {
+      editReply: async (o: { content?: string; components?: unknown[] }) => {
+        edits.push(o);
+      },
+    },
+    edits,
+  };
+}
+
+const opts = { userId: 'u1', customId: 'pick' };
+// biome-ignore lint/suspicious/noExplicitAny: narrow interaction/response test doubles
+const call = (interaction: unknown, response: unknown) => awaitSelectMenuChoice(interaction as any, response as any, opts);
+
+describe('awaitSelectMenuChoice', () => {
+  test('returns the select interaction when the user makes a choice', async () => {
+    const picked = { isStringSelectMenu: () => true, values: ['5'] };
+    const { interaction, edits } = makeInteraction();
+
+    const result = await call(interaction, makeResponse({ resolve: picked }));
+
+    expect(result).toBe(picked as never);
+    expect(result?.values).toEqual(['5']);
+    expect(edits).toHaveLength(0);
+  });
+
+  test('returns null and clears the menu with the timeout message on timeout', async () => {
+    const { interaction, edits } = makeInteraction();
+
+    const result = await call(interaction, makeResponse({ reject: true }));
+
+    expect(result).toBeNull();
+    expect(edits).toHaveLength(1);
+    expect(edits[0].components).toEqual([]);
+  });
+
+  test('returns null for a non-select component', async () => {
+    const { interaction } = makeInteraction();
+
+    const result = await call(interaction, makeResponse({ resolve: { isStringSelectMenu: () => false } }));
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Unification — `awaitSelectMenuChoice` (select-menu helper, proof-of-fit)

Adds a shared primitive for the one-shot select-menu pattern several handlers hand-roll, and migrates one handler as proof-of-fit. **Focused scope** — the broader migration is deferred (see below).

### What changed
- **New `src/utils/interactions/selectMenuHelper.ts`**: `awaitSelectMenuChoice(interaction, response, { userId, customId, timeout? })` — awaits a single string-select choice, returns the select interaction (the caller reads `.values` and issues its own `.update`), or `null` when the user makes no choice before the timeout (clearing the menu with the standard timeout message). New `TIMEOUTS.SELECT_MENU` (30s). **+3 unit tests**.
- **`memory/channelPicker`** migrated as proof-of-fit: drops the hand-rolled `awaitMessageComponent` + try/catch and the hardcoded `30000` (now the default constant).

### Deliberately deferred / out of scope
- The other ~4 await-one sites — `memorySetup` (a nested select→confirm flow), `botSetup/systemFlows`, `botReset`, `automod/backup`. These are the documented follow-up.
- **Stateful multi-step component flows** (live-updating menus, confirm chains in `memory/delete`, `update`, `tags`, `tagSelection`) stay on the event-based collectors in `utils/collectors.ts` — they're a different shape and the helper's doc comment says so.

### Verification
- Behavior-preserving on the happy path; the timeout cleanup now defensively swallows a secondary `editReply` failure (robustness, not a regression).
- `bun run build` clean · `bun run check` (biome) clean · `bun test` — 1367 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable select menu interaction helper enabling consistent single-choice selection behavior across the application

* **Improvements**
  * Refactored channel picker to leverage the new shared interaction patterns for improved consistency
  * Enhanced select menu timeout configuration and handling
  * Expanded unit test suite for interaction utilities and select menu functionality
  * General code refactoring and maintenance improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->