### PR TITLE
chore: v3.13.2 — close-flow follow-ups + changelog drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Contract drift check
         run: bun run check:contract
 
+      - name: Changelog drift check
+        run: bun run check:changelog
+
       - name: Run tests
         run: bun test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.2] - 2026-06-26
+
+Close-flow follow-ups + a release-notes drift guard.
+
+### Fixed
+
+- **Admin Only button** no longer leaves the ticket stuck on "Changing to Admin
+  Only…", and no longer pings a literal "undefined" when no global staff role is
+  set. A missing ticket now surfaces an error, staff-role view removal is awaited
+  (it was fire-and-forget), and the acknowledgement resolves to a clear success
+  or request-sent message.
+- **Close flows** (ticket + application) now tell the user when the transcript
+  was archived but the channel couldn't be deleted (e.g. missing Manage
+  Channels), instead of sitting on "Closing…" forever.
+- **Setup** now warns when a ticket/application creation channel is configured
+  without an archive forum — the exact misconfiguration that makes the Close
+  button fail.
+
+### Added
+
+- CI **changelog drift gate** (`bun run check:changelog`): fails the build when
+  `package.json`'s version doesn't match the top `CHANGELOG.md` entry, so a
+  version bump can never ship stale Discord release notes again.
+
+## [3.13.1] - 2026-06-25
+
+### Fixed
+
+- **Ticket & application Close button no longer hangs.** After confirming a
+  close, three early-return guards (no archive config / no ticket / already
+  closed) returned silently, freezing the "Closing ticket…" message forever and
+  never closing the ticket. They now surface feedback; an unexpected error during
+  archiving reverts the status instead of stranding the ticket as `closed` with a
+  live channel. Added a router-level safety net so any post-acknowledgement throw
+  in any button/select/modal handler becomes a visible error rather than a
+  permanent hang.
+
 ## [3.13.0] - 2026-06-21
 
 Bot→dashboard contract unification (Phase 1 — contract backbone).

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.13.1",
+  "botVersion": "3.13.2",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
     "docs:sync": "bun run scripts/extractCommands.ts",
     "build:contract": "bun run scripts/generateContract.ts",
     "check:contract": "bun run scripts/generateContract.ts && git diff --exit-code contract/cogworks-contract.json",
+    "check:changelog": "bun run scripts/checkChangelog.ts",
     "lint": "biome lint ./src",
     "lint:fix": "biome lint --write ./src",
     "format": "biome format ./src",

--- a/scripts/checkChangelog.ts
+++ b/scripts/checkChangelog.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+/**
+ * Changelog drift gate.
+ *
+ * The deploy workflow's Discord release message posts the TOP `## [x.y.z]`
+ * entry of CHANGELOG.md. `release.sh` bumps package.json but does NOT touch the
+ * changelog, so a forgotten entry silently ships stale release notes (the bot
+ * announced the previous version's notes for v3.13.1). This guard fails CI when
+ * package.json's version doesn't match the top CHANGELOG entry, making that
+ * impossible: a version bump must come with its changelog entry.
+ *
+ * Run: `bun run check:changelog` (wired into CI before tests).
+ */
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { version } from '../package.json';
+
+function main() {
+  const changelog = readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf8');
+  // Mirror deploy.yml's extraction: first `## [x.y.z]` heading.
+  const match = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m);
+  const top = match?.[1];
+
+  if (top !== version) {
+    console.error(
+      `✗ CHANGELOG drift: package.json is ${version} but the top CHANGELOG.md entry is ${top ?? '(none found)'}.`,
+    );
+    console.error(`  Add a "## [${version}] - <date>" section to the top of CHANGELOG.md before releasing,`);
+    console.error('  otherwise the deploy will announce the wrong version to Discord.');
+    process.exit(1);
+  }
+
+  console.log(`✓ CHANGELOG top entry matches package.json version (${version}).`);
+}
+
+main();

--- a/src/commands/handlers/application/applicationSetup.ts
+++ b/src/commands/handlers/application/applicationSetup.ts
@@ -203,7 +203,12 @@ export async function applicationSetupHandler(_client: Client, interaction: Chat
 
     const statusEmbed = buildApplicationStatusEmbed(applicationConfig, archivedApplicationConfig, !!hasAnyOption);
 
+    // Closing an application requires an archive forum; warn when creation is
+    // enabled but the archive is missing (mirrors ticket setup).
+    const closeNeedsArchive = !!applicationConfig?.channelId && !archivedApplicationConfig?.channelId;
+
     await interaction.reply({
+      content: closeNeedsArchive ? tl.closeNeedsArchive : undefined,
       embeds: [statusEmbed],
       flags: [MessageFlags.Ephemeral],
     });

--- a/src/commands/handlers/ticketSetup.ts
+++ b/src/commands/handlers/ticketSetup.ts
@@ -208,7 +208,13 @@ export async function ticketSetupHandler(_client: Client, interaction: ChatInput
 
     const statusEmbed = buildTicketStatusEmbed(ticketConfig, archivedTicketConfig, !!hasAnyOption);
 
+    // Ticket creation works with just a channel, but closing requires an archive
+    // forum (the close flow has nowhere to post the transcript otherwise). Warn
+    // explicitly when creation is enabled but the archive is missing.
+    const closeNeedsArchive = !!ticketConfig?.channelId && !archivedTicketConfig?.channelId;
+
     await interaction.reply({
+      content: closeNeedsArchive ? tl.closeNeedsArchive : undefined,
       embeds: [statusEmbed],
       flags: [MessageFlags.Ephemeral],
     });

--- a/src/events/application/close.ts
+++ b/src/events/application/close.ts
@@ -98,6 +98,15 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
         { guildId, channelId, applicationId: application.id },
       );
     });
+  } else if (result.channelDeleted === false) {
+    // Archived OK, but Discord refused to delete the channel — surface it so the
+    // "Closing application..." ack doesn't sit forever on a live channel.
+    enhancedLogger.warn('Application archived but channel delete failed — notifying user', LogCategory.SYSTEM, {
+      guildId,
+      channelId,
+      applicationId: application.id,
+    });
+    await replyEphemeralError(interaction, tl.archivedChannelRemains, { bugReport: true }).catch(() => {});
   }
 };
 

--- a/src/events/ticket/adminOnly.ts
+++ b/src/events/ticket/adminOnly.ts
@@ -37,11 +37,15 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
   const botConfigRepo = AppDataSource.getRepository(BotConfig);
   const botConfig = await botConfigRepo.findOneBy({ guildId });
   const gsrFlag = botConfig?.enableGlobalStaffRole;
-  const gsr = `${botConfig?.globalStaffRole}\n`;
+  const globalStaffRole = botConfig?.globalStaffRole;
 
   // check if the ticket exists in the database
   if (!ticket) {
-    return enhancedLogger.error(lang.general.fatalError, undefined, LogCategory.COMMAND_EXECUTION);
+    enhancedLogger.error(lang.general.fatalError, undefined, LogCategory.COMMAND_EXECUTION, { guildId, channelId });
+    // confirmAdminOnly already showed "Changing to Admin Only..." — surface the
+    // failure instead of leaving the user on a frozen ack.
+    await replyEphemeralError(interaction, lang.general.fatalError, { bugReport: true });
+    return;
   }
 
   // check if the person hitting the button is the ticket creator
@@ -50,16 +54,22 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
     const ticketConfig = await ticketConfigRepo.findOneBy({ guildId });
     const shouldMentionStaff = ticketConfig?.adminOnlyMentionStaff ?? true;
 
-    // Only mention staff if the setting is enabled and staff role is configured
-    if (gsrFlag && gsr && shouldMentionStaff) {
+    // Only mention staff if the setting is enabled AND a staff role is actually
+    // configured — `globalStaffRole` may be null/empty, and the old
+    // `${botConfig?.globalStaffRole}\n` template was always truthy, so it could
+    // ping a literal "undefined".
+    if (gsrFlag && globalStaffRole && shouldMentionStaff) {
       await channel.send({
-        content: `${gsr}❗Oh, Mods!❗ ${user} ${tl.request}`,
+        content: `${globalStaffRole}\n❗Oh, Mods!❗ ${user} ${tl.request}`,
       });
     } else {
       await channel.send({
         content: `❗Oh, Mods!❗ ${user} ${tl.request}`,
       });
     }
+    // Resolve the "Changing to Admin Only..." ack: the creator is *requesting*
+    // admin-only (staff act on it), not performing it.
+    await interaction.editReply({ content: tl.requestSent }).catch(() => {});
     return;
   }
 
@@ -70,34 +80,47 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
     .andWhere('type = :type', { type: 'staff' })
     .getRawMany();
 
-  // get each staff role and remove them from being able to view the channel
-  savedRoles.forEach(role => {
+  // Remove each staff role's view access. Await sequentially (forEach does NOT
+  // await async callbacks — the old fire-and-forget edits raced and could throw
+  // unhandled) and tolerate per-role failures so one bad role doesn't abort the
+  // rest or strand the interaction.
+  for (const role of savedRoles) {
     const roleId = extractIdFromMention(role.role);
     if (!roleId) {
       enhancedLogger.warn(`Invalid role format: ${role.role}`, LogCategory.COMMAND_EXECUTION);
-      return; // skip this role
+      continue;
     }
+    try {
+      await channel.permissionOverwrites.edit(roleId, { ViewChannel: false });
+    } catch (error) {
+      enhancedLogger.error(
+        'Failed to hide ticket channel from staff role during admin-only',
+        error instanceof Error ? error : undefined,
+        LogCategory.COMMAND_EXECUTION,
+        { guildId, roleId },
+      );
+    }
+  }
 
-    channel.permissionOverwrites.edit(roleId, {
-      ViewChannel: false,
-    });
-  });
-
-  // edit the channel's initial welcome message to not include the admin only button
+  // Strip the Admin Only button from the welcome message, leaving just Close.
   const messageId = ticket.messageId;
-  if (!messageId) return;
-  const msg = channel.messages.fetch(messageId);
-
-  // close ticket button
-  const closeButton = new ActionRowBuilder<ButtonBuilder>().setComponents(
-    new ButtonBuilder().setCustomId('close_ticket').setLabel('Close Ticket').setStyle(ButtonStyle.Danger),
-  );
-
-  // set the components of the welcome message to just have the close button
-  (await msg)?.edit({ components: [closeButton] });
+  if (messageId) {
+    const closeButton = new ActionRowBuilder<ButtonBuilder>().setComponents(
+      new ButtonBuilder().setCustomId('close_ticket').setLabel('Close Ticket').setStyle(ButtonStyle.Danger),
+    );
+    const msg = await channel.messages.fetch(messageId).catch(() => null);
+    await msg?.edit({ components: [closeButton] }).catch((error: unknown) => {
+      enhancedLogger.warn(`Failed to update admin-only welcome message: ${error}`, LogCategory.COMMAND_EXECUTION, {
+        guildId,
+      });
+    });
+  }
 
   // update the ticket status
   await ticketRepo.update({ id: ticket.id, guildId }, { status: 'adminOnly' });
+
+  // Resolve the "Changing to Admin Only..." ack so it isn't left frozen.
+  await interaction.editReply({ content: tl.success }).catch(() => {});
 };
 
 export const adminOnlyButton = async (_client: Client, interaction: ButtonInteraction) => {

--- a/src/events/ticket/close.ts
+++ b/src/events/ticket/close.ts
@@ -126,6 +126,16 @@ export const ticketCloseEvent = async (
         { guildId, channelId, ticketId: ticket.id },
       );
     });
+  } else if (result.channelDeleted === false) {
+    // Transcript archived OK, but Discord refused to delete the channel (e.g.
+    // missing Manage Channels). The channel — and the "Closing ticket..." ack —
+    // are still here, so tell the user instead of looking like a hang.
+    enhancedLogger.warn('Ticket archived but channel delete failed — notifying user', LogCategory.SYSTEM, {
+      guildId,
+      channelId,
+      ticketId: ticket.id,
+    });
+    await deps.replyEphemeralError(interaction, tl.archivedChannelRemains, { bugReport: true }).catch(() => {});
   }
 };
 

--- a/src/lang/en/application.json
+++ b/src/lang/en/application.json
@@ -22,7 +22,8 @@
     "statusTitle": "Application System",
     "missingChannel": "Text channel for the application position buttons",
     "missingArchive": "Forum channel for archived/closed applications",
-    "missingCategory": "Category where application threads are created"
+    "missingCategory": "Category where application threads are created",
+    "closeNeedsArchive": "⚠️ Applications can't be closed until an archive forum is set. Run `/application-setup` again with the **archive** option — otherwise the Close button will fail."
   },
   "close": {
     "confirm": "Are you sure you want to close this application?",
@@ -34,6 +35,7 @@
     "notConfigured": "This application can't be closed yet — no archive forum is configured. An admin needs to run application setup and choose an archive forum.",
     "notFound": "This application could not be found — it may have already been closed.",
     "alreadyClosed": "This application is already being closed.",
+    "archivedChannelRemains": "This application was archived, but I couldn't delete its channel — please check my **Manage Channels** permission and delete it manually.",
     "transcriptCreate": {
       "success": "Transcript successfully sent to channel and deleted from memory!",
       "error": "Error making transcript file!",

--- a/src/lang/en/ticket.json
+++ b/src/lang/en/ticket.json
@@ -11,7 +11,9 @@
     "confirm": "Are you sure you want to make this ticket Admin Only?",
     "changing": "Changing to Admin Only...",
     "cancel": "Change to Admin Only canceled.",
-    "request": "has requested to make this ticket Admin Only."
+    "request": "has requested to make this ticket Admin Only.",
+    "requestSent": "Your request to make this ticket Admin Only has been sent to the staff team.",
+    "success": "This ticket is now Admin Only — staff roles can no longer view it."
   },
   "close": {
     "confirm": "Are you sure you want to close this ticket?",
@@ -21,6 +23,7 @@
     "notConfigured": "This ticket can't be closed yet — no archive forum is configured. An admin needs to run ticket setup and choose an archive forum.",
     "notFound": "This ticket could not be found — it may have already been closed.",
     "alreadyClosed": "This ticket is already being closed.",
+    "archivedChannelRemains": "This ticket was archived, but I couldn't delete its channel — please check my **Manage Channels** permission and delete it manually.",
     "transcriptCreate": {
       "success": "Transcript successfully sent to channel and deleted from memory!",
       "error": "Error making transcript file!",
@@ -48,7 +51,8 @@
     "statusTitle": "Ticket System",
     "missingChannel": "Text channel for the ticket creation button",
     "missingArchive": "Forum channel for archived/closed tickets",
-    "missingCategory": "Category where ticket threads are created"
+    "missingCategory": "Category where ticket threads are created",
+    "closeNeedsArchive": "⚠️ Tickets can't be closed until an archive forum is set. Run `/ticket-setup` again with the **archive** option — otherwise the Close button will fail."
   },
   "customTypes": {
     "typeAdd": {

--- a/src/lang/types.ts
+++ b/src/lang/types.ts
@@ -427,6 +427,7 @@ export interface LangTicketSetup {
   missingChannel: string;
   missingArchive: string;
   missingCategory: string;
+  closeNeedsArchive: string;
 }
 
 export interface LangTicket {
@@ -443,6 +444,8 @@ export interface LangTicket {
     changing: string;
     cancel: string;
     request: string;
+    requestSent: string;
+    success: string;
   };
   close: {
     confirm: string;
@@ -452,6 +455,7 @@ export interface LangTicket {
     notConfigured: string;
     notFound: string;
     alreadyClosed: string;
+    archivedChannelRemains: string;
     transcriptCreate: {
       success: string;
       error: string;
@@ -757,6 +761,7 @@ export interface LangApplication {
     missingChannel: string;
     missingArchive: string;
     missingCategory: string;
+    closeNeedsArchive: string;
   };
   applicationConfigNotFound: string;
   applicationCategoryNotFound: string;
@@ -775,6 +780,7 @@ export interface LangApplication {
     notConfigured: string;
     notFound: string;
     alreadyClosed: string;
+    archivedChannelRemains: string;
     transcriptCreate: {
       success: string;
       error: string;

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -25,6 +25,12 @@ const archivedAppRepo = lazyRepo(ArchivedApplication);
 export interface ArchiveApplicationResult {
   success: boolean;
   archived: boolean;
+  /**
+   * Whether the source application channel was actually deleted. Only
+   * meaningful when `archived` is true: the transcript was saved but the
+   * channel delete failed, so it's still live and the caller should say so.
+   */
+  channelDeleted?: boolean;
   transcriptFailed?: boolean;
 }
 
@@ -193,5 +199,5 @@ export async function archiveAndCloseApplication(
     );
   }
 
-  return { success: true, archived: true };
+  return { success: true, archived: true, channelDeleted: deleteResult.success };
 }

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -26,6 +26,13 @@ const archivedTicketRepo = lazyRepo(ArchivedTicket);
 export interface ArchiveTicketResult {
   success: boolean;
   archived: boolean;
+  /**
+   * Whether the source ticket channel was actually deleted. Only meaningful
+   * when `archived` is true: the transcript was saved but Discord refused the
+   * channel delete (e.g. missing Manage Channels), so the channel is still
+   * live and the caller should tell the user rather than silently "succeed".
+   */
+  channelDeleted?: boolean;
   postId?: string;
   transcriptFailed?: boolean;
   error?: string;
@@ -360,5 +367,8 @@ export async function archiveAndCloseTicket(
     );
   }
 
-  return { success: true, archived: true };
+  // archived:true reflects that the transcript is safely saved. channelDeleted
+  // tells the caller whether the channel actually went away — when false, the
+  // "Closing ticket..." ack would otherwise sit forever on a live channel.
+  return { success: true, archived: true, channelDeleted: deleteResult.success };
 }

--- a/tests/unit/events/ticket/close.test.ts
+++ b/tests/unit/events/ticket/close.test.ts
@@ -125,4 +125,23 @@ describe('ticketCloseEvent', () => {
     expect(ticketRepo.update).toHaveBeenCalledWith({ id: 7, guildId: 'guild1' }, { status: 'closed' });
     expect(replyEphemeralError).not.toHaveBeenCalled();
   });
+
+  test('archived but channel delete failed → notifies user instead of leaving a live channel hanging', async () => {
+    const { deps, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    archiveAndCloseTicket.mockResolvedValue({ success: true, archived: true, channelDeleted: false });
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledTimes(1);
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.archivedChannelRemains, expect.anything());
+  });
+
+  test('archived and channel deleted → clean success, no notice', async () => {
+    const { deps, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    archiveAndCloseTicket.mockResolvedValue({ success: true, archived: true, channelDeleted: true });
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -151,7 +151,7 @@ describe("archiveAndCloseApplication", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
     expect(fakeRepoState.createCalls).toHaveLength(1);
     expect(fakeRepoState.createCalls[0]).toMatchObject({
@@ -174,7 +174,7 @@ describe("archiveAndCloseApplication", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(forumChannel.threads.create).not.toHaveBeenCalled();
     expect(forumChannel.threads.fetch).toHaveBeenCalledWith("existing-app-thread", { force: true });
     const thread = forumState.threadsFetched.get("existing-app-thread");
@@ -196,7 +196,7 @@ describe("archiveAndCloseApplication", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
     expect(fakeRepoState.saveCalls).toHaveLength(1);
     expect(fakeRepoState.saveCalls[0].messageId).toBe(forumState.threadsCreated[0].id);

--- a/tests/unit/utils/ticket/closeWorkflow.test.ts
+++ b/tests/unit/utils/ticket/closeWorkflow.test.ts
@@ -302,7 +302,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
     expect(forumState.threadsCreated).toHaveLength(1);
     // Header is the initial create message; transcript chunks (if any) are follow-ups.
@@ -353,7 +353,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(fakeResolveTicketType).not.toHaveBeenCalled();
     expect(fakeBuiltinTypeInfo).toHaveBeenCalledWith("general");
     expect(fakeEnsureForumTag).toHaveBeenCalledWith(
@@ -387,7 +387,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // Email ticket lookup is scoped to the EMAIL archive namespace
     // (isEmailTicket:true + emailSender) — never the createdBy namespace.
     expect(fakeRepo.findOneBy).toHaveBeenCalledWith({
@@ -462,7 +462,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // No NEW thread created — existing one fetched (force:true bypasses cache)
     expect(forumChannel.threads.create).not.toHaveBeenCalled();
     expect(forumChannel.threads.fetch).toHaveBeenCalledWith(
@@ -504,7 +504,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(fakeApplyForumTags).toHaveBeenCalledTimes(1);
     expect(fakeApplyForumTags).toHaveBeenCalledWith(
       forumChannel,
@@ -660,7 +660,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // A replacement thread was created (the deleted one is unrecoverable).
     expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
     // Archive row repointed to the new thread + accumulated tags, then saved.
@@ -732,7 +732,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
@@ -764,9 +764,9 @@ describe("archiveAndCloseTicket", () => {
 
     // Workflow returns success: true regardless — channel delete failure is logged,
     // not propagated. The archive succeeded; the orphaned channel is a Discord-side
-    // problem. This documents current behavior; bumping it to success: false would
-    // be a separate behavior-change patch.
-    expect(result).toEqual({ success: true, archived: true });
+    // problem. channelDeleted: false carries that outcome so the close handler can
+    // tell the user the channel still needs to be removed.
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: false });
   });
 
   test("orphaned customTypeId (resolveTicketType returns null): falls back to default title", async () => {
@@ -789,7 +789,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(fakeResolveTicketType).toHaveBeenCalledWith(
       "guild-1",
       "deleted-type-id",
@@ -825,7 +825,7 @@ describe("archiveAndCloseTicket", () => {
       deps,
     );
 
-    expect(result).toEqual({ success: true, archived: true });
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // Builtin fallback intentionally returns null — no tag ensured
     expect(fakeEnsureForumTag).not.toHaveBeenCalled();
     // builtinTypeInfo NOT consulted because customTypeId branch already returned null


### PR DESCRIPTION
Follow-ups to the v3.13.1 close-button hotfix (#17), plus the root-cause fix for the **stale Discord release message** (the deploy announced v3.13.0's notes for the v3.13.1 deploy).

## Fixed
- **Admin Only button** (`events/ticket/adminOnly.ts`) — same bug class as the close hang, plus two latent bugs:
  - Silent `!ticket` return after the "Changing to Admin Only…" ack → now surfaces feedback.
  - `${globalStaffRole}\n` template was **always truthy**, so a guild with no global staff role could ping a literal **"undefined"** → now gated on the real value.
  - Staff-role view removal was a **fire-and-forget `forEach`** (async callbacks not awaited → races / unhandled rejections) → now `for…of` + `await` + per-role error handling.
  - Welcome-message fetch/edit guarded; the ack resolves to a clear **success / request-sent** message instead of staying frozen.
- **Close flows** (ticket + application) — the workflows now report `channelDeleted`; when the transcript is archived but the channel can't be deleted (e.g. missing Manage Channels), the handler tells the user instead of leaving "Closing…" on a live channel forever.
- **Setup** (`/ticket-setup`, `/application-setup`) — warns when a creation channel is configured **without an archive forum**, the exact misconfiguration that made Close fail in v3.13.1.

## Added
- **`check:changelog` CI guard** (`scripts/checkChangelog.ts`) — fails the build when `package.json`'s version ≠ the top `CHANGELOG.md` entry. **This is the durable fix for the stale-release-notes bug:** `release.sh` bumps the version but never enforced a matching changelog entry, so a forgotten entry silently shipped the previous version's notes to Discord. Now it can't.
- Retroactive **3.13.1** + new **3.13.2** CHANGELOG entries.

## Verification
- `bun run build` (tsc) ✓ · `bun run check` (biome) ✓ · `check:contract` ✓ (botVersion only) · `check:changelog` ✓
- `bun test` → **1383 pass / 0 fail** (+2 tests for the channel-delete-reporting paths; updated the existing close-workflow result assertions to cover the new `channelDeleted` field)
- **Adversarial multi-agent review (13 agents): verdict `ship`, 0 must-fix, no regressions.**

## Deferred (deliberate product decision — not a regression)
`autoClose.ts` keeps an auto-closed ticket's channel + Close button alive. The **hang is already fixed** (v3.13.1 makes the dup-close guard give feedback). Whether the Close button should *re-archive* an auto-closed ticket vs. *remove the button* vs. *delete the channel* each carry real tradeoffs (double-archive race / channel accumulation), so the behavior is unchanged pending a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)