### PR TITLE
fix: v3.13.1 — ticket/application close button no longer hangs

### DIFF
--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.13.0",
+  "botVersion": "3.13.1",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/events/application/close.ts
+++ b/src/events/application/close.ts
@@ -10,7 +10,7 @@ import {
 import { Application } from '../../typeorm/entities/application/Application';
 import { ArchivedApplicationConfig } from '../../typeorm/entities/application/ArchivedApplicationConfig';
 import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../../utils';
-import { archiveAndCloseApplication } from '../../utils/application/closeWorkflow';
+import { type ArchiveApplicationResult, archiveAndCloseApplication } from '../../utils/application/closeWorkflow';
 import { lazyRepo } from '../../utils/database/lazyRepo';
 
 const tl = lang.application.close;
@@ -27,13 +27,19 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
   });
   const application = await applicationRepo.findOneBy({ guildId, channelId });
 
+  // Every early return below runs AFTER confirmCloseApplication already showed
+  // "Closing application..." (interaction.update). A bare return freezes that
+  // message forever (the close-button hang). Each guard surfaces an ephemeral
+  // followUp before bailing — mirrors the ticket close flow.
   if (!archivedConfig) {
     enhancedLogger.warn(lang.application.applicationConfigNotFound, LogCategory.SYSTEM, { guildId });
+    await replyEphemeralError(interaction, tl.notConfigured);
     return;
   }
 
   if (!application) {
     enhancedLogger.error(lang.general.fatalError, undefined, LogCategory.SYSTEM, { guildId, channelId });
+    await replyEphemeralError(interaction, tl.notFound);
     return;
   }
 
@@ -43,12 +49,29 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
       guildId,
       channelId,
     });
+    await replyEphemeralError(interaction, tl.alreadyClosed);
     return;
   }
 
   await applicationRepo.update({ id: application.id, guildId }, { status: 'closed' });
 
-  const result = await archiveAndCloseApplication(client, application, guildId, channel, archivedConfig.channelId);
+  let result: ArchiveApplicationResult;
+  try {
+    result = await archiveAndCloseApplication(client, application, guildId, channel, archivedConfig.channelId);
+  } catch (error) {
+    // Unexpected throw escaped the workflow. Status was flipped to 'closed'
+    // above but the channel still exists — revert (otherwise the dup-close guard
+    // strands it) and tell the user instead of leaving "Closing application...".
+    await applicationRepo.update({ id: application.id, guildId }, { status: application.status });
+    enhancedLogger.error(
+      'Application close threw unexpectedly — status reverted, channel preserved for retry',
+      error instanceof Error ? error : undefined,
+      LogCategory.ERROR,
+      { guildId, channelId, applicationId: application.id },
+    );
+    await replyEphemeralError(interaction, tl.transcriptCreate.error).catch(() => {});
+    return;
+  }
 
   if (!result.archived) {
     // Close did not complete (transcript fetch or forum post failed). The
@@ -65,11 +88,9 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
         transcriptFailed: result.transcriptFailed ?? false,
       },
     );
-    const notify =
-      interaction.replied || interaction.deferred
-        ? replyEphemeralError(interaction, tl.transcriptCreate.error)
-        : replyEphemeralError(interaction, tl.transcriptCreate.error);
-    await notify.catch((err: unknown) => {
+    // replyEphemeralError picks reply/editReply/followUp from the interaction
+    // state internally, so no branch on replied/deferred is needed.
+    await replyEphemeralError(interaction, tl.transcriptCreate.error).catch((err: unknown) => {
       enhancedLogger.error(
         'Failed to deliver application-close failure notice to the user',
         err instanceof Error ? err : undefined,

--- a/src/events/interactionRouter.ts
+++ b/src/events/interactionRouter.ts
@@ -14,6 +14,7 @@
  */
 
 import type { Client, Interaction } from 'discord.js';
+import { lang, logHandlerError, replyEphemeralError } from '../utils';
 import { applicationFieldsInteraction } from './applicationFieldsInteraction';
 import { handleApplicationInteraction } from './applicationInteraction';
 import { handleTicketInteraction } from './ticketInteraction';
@@ -35,12 +36,27 @@ const FEATURE_DISPATCHERS: FeatureDispatcher[] = [
   handleTicketInteraction,
 ];
 
-export const routeInteraction = async (client: Client, interaction: Interaction): Promise<void> => {
+export const routeInteraction = async (
+  client: Client,
+  interaction: Interaction,
+  dispatchers: FeatureDispatcher[] = FEATURE_DISPATCHERS,
+): Promise<void> => {
   if (!interaction.isButton() && !interaction.isStringSelectMenu() && !interaction.isModalSubmit()) {
     return;
   }
 
-  for (const dispatch of FEATURE_DISPATCHERS) {
-    if (await dispatch(client, interaction)) return;
+  try {
+    for (const dispatch of dispatchers) {
+      if (await dispatch(client, interaction)) return;
+    }
+  } catch (error) {
+    // A feature handler threw mid-dispatch. If it had already acknowledged the
+    // interaction (reply/update/defer), Discord shows no "interaction failed" —
+    // the user is stranded on a stale loading state forever. Convert any such
+    // post-ack throw into a visible ephemeral error so a button can never hang.
+    // (Site-level guards still handle the non-throwing early returns; this is
+    // the defense-in-depth net for every feature, not a substitute for them.)
+    logHandlerError('interaction-router', error, { customId: interaction.customId });
+    await replyEphemeralError(interaction, lang.general.fatalError, { bugReport: true });
   }
 };

--- a/src/events/ticket/close.ts
+++ b/src/events/ticket/close.ts
@@ -11,27 +11,58 @@ import { ArchivedTicketConfig } from '../../typeorm/entities/ticket/ArchivedTick
 import { Ticket } from '../../typeorm/entities/ticket/Ticket';
 import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../../utils';
 import { lazyRepo } from '../../utils/database/lazyRepo';
-import { archiveAndCloseTicket } from '../../utils/ticket/closeWorkflow';
+import { type ArchiveTicketResult, archiveAndCloseTicket } from '../../utils/ticket/closeWorkflow';
 
 const tl = lang.ticket.close;
 const ticketRepo = lazyRepo(Ticket);
 const archivedTicketConfigRepo = lazyRepo(ArchivedTicketConfig);
 
-export const ticketCloseEvent = async (client: Client, interaction: ButtonInteraction) => {
+/**
+ * Injectable seam for {@link ticketCloseEvent}. Production callers omit it (the
+ * defaults bind the real repos + workflow). Tests pass fakes directly rather
+ * than relying on `mock.module()`, which bun applies inconsistently across a
+ * full-suite run — the same deterministic-injection pattern used by
+ * `archiveAndCloseTicket` in closeWorkflow.ts.
+ */
+export interface TicketCloseDeps {
+  ticketRepo: typeof ticketRepo;
+  archivedTicketConfigRepo: typeof archivedTicketConfigRepo;
+  archiveAndCloseTicket: typeof archiveAndCloseTicket;
+  replyEphemeralError: typeof replyEphemeralError;
+}
+
+const defaultTicketCloseDeps: TicketCloseDeps = {
+  ticketRepo,
+  archivedTicketConfigRepo,
+  archiveAndCloseTicket,
+  replyEphemeralError,
+};
+
+export const ticketCloseEvent = async (
+  client: Client,
+  interaction: ButtonInteraction,
+  deps: TicketCloseDeps = defaultTicketCloseDeps,
+) => {
   if (!interaction.guildId) return;
   const guildId = interaction.guildId;
   const channel = interaction.channel as GuildTextBasedChannel;
   const channelId = interaction.channelId || '';
-  const archivedConfig = await archivedTicketConfigRepo.findOneBy({ guildId });
-  const ticket = await ticketRepo.findOneBy({ guildId, channelId });
+  const archivedConfig = await deps.archivedTicketConfigRepo.findOneBy({ guildId });
+  const ticket = await deps.ticketRepo.findOneBy({ guildId, channelId });
 
+  // Every early return below runs AFTER confirmClose already showed the user
+  // "Closing ticket..." (interaction.update). A bare return would freeze that
+  // message forever — the reported "close button hangs, ticket never closes".
+  // So each guard surfaces an ephemeral followUp before bailing.
   if (!archivedConfig) {
     enhancedLogger.warn(lang.ticket.archiveTicketConfigNotFound, LogCategory.SYSTEM, { guildId });
+    await deps.replyEphemeralError(interaction, tl.notConfigured);
     return;
   }
 
   if (!ticket) {
     enhancedLogger.error(lang.general.fatalError, undefined, LogCategory.SYSTEM, { guildId, channelId });
+    await deps.replyEphemeralError(interaction, tl.notFound);
     return;
   }
 
@@ -41,20 +72,40 @@ export const ticketCloseEvent = async (client: Client, interaction: ButtonIntera
       guildId,
       channelId,
     });
+    await deps.replyEphemeralError(interaction, tl.alreadyClosed);
     return;
   }
 
   // Immediately mark as closed to prevent concurrent close attempts
-  await ticketRepo.update({ id: ticket.id, guildId }, { status: 'closed' });
+  await deps.ticketRepo.update({ id: ticket.id, guildId }, { status: 'closed' });
 
-  const result = await archiveAndCloseTicket(client, ticket, guildId, channel, archivedConfig.channelId);
+  let result: ArchiveTicketResult;
+  try {
+    result = await deps.archiveAndCloseTicket(client, ticket, guildId, channel, archivedConfig.channelId);
+  } catch (error) {
+    // An unexpected throw escaped the workflow (e.g. a transient DB error while
+    // resolving a custom ticket type — closeWorkflow's metadata region isn't
+    // inside its try blocks). The ticket was flipped to 'closed' above but the
+    // channel still exists, so revert the status (otherwise the dup-close guard
+    // strands it permanently) and tell the user instead of leaving them on
+    // "Closing ticket...".
+    await deps.ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+    enhancedLogger.error(
+      'Ticket close threw unexpectedly — status reverted, channel preserved for retry',
+      error instanceof Error ? error : undefined,
+      LogCategory.ERROR,
+      { guildId, channelId, ticketId: ticket.id },
+    );
+    await deps.replyEphemeralError(interaction, tl.transcriptCreate.error).catch(() => {});
+    return;
+  }
 
   if (!result.archived) {
     // Close did not complete (transcript fetch or forum post failed). The
     // workflow deliberately preserved the channel, so revert the status —
     // otherwise the ticket is stranded 'closed' with a live channel and the
     // dup-close guard blocks any retry.
-    await ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+    await deps.ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
     enhancedLogger.warn(
       'Ticket close reverted — archive failed, channel + ticket preserved for retry',
       LogCategory.SYSTEM,
@@ -65,11 +116,9 @@ export const ticketCloseEvent = async (client: Client, interaction: ButtonIntera
         transcriptFailed: result.transcriptFailed ?? false,
       },
     );
-    const notify =
-      interaction.replied || interaction.deferred
-        ? replyEphemeralError(interaction, tl.transcriptCreate.error)
-        : replyEphemeralError(interaction, tl.transcriptCreate.error);
-    await notify.catch((err: unknown) => {
+    // replyEphemeralError picks reply/editReply/followUp from the interaction
+    // state internally, so no branch on replied/deferred is needed.
+    await deps.replyEphemeralError(interaction, tl.transcriptCreate.error).catch((err: unknown) => {
       enhancedLogger.error(
         'Failed to deliver ticket-close failure notice to the user',
         err instanceof Error ? err : undefined,

--- a/src/lang/en/application.json
+++ b/src/lang/en/application.json
@@ -31,6 +31,9 @@
     "cancel": "Application close cancelled",
     "cancelL": "Cancel",
     "byUser": "User has initiated the application to close...",
+    "notConfigured": "This application can't be closed yet — no archive forum is configured. An admin needs to run application setup and choose an archive forum.",
+    "notFound": "This application could not be found — it may have already been closed.",
+    "alreadyClosed": "This application is already being closed.",
     "transcriptCreate": {
       "success": "Transcript successfully sent to channel and deleted from memory!",
       "error": "Error making transcript file!",

--- a/src/lang/en/ticket.json
+++ b/src/lang/en/ticket.json
@@ -18,6 +18,9 @@
     "closing": "Closing ticket...",
     "cancel": "Ticket close cancelled",
     "byUser": "User has initiated the ticket to close...",
+    "notConfigured": "This ticket can't be closed yet — no archive forum is configured. An admin needs to run ticket setup and choose an archive forum.",
+    "notFound": "This ticket could not be found — it may have already been closed.",
+    "alreadyClosed": "This ticket is already being closed.",
     "transcriptCreate": {
       "success": "Transcript successfully sent to channel and deleted from memory!",
       "error": "Error making transcript file!",

--- a/src/lang/types.ts
+++ b/src/lang/types.ts
@@ -449,6 +449,9 @@ export interface LangTicket {
     closing: string;
     cancel: string;
     byUser: string;
+    notConfigured: string;
+    notFound: string;
+    alreadyClosed: string;
     transcriptCreate: {
       success: string;
       error: string;
@@ -769,6 +772,9 @@ export interface LangApplication {
     cancel: string;
     cancelL: string;
     byUser: string;
+    notConfigured: string;
+    notFound: string;
+    alreadyClosed: string;
     transcriptCreate: {
       success: string;
       error: string;

--- a/tests/unit/events/interactionRouter.test.ts
+++ b/tests/unit/events/interactionRouter.test.ts
@@ -1,0 +1,83 @@
+/**
+ * routeInteraction safety-net tests.
+ *
+ * The dispatch chain acknowledges interactions (reply/update/defer) inside the
+ * feature handlers, so a throw AFTER acknowledgement used to become an
+ * unhandled rejection — Discord shows no "interaction failed" and the user is
+ * stranded on a stale loading state forever. The router now wraps the dispatch
+ * loop in try/catch and surfaces an ephemeral error. These tests lock that in,
+ * plus the existing short-circuit / non-component contract.
+ *
+ * The dispatcher list is injected via routeInteraction's optional 3rd arg so we
+ * can drive a throwing/short-circuiting dispatcher deterministically.
+ */
+
+import { describe, expect, jest, test } from 'bun:test';
+import { routeInteraction } from '../../../src/events/interactionRouter';
+
+function makeButton() {
+  return {
+    customId: 'some_button',
+    replied: true,
+    deferred: false,
+    isButton: () => true,
+    isStringSelectMenu: () => false,
+    isModalSubmit: () => false,
+    reply: jest.fn().mockResolvedValue(undefined),
+    followUp: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+  } as never;
+}
+
+const client = {} as never;
+
+describe('routeInteraction', () => {
+  test('a dispatcher that throws after ack does NOT reject and surfaces an ephemeral error', async () => {
+    const interaction = makeButton();
+    const throwing = jest.fn(async () => {
+      throw new Error('handler blew up after interaction.update');
+    });
+
+    // Must not reject — an unhandled rejection here is the permanent-hang bug.
+    await expect(routeInteraction(client, interaction, [throwing as never])).resolves.toBeUndefined();
+
+    expect(throwing).toHaveBeenCalledTimes(1);
+    // interaction.replied === true → replyEphemeralError follows up ephemerally.
+    expect((interaction as unknown as { followUp: ReturnType<typeof jest.fn> }).followUp).toHaveBeenCalledTimes(1);
+  });
+
+  test('first dispatcher returning true short-circuits the rest', async () => {
+    const interaction = makeButton();
+    const first = jest.fn(async () => true);
+    const second = jest.fn(async () => true);
+
+    await routeInteraction(client, interaction, [first as never, second as never]);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  test('falls through every dispatcher when none claims the interaction', async () => {
+    const interaction = makeButton();
+    const a = jest.fn(async () => false);
+    const b = jest.fn(async () => false);
+
+    await routeInteraction(client, interaction, [a as never, b as never]);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-component interactions are ignored (no dispatchers run)', async () => {
+    const autocomplete = {
+      isButton: () => false,
+      isStringSelectMenu: () => false,
+      isModalSubmit: () => false,
+    } as never;
+    const dispatcher = jest.fn(async () => true);
+
+    await routeInteraction(client, autocomplete, [dispatcher as never]);
+
+    expect(dispatcher).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/events/ticket/close.test.ts
+++ b/tests/unit/events/ticket/close.test.ts
@@ -1,0 +1,128 @@
+/**
+ * ticketCloseEvent regression tests — the "close button hangs / ticket never
+ * closes" hotfix.
+ *
+ * confirmClose acknowledges the click with interaction.update({ content:
+ * "Closing ticket..." }) BEFORE calling ticketCloseEvent. Historically every
+ * early return in ticketCloseEvent (no archive config / no ticket / already
+ * closed) was a bare `return`, leaving that ephemeral message frozen forever —
+ * the reported permanent hang. These tests lock in that EVERY exit now either
+ * deletes the channel (happy path) or surfaces user feedback, and that an
+ * unexpected throw from the workflow reverts the status instead of stranding
+ * the ticket 'closed' with a live channel.
+ *
+ * All dependencies are injected via the function's `deps` argument (the same
+ * deterministic seam closeWorkflow.ts uses) — no mock.module(), which bun
+ * applies inconsistently across a full-suite run.
+ */
+
+import { describe, expect, jest, test } from 'bun:test';
+import ticketLang from '../../../../src/lang/en/ticket.json';
+import { type TicketCloseDeps, ticketCloseEvent } from '../../../../src/events/ticket/close';
+
+const tl = ticketLang.close;
+
+function makeDeps(overrides: Partial<Record<keyof TicketCloseDeps, unknown>> = {}) {
+  const archivedTicketConfigRepo = { findOneBy: jest.fn().mockResolvedValue({ channelId: 'forum-1' }) };
+  const ticketRepo = {
+    findOneBy: jest.fn().mockResolvedValue({ id: 7, guildId: 'guild1', channelId: 'chan1', status: 'opened' }),
+    update: jest.fn().mockResolvedValue({ affected: 1 }),
+  };
+  const archiveAndCloseTicket = jest.fn().mockResolvedValue({ success: true, archived: true });
+  const replyEphemeralError = jest.fn().mockResolvedValue(undefined);
+  return {
+    deps: { archivedTicketConfigRepo, ticketRepo, archiveAndCloseTicket, replyEphemeralError, ...overrides } as unknown as TicketCloseDeps,
+    archivedTicketConfigRepo,
+    ticketRepo,
+    archiveAndCloseTicket,
+    replyEphemeralError,
+  };
+}
+
+function makeInteraction() {
+  return {
+    guildId: 'guild1',
+    channelId: 'chan1',
+    channel: { id: 'chan1' },
+    user: { id: 'user1' },
+    replied: true,
+    deferred: false,
+  } as never;
+}
+
+const client = {} as never;
+
+describe('ticketCloseEvent', () => {
+  test('no ArchivedTicketConfig → surfaces feedback, never silently returns, never closes', async () => {
+    const { deps, archivedTicketConfigRepo, ticketRepo, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    archivedTicketConfigRepo.findOneBy.mockResolvedValue(null);
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledTimes(1);
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.notConfigured);
+    // Guard must short-circuit BEFORE marking closed or archiving.
+    expect(ticketRepo.update).not.toHaveBeenCalled();
+    expect(archiveAndCloseTicket).not.toHaveBeenCalled();
+  });
+
+  test('no Ticket row → surfaces feedback and does not proceed', async () => {
+    const { deps, ticketRepo, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    ticketRepo.findOneBy.mockResolvedValue(null);
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledTimes(1);
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.notFound);
+    expect(ticketRepo.update).not.toHaveBeenCalled();
+    expect(archiveAndCloseTicket).not.toHaveBeenCalled();
+  });
+
+  test('ticket already closed → surfaces feedback, no duplicate archive', async () => {
+    const { deps, ticketRepo, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    ticketRepo.findOneBy.mockResolvedValue({ id: 7, guildId: 'guild1', channelId: 'chan1', status: 'closed' });
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledTimes(1);
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.alreadyClosed);
+    expect(ticketRepo.update).not.toHaveBeenCalled();
+    expect(archiveAndCloseTicket).not.toHaveBeenCalled();
+  });
+
+  test('workflow throws → reverts status to original and notifies (no stranded close)', async () => {
+    const { deps, ticketRepo, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    archiveAndCloseTicket.mockRejectedValue(new Error('transient DB error'));
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    // First update flips to 'closed', second reverts to the original 'opened'.
+    expect(ticketRepo.update).toHaveBeenCalledTimes(2);
+    expect(ticketRepo.update).toHaveBeenNthCalledWith(1, { id: 7, guildId: 'guild1' }, { status: 'closed' });
+    expect(ticketRepo.update).toHaveBeenNthCalledWith(2, { id: 7, guildId: 'guild1' }, { status: 'opened' });
+    expect(replyEphemeralError).toHaveBeenCalledTimes(1);
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.transcriptCreate.error);
+  });
+
+  test('archive returns archived:false → reverts status and notifies', async () => {
+    const { deps, ticketRepo, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    archiveAndCloseTicket.mockResolvedValue({ success: false, archived: false, transcriptFailed: true });
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(ticketRepo.update).toHaveBeenCalledTimes(2);
+    expect(ticketRepo.update).toHaveBeenNthCalledWith(2, { id: 7, guildId: 'guild1' }, { status: 'opened' });
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.transcriptCreate.error);
+  });
+
+  test('happy path → marks closed once, archives, no error feedback', async () => {
+    const { deps, ticketRepo, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(archiveAndCloseTicket).toHaveBeenCalledTimes(1);
+    expect(ticketRepo.update).toHaveBeenCalledTimes(1);
+    expect(ticketRepo.update).toHaveBeenCalledWith({ id: 7, guildId: 'guild1' }, { status: 'closed' });
+    expect(replyEphemeralError).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/events/ticketInteraction.test.ts
+++ b/tests/unit/events/ticketInteraction.test.ts
@@ -38,15 +38,16 @@ import { Repository } from "typeorm";
 // Sub-event handlers — replaced before the module under test is evaluated
 // ---------------------------------------------------------------------------
 
-const mockTicketCloseEvent = jest.fn().mockResolvedValue(undefined);
 const mockTicketAdminOnlyEvent = jest.fn().mockResolvedValue(undefined);
 const mockTypeAddModalHandler = jest.fn().mockResolvedValue(undefined);
 const mockEmailImportModalHandler = jest.fn().mockResolvedValue(undefined);
 
-mock.module("../../../src/events/ticket/close", () => ({
-  ticketCloseEvent: (...args: unknown[]) => mockTicketCloseEvent(...args),
-}));
-
+// NOTE: the close module is intentionally NOT mocked. mock.module() is
+// process-global in bun, so faking ticketCloseEvent here leaked into
+// events/ticket/close.test.ts (which tests the real handler via its injected
+// deps seam) and broke it. confirmClose/closeButton/cancelClose run for real
+// here; routing into ticketCloseEvent is verified via the DB lookup it performs
+// (findOneBySpy) rather than a spy on the function itself.
 mock.module("../../../src/events/ticket/adminOnly", () => ({
   ticketAdminOnlyEvent: (...args: unknown[]) =>
     mockTicketAdminOnlyEvent(...args),
@@ -311,12 +312,14 @@ describe("handleTicketInteraction", () => {
       );
     });
 
-    test("should not call ticketCloseEvent on the initial close_ticket button", async () => {
+    test("should not run the close workflow on the initial close_ticket button", async () => {
       const interaction = makeButtonInteraction("close_ticket");
 
       await handleTicketInteraction(mockClient, interaction as never);
 
-      expect(mockTicketCloseEvent).not.toHaveBeenCalled();
+      // closeButton only shows the confirm prompt — it must not touch the DB
+      // (ticketCloseEvent's first action is the archivedConfig/ticket lookup).
+      expect(findOneBySpy).not.toHaveBeenCalled();
     });
   });
 
@@ -332,10 +335,10 @@ describe("handleTicketInteraction", () => {
       expect(interaction.update).toHaveBeenCalledWith(
         expect.objectContaining({ components: [] }),
       );
-      expect(mockTicketCloseEvent).toHaveBeenCalledWith(
-        mockClient,
-        interaction,
-      );
+      // ticketCloseEvent ran for real — proven by its archivedConfig/ticket
+      // lookup. (No archive config in this test → it surfaces feedback and
+      // returns, which is itself the close-hang regression guard.)
+      expect(findOneBySpy).toHaveBeenCalled();
     });
   });
 
@@ -351,7 +354,8 @@ describe("handleTicketInteraction", () => {
       expect(interaction.update).toHaveBeenCalledWith(
         expect.objectContaining({ components: [] }),
       );
-      expect(mockTicketCloseEvent).not.toHaveBeenCalled();
+      // cancelClose only edits the message — it must not run the close workflow.
+      expect(findOneBySpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Problem
The **Close Ticket** button left Cogworks stuck on \"Closing ticket…\" and the ticket never closed — a permanent hang.

## Root cause (adversarially verified via a multi-agent audit of the close flow)
`ticketCloseEvent` runs three early-return guards (**no archive config** / **no ticket** / **already-closed**) *after* `confirmClose` already acknowledged the click with `interaction.update({ content: "Closing ticket…" })`. Each guard was a bare `return` — no `editReply`/`followUp` — so the ephemeral message froze forever and the channel was never deleted.

The **deterministic, every-close trigger** is the missing-`ArchivedTicketConfig` guard: `/ticket-setup` only creates the archive-config row when an archive **forum** option is supplied. A guild set up with just a channel + category has working Create/Close buttons but **no archive row**, so *every* close hangs. (The v3 `/bot-setup` path always co-creates the row, so those guilds were unaffected — which is why it wasn't universal.)

## Fixes
- **`events/ticket/close.ts`**
  - All three guards now surface an ephemeral `replyEphemeralError` before returning (new lang keys `close.notConfigured` / `notFound` / `alreadyClosed`).
  - Wrap `archiveAndCloseTicket` in try/catch — an unexpected throw (e.g. transient DB error in the workflow's unguarded metadata region) now reverts status + notifies instead of stranding the ticket `closed` with a live channel (which would trip the dup-close guard on every retry).
  - Collapse the dead `replied/deferred` ternary (both branches were identical).
- **`events/application/close.ts`** — identical fixes; it is a verbatim mirror of the same bug.
- **`events/interactionRouter.ts`** — wrap the dispatch loop in try/catch as a defense-in-depth net so *any* post-acknowledgement throw in *any* feature becomes a visible ephemeral error instead of a hang.

## Testability
- `ticketCloseEvent` gains an injectable `deps` seam (mirrors `archiveAndCloseTicket`'s established pattern); `routeInteraction` gains an optional `dispatchers` arg. Both default to production behavior.
- Removed the process-global `mock.module` of the `close` module from `ticketInteraction.test.ts` (it leaked into the new real-handler test, the documented Bun gotcha). Routing is now asserted via the DB-lookup side effect.

## Verification
- `bun run build` (tsc) ✓ · `bun run check` (biome, 523 files) ✓
- `bun test` → **1381 pass / 0 fail** (+10 new tests covering every close exit + the router net)
- Contract drift gate: only `botVersion` 3.13.0 → 3.13.1 changed (commands/features/bait fields identical); regenerated + committed.

## Deferred (follow-ups, not this hotfix)
- `adminOnly.ts` silent `!ticket` return + fire-and-forget edits (same hang class, Admin-Only button).
- `autoClose.ts` keeps the channel + Close button alive after marking `closed` — now surfaces \"already closing\" feedback instead of hanging, but honoring the documented \"close button archives an auto-closed ticket\" promise is a product decision.
- `/ticket-setup` UX: warn (or block) when ticket creation is enabled without an archive forum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved close flows so users now receive clear error messages instead of silent failures.
  * Prevents tickets and applications from getting stuck in a closed/closing state if an unexpected error occurs.
  * Handles duplicate close attempts gracefully with an “already closed” message.

* **Chores**
  * Updated the app and contract version to 3.13.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->