### PR TITLE
feat: v3.14.0 — archival transcript overhaul + attachment re-upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,15 @@ survive forever.
 - **Attachments are re-uploaded into the archive thread.** Pictures and videos
   render inline and stay viewable after the ticket channel is deleted — the old
   behavior linked to Discord CDN URLs, which expire. Files ride directly under
-  the message they belong to; anything over 10 MB (or a failed download) falls
-  back to a link.
+  the message they belong to, batched so no single post exceeds the upload
+  budget; a batch Discord still rejects is rescued file-by-file, and only a
+  file that can't upload at all falls back to its link. Anything over 10 MB
+  (or a failed/stalled download — 30s timeout) links instead of uploading.
+- **Transcript chrome can't be spoofed**: user lines that mimic the archive's
+  author lines or day dividers are neutralized with an invisible zero-width
+  space, so nobody can fabricate a staff message in the moderation archive.
+  Attachment/sticker names and poll questions are escaped so they can't break
+  the transcript markup.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.0] - 2026-07-03
+
+Archive transcripts got a full readability overhaul — and attachments now
+survive forever.
+
+### Added
+
+- **Attachments are re-uploaded into the archive thread.** Pictures and videos
+  render inline and stay viewable after the ticket channel is deleted — the old
+  behavior linked to Discord CDN URLs, which expire. Files ride directly under
+  the message they belong to; anything over 10 MB (or a failed download) falls
+  back to a link.
+
+### Changed
+
+- **Archive forum posts are now chat-style** (ticket + application closes):
+  a colored embed header card (opened / closed / duration / type / creator /
+  assignee / message count), day dividers, short time-only timestamps,
+  consecutive messages from one author grouped under a single name line, and
+  plain message bodies — only foreign-bot embeds stay blockquoted. Transcripts
+  read like the conversation they archive.
+- **Author lines carry role badges**: 👤 the ticket opener, 🛡️ the assignee,
+  🤖 bots — you can tell who's who at a glance.
+- **Replies show context**: `↳ to staff_bob: "which rank did you buy…"`
+  instead of just naming the author.
+- **Re-closes** into an existing archive thread are now separated by a fresh
+  header card instead of a thin line, so multiple tickets in one thread are
+  easy to tell apart.
+
+### Fixed
+
+- Application archive headers no longer render as "🎫 Ticket: Application:
+  name" — applications get their own 📋 card.
+- **Silent transcript loss on re-close**: an archive row with a missing
+  thread reference matched neither the create nor the append branch — the
+  ticket channel was deleted while the transcript was never posted anywhere.
+  Those rows now recreate the archive thread instead.
+- Email-import archive threads with very long sender names no longer fail to
+  create (thread names are clamped to Discord's 100-char limit); very long
+  email subjects no longer break the header card (256-char embed-title clamp).
+
 ## [3.13.2] - 2026-06-26
 
 Close-flow follow-ups + a release-notes drift guard.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - **Runtime**: Bun
 - **Deployment**: Docker containers
 - **Branches**: `main` (production)
-- **Version**: 3.2.2
+- **Version**: 3.14.0 (see `package.json` — this line drifts; trust the package)
 
 ## Critical Rules
 

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.13.2",
+  "botVersion": "3.14.0",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.13.2",
+  "version": "3.14.0",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -13,12 +13,13 @@
 import type { Client, ForumChannel, ForumThreadChannel, GuildTextBasedChannel } from 'discord.js';
 import type { Application } from '../../typeorm/entities/application/Application';
 import { ArchivedApplication } from '../../typeorm/entities/application/ArchivedApplication';
+import { Colors } from '../colors';
 import { lazyRepo } from '../database/lazyRepo';
 import { verifiedChannelDelete } from '../discord/verifiedDelete';
 import { fetchMessagesAsTranscript } from '../fetchAllMessages';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { buildTranscript, type TicketMetadata, type TranscriptMessage } from '../ticket/transcriptBuilder';
-import { postTranscriptToThread } from '../ticket/transcriptPoster';
+import { buildHeaderEmbed, postTranscriptToThread } from '../ticket/transcriptPoster';
 
 const archivedAppRepo = lazyRepo(ArchivedApplication);
 
@@ -85,15 +86,18 @@ export async function archiveAndCloseApplication(
   const creatorUser = await client.users.fetch(application.createdBy).catch(() => null);
   const threadName = creatorUser?.username || 'Unknown';
   const metadata: TicketMetadata = {
-    title: `Application: ${threadName}`,
+    title: `Application — ${threadName}`,
     type: 'Application',
     createdByUsername: threadName,
     openedAt: 'createdAt' in channel && channel.createdAt instanceof Date ? channel.createdAt : new Date(),
     closedAt: new Date(),
     assignedToUsername: null,
+    kind: 'application',
+    createdById: application.createdBy,
   };
 
   const transcript = buildTranscript(transcriptMessages, metadata);
+  const headerEmbed = buildHeaderEmbed(transcript.headerData, Colors.application.review);
 
   let archived = true;
   try {
@@ -107,7 +111,7 @@ export async function archiveAndCloseApplication(
       const newPost = await forumChannel.threads.create({
         name: threadName,
         // allowedMentions parse:[] — historical transcript, never ping anyone.
-        message: { content: transcript.header, allowedMentions: { parse: [] } },
+        message: { embeds: [headerEmbed], allowedMentions: { parse: [] } },
       });
 
       // Persist the archive row BEFORE posting chunks: a chunk failure then
@@ -122,22 +126,25 @@ export async function archiveAndCloseApplication(
       );
 
       await postTranscriptToThread(newPost, transcript.chunks, { guildId, channelId, label: 'Application transcript' });
-    } else if (existingArchive.messageId) {
+    } else {
       // Re-close: reuse the archive thread, but it may have been deleted out
       // from under us. force:true bypasses the cache; catch ONLY 10003 (Unknown
       // Channel) and recreate so the transcript is never lost — let other errors
       // bubble to the outer catch (marks archived:false, preserves the channel).
-      const post = (await forumChannel.threads
-        .fetch(existingArchive.messageId, { force: true })
-        .catch((err: unknown) => {
-          if ((err as { code?: number })?.code === 10003) return null;
-          throw err;
-        })) as ForumThreadChannel | null;
+      // A row with a NULL messageId also takes the recreate path — it previously
+      // matched neither branch, deleting the channel with the transcript never
+      // posted anywhere (silent data loss).
+      const post = existingArchive.messageId
+        ? ((await forumChannel.threads.fetch(existingArchive.messageId, { force: true }).catch((err: unknown) => {
+            if ((err as { code?: number })?.code === 10003) return null;
+            throw err;
+          })) as ForumThreadChannel | null)
+        : null;
 
       if (!post) {
         const newPost = await forumChannel.threads.create({
           name: threadName,
-          message: { content: transcript.header, allowedMentions: { parse: [] } },
+          message: { embeds: [headerEmbed], allowedMentions: { parse: [] } },
         });
         // Repoint + persist BEFORE chunks so a chunk failure can't orphan it.
         existingArchive.messageId = newPost.id;
@@ -148,9 +155,9 @@ export async function archiveAndCloseApplication(
           label: 'Application transcript',
         });
       } else {
-        const separator = '\n━━━━━━━━━━━━━━━━━━━━━━━━\n';
+        // A fresh header embed is the visual divider between closes.
         await post.send({
-          content: separator + transcript.header,
+          embeds: [headerEmbed],
           allowedMentions: { parse: [] },
         });
         await postTranscriptToThread(post, transcript.chunks, { guildId, channelId, label: 'Application transcript' });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -232,6 +232,8 @@ export const TIMEOUTS = {
   COMPONENT: 60_000,
   /** Long-lived dashboards/wizards: 5 minutes */
   DASHBOARD: 300_000,
+  /** Per-attachment CDN download timeout during archiving: 30 seconds */
+  TRANSCRIPT_DOWNLOAD: 30_000,
 } as const;
 
 export const TEXT_LIMITS = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -83,6 +83,12 @@ export const MAX = {
   JOIN_VELOCITY_ENTRIES: 1000,
   /** Internal API max request body size: 1 MB */
   API_BODY_SIZE: 1024 * 1024,
+  /**
+   * Largest attachment the archive poster re-uploads into a forum thread:
+   * 10 MB — Discord's baseline upload limit for non-boosted guilds. Bigger
+   * files fall back to the (eventually-expiring) CDN link in the chunk text.
+   */
+  TRANSCRIPT_REUPLOAD_BYTES: 10 * 1024 * 1024,
   /** Announcement templates per guild (Discord autocomplete limit) */
   ANNOUNCEMENT_TEMPLATES: 25,
   /** Embed fields per announcement template */

--- a/src/utils/fetchAllMessages.ts
+++ b/src/utils/fetchAllMessages.ts
@@ -60,6 +60,7 @@ function toTranscriptMessage(m: Message, byId: Map<string, Message>, botClientId
       name: a.name,
       url: a.url,
       contentType: a.contentType ?? undefined,
+      size: a.size,
     })),
     embeds: m.embeds.map(e => ({
       title: e.title ?? undefined,

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -12,6 +12,7 @@
 import type { Client, ForumChannel, ForumThreadChannel, GuildTextBasedChannel } from 'discord.js';
 import { ArchivedTicket } from '../../typeorm/entities/ticket/ArchivedTicket';
 import type { Ticket } from '../../typeorm/entities/ticket/Ticket';
+import { Colors } from '../colors';
 import { lazyRepo } from '../database/lazyRepo';
 import { verifiedChannelDelete } from '../discord/verifiedDelete';
 import { fetchMessagesAsTranscript } from '../fetchAllMessages';
@@ -19,7 +20,7 @@ import { applyForumTags, ensureForumTag } from '../forumTagManager';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { builtinTypeInfo, resolveTicketType } from './builtinTypes';
 import { buildTranscript, type TicketMetadata, type TranscriptMessage } from './transcriptBuilder';
-import { postTranscriptToThread } from './transcriptPoster';
+import { buildHeaderEmbed, postTranscriptToThread } from './transcriptPoster';
 
 const archivedTicketRepo = lazyRepo(ArchivedTicket);
 
@@ -135,8 +136,10 @@ async function findExistingArchive(
 }
 
 async function resolveArchiveThreadName(client: Client, ticket: Ticket): Promise<string> {
+  // Clamped to Discord's 100-char thread-name limit — emailSenderName is free
+  // text and an over-limit name fails the whole threads.create call.
   if (ticket.isEmailTicket && ticket.emailSender) {
-    return ticket.emailSenderName || ticket.emailSender.split('@')[0];
+    return (ticket.emailSenderName || ticket.emailSender.split('@')[0]).slice(0, 100);
   }
   const user = await client.users.fetch(ticket.createdBy).catch(() => null);
   return user?.username || 'Unknown';
@@ -198,6 +201,8 @@ export async function archiveAndCloseTicket(
     openedAt: ticket.lastActivityAt ? new Date(Math.min(ticket.lastActivityAt.getTime(), Date.now())) : new Date(),
     closedAt: new Date(),
     assignedToUsername: assignedUser?.username ?? null,
+    createdById: ticket.createdBy,
+    assignedToId: ticket.assignedTo ?? undefined,
   };
   // Prefer the channel's createdAt as a more accurate open time when available.
   if ('createdAt' in channel && channel.createdAt instanceof Date) {
@@ -205,6 +210,7 @@ export async function archiveAndCloseTicket(
   }
 
   const transcript = buildTranscript(transcriptMessages, metadata);
+  const headerEmbed = buildHeaderEmbed(transcript.headerData, Colors.ticket.created);
 
   let archived = true;
   try {
@@ -226,7 +232,7 @@ export async function archiveAndCloseTicket(
         name: threadName,
         // allowedMentions parse:[] — the transcript is historical content; it
         // must never ping anyone (@everyone/@here/user/role) when re-posted.
-        message: { content: transcript.header, allowedMentions: { parse: [] } },
+        message: { embeds: [headerEmbed], allowedMentions: { parse: [] } },
       });
 
       if (forumTagIds.length > 0) {
@@ -256,7 +262,7 @@ export async function archiveAndCloseTicket(
         guildId,
         channelId,
       });
-    } else if (existingArchive.messageId) {
+    } else {
       // Re-close for the same user. The archive thread is reused — but it may
       // have been deleted out from under us (manual delete, /archive cleanup).
       // Catch ONLY 10003 (Unknown Channel) and recreate so the transcript is
@@ -265,13 +271,16 @@ export async function archiveAndCloseTicket(
       // force:true bypasses the channel cache so a thread deleted while the bot
       // was offline (missed THREAD_DELETE) still surfaces as gone (10003 or a
       // null fetch) and engages the recreate path, instead of returning a stale
-      // cached object we'd post into the void.
-      const post = (await forumChannel.threads
-        .fetch(existingArchive.messageId, { force: true })
-        .catch((err: unknown) => {
-          if ((err as { code?: number })?.code === 10003) return null;
-          throw err;
-        })) as ForumThreadChannel | null;
+      // cached object we'd post into the void. A row with a NULL messageId
+      // (legacy/partial rows) also takes the recreate path — it previously
+      // matched neither branch, so the channel was deleted while the transcript
+      // was never posted anywhere (silent data loss).
+      const post = existingArchive.messageId
+        ? ((await forumChannel.threads.fetch(existingArchive.messageId, { force: true }).catch((err: unknown) => {
+            if ((err as { code?: number })?.code === 10003) return null;
+            throw err;
+          })) as ForumThreadChannel | null)
+        : null;
 
       if (!post) {
         // Thread gone: recreate it (header as the initial message), re-apply
@@ -280,7 +289,7 @@ export async function archiveAndCloseTicket(
         const newPost = await forumChannel.threads.create({
           name: threadName,
           message: {
-            content: transcript.header,
+            embeds: [headerEmbed],
             allowedMentions: { parse: [] },
           },
         });
@@ -298,11 +307,11 @@ export async function archiveAndCloseTicket(
           channelId,
         });
       } else {
-        // Normal append: separator + header + chunks into the existing thread.
+        // Normal append: a fresh header embed is the visual divider between
+        // this close and the previous ones, then the chunks follow.
         // Tags still accumulate — "Forum Tag System" per CLAUDE.md.
-        const separator = '\n━━━━━━━━━━━━━━━━━━━━━━━━\n';
         await post.send({
-          content: separator + transcript.header,
+          embeds: [headerEmbed],
           allowedMentions: { parse: [] },
         });
         await postTranscriptToThread(post, transcript.chunks, {
@@ -315,7 +324,7 @@ export async function archiveAndCloseTicket(
           const newTagId = forumTagIds[0];
           if (!existingTags.includes(newTagId)) {
             const mergedTags = [...existingTags, newTagId];
-            await deps.applyForumTags(forumChannel, existingArchive.messageId, mergedTags);
+            await deps.applyForumTags(forumChannel, post.id, mergedTags);
             existingArchive.forumTagIds = mergedTags;
             await deps.archivedTicketRepo.save(existingArchive);
           }

--- a/src/utils/ticket/transcriptBuilder.ts
+++ b/src/utils/ticket/transcriptBuilder.ts
@@ -1,17 +1,25 @@
 /**
  * Pure transcript builder. Takes a shape-checked `TranscriptMessage[]`
- * plus metadata and produces a markdown header + chunked follow-up
+ * plus metadata and produces embed-header data + chunked follow-up
  * messages sized to fit inside Discord's 2000-char message limit.
  *
  * No Discord client or I/O — all Discord-touching concerns stay in the
- * fetcher layer. That separation is what makes this testable without a
- * gateway connection.
+ * fetcher/poster layers. That separation is what makes this testable without
+ * a gateway connection.
  *
  * Fidelity contract (v3.2.1): the transcript is an exact carbon copy of the
  * conversation. Message content is NEVER truncated — a message longer than a
  * single Discord post is split across multiple chunks on line boundaries (the
  * pre-v3.2.1 builder hard-truncated at 500 chars and silently dropped the
  * tail). Stickers, polls, and embed media are captured too.
+ *
+ * Readability contract (v3.14.0): archive posts read like a real Discord
+ * conversation — day dividers, short time-only timestamps, consecutive
+ * messages from one author grouped under a single name line, plain (unquoted)
+ * bodies. Only foreign-embed content stays blockquoted, so bot output is
+ * visually distinct from what people actually said. Attachments ride on their
+ * chunk as re-uploadable payloads (`TranscriptChunk.files`) so the poster can
+ * attach the real files — CDN links die when the source channel is deleted.
  */
 
 import { TEXT_LIMITS } from '../constants';
@@ -35,6 +43,8 @@ export interface TranscriptAttachment {
   name: string;
   url: string;
   contentType?: string;
+  /** Byte size from Discord — lets the poster skip re-uploads over the limit. */
+  size?: number;
 }
 
 export interface TranscriptEmbed {
@@ -59,7 +69,7 @@ export interface TranscriptPoll {
   answers: { text: string; voteCount: number }[];
 }
 
-/** Ticket-level metadata rendered into the header. */
+/** Ticket-level metadata rendered into the header embed. */
 export interface TicketMetadata {
   title: string;
   type: string;
@@ -67,11 +77,35 @@ export interface TicketMetadata {
   openedAt: Date;
   closedAt: Date;
   assignedToUsername: string | null;
+  /** Picks the header emoji + field set. Defaults to 'ticket'. */
+  kind?: 'ticket' | 'application';
+  /** Discord user id of the opener — badges their author lines with 👤. */
+  createdById?: string;
+  /** Discord user id of the assignee — badges their author lines with 🛡️. */
+  assignedToId?: string;
+}
+
+/** Author-line badge context, derived from {@link TicketMetadata}. */
+export interface AuthorBadges {
+  createdById?: string;
+  assignedToId?: string;
+}
+
+/** Pure header-embed data — the poster turns this into an EmbedBuilder. */
+export interface TranscriptHeaderData {
+  title: string;
+  fields: { name: string; value: string; inline: boolean }[];
+}
+
+/** One postable archive message: text plus the files to re-upload with it. */
+export interface TranscriptChunk {
+  content: string;
+  files: TranscriptAttachment[];
 }
 
 export interface TranscriptResult {
-  header: string;
-  chunks: string[];
+  headerData: TranscriptHeaderData;
+  chunks: TranscriptChunk[];
   messageCount: number;
   attachmentCount: number;
 }
@@ -80,9 +114,21 @@ export interface TranscriptResult {
 const CHUNK_SOFT_LIMIT = TEXT_LIMITS.TRANSCRIPT_CHUNK_SOFT;
 /** Discord's hard per-message limit. No emitted chunk may exceed this. */
 const CHUNK_HARD_LIMIT = TEXT_LIMITS.TRANSCRIPT_CHUNK_HARD;
+/** Discord's hard per-message attachment limit. */
+const MAX_FILES_PER_MESSAGE = 10;
+/**
+ * Messages from the same author within this window collapse under one name
+ * line — mirrors Discord's own message-grouping behavior.
+ */
+const GROUP_WINDOW_MS = 7 * 60_000;
 
-/** `<t:unix:f>` — Discord renders this in the viewer's local timezone. */
-function formatDiscordTimestamp(date: Date): string {
+/** `<t:unix:t>` — short time-only stamp; the day divider carries the date. */
+function formatTimeStamp(date: Date): string {
+  return `<t:${toUnixSeconds(date)}:t>`;
+}
+
+/** `<t:unix:f>` — full date+time, used in the header embed fields. */
+function formatFullStamp(date: Date): string {
   return `<t:${toUnixSeconds(date)}:f>`;
 }
 
@@ -106,39 +152,56 @@ function blockquote(body: string): string {
     .join('\n');
 }
 
-export function formatHeader(metadata: TicketMetadata, messageCount: number, attachmentCount: number): string {
+/**
+ * Header data for the archive post's embed card. Applications omit the
+ * "Assigned to" row when there's no assignee (tickets show "Unassigned" —
+ * unassigned tickets are signal, unassigned applications are the norm).
+ */
+export function buildHeaderData(
+  metadata: TicketMetadata,
+  messageCount: number,
+  attachmentCount: number,
+): TranscriptHeaderData {
+  const kind = metadata.kind ?? 'ticket';
   const duration = formatDurationShort(metadata.closedAt.getTime() - metadata.openedAt.getTime());
-  const lines = [
-    `# 🎫 Ticket: ${metadata.title}`,
-    '',
-    `**Created by:** ${metadata.createdByUsername}`,
-    `**Opened:** ${formatDiscordTimestamp(metadata.openedAt)}`,
-    `**Closed:** ${formatDiscordTimestamp(metadata.closedAt)}`,
-    `**Duration:** ${duration}`,
-    `**Type:** ${metadata.type}`,
-    `**Assigned to:** ${metadata.assignedToUsername ?? 'Unassigned'}`,
-    `**Messages:** ${messageCount}`,
+  const fields: TranscriptHeaderData['fields'] = [
+    { name: 'Opened', value: formatFullStamp(metadata.openedAt), inline: true },
+    { name: 'Closed', value: formatFullStamp(metadata.closedAt), inline: true },
+    { name: 'Duration', value: duration, inline: true },
+    { name: 'Type', value: metadata.type, inline: true },
+    { name: 'Created by', value: metadata.createdByUsername, inline: true },
   ];
-  if (attachmentCount > 0) lines.push(`**Attachments:** ${attachmentCount}`);
-  lines.push('', '---');
-  return lines.join('\n');
+  if (metadata.assignedToUsername !== null || kind === 'ticket') {
+    fields.push({ name: 'Assigned to', value: metadata.assignedToUsername ?? 'Unassigned', inline: true });
+  }
+  const counts = attachmentCount > 0 ? `${messageCount} · ${attachmentCount} 📎` : `${messageCount}`;
+  fields.push({ name: 'Messages', value: counts, inline: true });
+  // Discord caps embed titles at 256 chars — an email-ticket subject can
+  // exceed that, and an over-limit title fails the whole archive post.
+  const title = `${kind === 'application' ? '📋' : '🎫'} ${metadata.title}`;
+  return {
+    title: title.length > 256 ? `${title.slice(0, 255)}…` : title,
+    fields,
+  };
 }
 
 function formatAttachment(a: TranscriptAttachment): string {
-  if (!a.url) return `> 📎 ~~${a.name}~~ (unavailable)`;
-  return `> 📎 [${a.name}](${a.url})`;
+  if (!a.url) return `📎 ~~${a.name}~~ (unavailable)`;
+  // <url> suppresses Discord's link preview — the re-uploaded file on the
+  // same chunk is the visible copy; the link is the fallback if that fails.
+  return `📎 [${a.name}](<${a.url}>)`;
 }
 
 function formatSticker(s: TranscriptSticker): string {
-  if (!s.url) return `> 🏷️ Sticker: ${s.name}`;
-  return `> 🏷️ Sticker: [${s.name}](${s.url})`;
+  if (!s.url) return `🏷️ Sticker: ${s.name}`;
+  return `🏷️ Sticker: [${s.name}](${s.url})`;
 }
 
 function formatPoll(poll: TranscriptPoll): string[] {
-  const lines = [`> 📊 **Poll:** ${poll.question}`];
+  const lines = [`📊 **Poll:** ${poll.question}`];
   for (const answer of poll.answers) {
     const votes = `${answer.voteCount} vote${answer.voteCount === 1 ? '' : 's'}`;
-    lines.push(`> • ${answer.text} — ${votes}`);
+    lines.push(`• ${answer.text} — ${votes}`);
   }
   return lines;
 }
@@ -157,23 +220,19 @@ function formatEmbedBody(embed: TranscriptEmbed): string[] {
   if (embed.thumbnailUrl) parts.push(`🖼️ [thumbnail](${embed.thumbnailUrl})`);
   if (embed.footer) parts.push(`— ${embed.footer}`);
   if (parts.length === 0) return [];
-  // Indent the whole embed one level deeper than the message blockquote.
-  return blockquote(parts.join('\n'))
-    .split('\n')
-    .map(line => `> ${line}`);
+  // Blockquote the embed so foreign-bot output stays visually distinct from
+  // the plain-bodied human conversation around it.
+  return blockquote(parts.join('\n')).split('\n');
 }
 
-export function formatMessage(msg: TranscriptMessage): string {
-  const header = msg.replyTo
-    ? `**${msg.author.username}** ${formatDiscordTimestamp(msg.timestamp)}  ↩️ *replying to ${msg.replyTo.author}*`
-    : `**${msg.author.username}** ${formatDiscordTimestamp(msg.timestamp)}`;
-
+/** Body lines only — used for both fresh messages and grouped continuations. */
+function formatMessageBody(msg: TranscriptMessage): string {
   const bodyLines: string[] = [];
 
   // Full content — never truncated. Oversized messages are split across
-  // chunks by chunkByMessageBoundary so nothing is ever lost.
+  // chunks by the chunker so nothing is ever lost.
   if (msg.content) {
-    bodyLines.push(blockquote(msg.content));
+    bodyLines.push(msg.content);
   }
 
   for (const embed of msg.embeds) {
@@ -193,12 +252,99 @@ export function formatMessage(msg: TranscriptMessage): string {
   }
 
   if (bodyLines.length === 0) {
-    // Message filtered from body content but kept because something referenced it
-    // (edge case: a reply chain anchor with empty body).
-    bodyLines.push('> *(no content)*');
+    // Message filtered from body content but kept because something referenced
+    // it (edge case: a reply chain anchor with empty body).
+    bodyLines.push('*(no content)*');
   }
 
-  return [header, ...bodyLines].join('\n');
+  return bodyLines.join('\n');
+}
+
+/** 🤖 bots, 👤 the ticket opener, 🛡️ the assignee — no badge for anyone else. */
+function authorBadge(msg: TranscriptMessage, badges?: AuthorBadges): string {
+  if (msg.author.bot) return '🤖 ';
+  if (badges?.createdById && msg.author.id === badges.createdById) return '👤 ';
+  if (badges?.assignedToId && msg.author.id === badges.assignedToId) return '🛡️ ';
+  return '';
+}
+
+/**
+ * Reply marker with a short context snippet — the full original message is
+ * elsewhere in the transcript, so the snippet trims markdown and truncates.
+ */
+function formatReplyMarker(replyTo: NonNullable<TranscriptMessage['replyTo']>): string {
+  const clean = replyTo.content
+    .replace(/[*_`|~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!clean) return `↳ *to ${replyTo.author}*`;
+  const snippet = clean.length > 60 ? `${clean.slice(0, 59)}…` : clean;
+  return `↳ *to ${replyTo.author}: "${snippet}"*`;
+}
+
+export function formatMessage(msg: TranscriptMessage, badges?: AuthorBadges): string {
+  const stamp = `${authorBadge(msg, badges)}**${msg.author.username}** · ${formatTimeStamp(msg.timestamp)}`;
+  const header = msg.replyTo ? `${stamp}  ${formatReplyMarker(msg.replyTo)}` : stamp;
+  return `${header}\n${formatMessageBody(msg)}`;
+}
+
+/** UTC calendar-day key for divider bucketing. */
+function utcDayKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** `-# ── Wednesday, April 1, 2026 ──` — small grey subtext divider (UTC). */
+function formatDayDivider(date: Date): string {
+  const label = date.toLocaleDateString('en-US', {
+    timeZone: 'UTC',
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  return `-# ── ${label} ──`;
+}
+
+/** One packable unit: a formatted message (or author-group) plus its files. */
+interface TranscriptUnit {
+  text: string;
+  files: TranscriptAttachment[];
+}
+
+/**
+ * Format kept messages into units: day dividers are prepended to the first
+ * message of each UTC day, and consecutive messages from the same author
+ * within {@link GROUP_WINDOW_MS} merge under one name line. A message that
+ * carries attachments ends its unit so the chunker can pin the files directly
+ * beneath its text.
+ */
+function buildUnits(kept: TranscriptMessage[], badges?: AuthorBadges): TranscriptUnit[] {
+  const units: TranscriptUnit[] = [];
+  let prev: TranscriptMessage | null = null;
+
+  for (const msg of kept) {
+    const uploadable = msg.attachments.filter(a => a.url);
+    const newDay = !prev || utcDayKey(prev.timestamp) !== utcDayKey(msg.timestamp);
+    const canGroup =
+      prev !== null &&
+      !newDay &&
+      prev.author.id === msg.author.id &&
+      !msg.replyTo &&
+      prev.attachments.length === 0 &&
+      msg.timestamp.getTime() - prev.timestamp.getTime() <= GROUP_WINDOW_MS;
+
+    if (canGroup) {
+      const unit = units[units.length - 1];
+      unit.text += `\n${formatMessageBody(msg)}`;
+      unit.files.push(...uploadable);
+    } else {
+      const divider = newDay ? `${formatDayDivider(msg.timestamp)}\n` : '';
+      units.push({ text: divider + formatMessage(msg, badges), files: [...uploadable] });
+    }
+    prev = msg;
+  }
+
+  return units;
 }
 
 /** Hard-slice a string into ≤`limit` segments. Last resort — never drops content. */
@@ -219,7 +365,7 @@ const QUOTE_PREFIX_RE = /^((?:> )+)/;
  * closed on the current piece and reopened on the next — at the SAME blockquote
  * depth the fence was opened — so each resulting Discord message renders as
  * valid markdown. A single line longer than `limit` is hard-sliced on its
- * content while preserving its `> ` prefix on every segment, so continuation
+ * content while preserving any `> ` prefix on every segment, so continuation
  * pieces stay blockquoted. Content is never dropped.
  */
 function splitFormattedMessage(message: string, limit: number): string[] {
@@ -228,8 +374,8 @@ function splitFormattedMessage(message: string, limit: number): string[] {
   let bufLen = 0;
   let inFence = false;
   // The blockquote depth the active fence was opened at — close/reopen must
-  // match it (a fence inside an embed body is double-quoted: `> > ```).
-  let fencePrefix = '> ';
+  // match it (a fence inside an embed body is quoted: `> ```).
+  let fencePrefix = '';
   const fenceLine = () => `${fencePrefix}\`\`\``;
 
   const flush = (willContinue: boolean) => {
@@ -260,8 +406,8 @@ function splitFormattedMessage(message: string, limit: number): string[] {
 
     if (line.length > limit) {
       // Pathological single line (a long URL / base64 blob with no newline).
-      // Hard-slice the CONTENT and re-apply the quote prefix to every segment so
-      // continuation pieces stay blockquoted; reserve headroom for a fence
+      // Hard-slice the CONTENT and re-apply any quote prefix to every segment
+      // so continuation pieces stay blockquoted; reserve headroom for a fence
       // close/reopen wrapper so every emitted piece stays ≤ limit. A fence
       // marker is short and never lands here, so fence state is unaffected.
       const reserve = fenceLine().length + 1;
@@ -282,38 +428,79 @@ function splitFormattedMessage(message: string, limit: number): string[] {
   return pieces;
 }
 
+/** Split files into ≤10-per-message batches (Discord's attachment cap). */
+function batchFiles(files: TranscriptAttachment[]): TranscriptAttachment[][] {
+  const batches: TranscriptAttachment[][] = [];
+  for (let i = 0; i < files.length; i += MAX_FILES_PER_MESSAGE) {
+    batches.push(files.slice(i, i + MAX_FILES_PER_MESSAGE));
+  }
+  return batches;
+}
+
 /**
- * Pack already-formatted messages into chunks, each guaranteed ≤ `hardLimit`
- * characters, never dropping content. Whole messages stay together when they
- * fit; a single message larger than `softLimit` is split on line boundaries
- * (see {@link splitFormattedMessage}). A final defensive pass hard-slices any
- * chunk still over `hardLimit` — silent loss here is the exact failure mode the
- * carbon-copy fix exists to prevent.
+ * Pack formatted units into chunks, each guaranteed ≤ `hardLimit` characters
+ * and ≤ 10 files, never dropping content. Whole units stay together when they
+ * fit; a single unit larger than `softLimit` is split on line boundaries (see
+ * {@link splitFormattedMessage}). A unit with files forces a flush right after
+ * its text so the re-uploaded attachments render directly beneath the message
+ * they belong to. A final defensive pass hard-slices any chunk still over
+ * `hardLimit` — silent loss here is the exact failure mode the carbon-copy fix
+ * exists to prevent.
+ */
+function chunkUnits(units: TranscriptUnit[], softLimit: number, hardLimit: number): TranscriptChunk[] {
+  const chunks: TranscriptChunk[] = [];
+  let buffer = '';
+  const flush = () => {
+    if (buffer) {
+      chunks.push({ content: buffer, files: [] });
+      buffer = '';
+    }
+  };
+
+  for (const unit of units) {
+    const pieces = unit.text.length <= softLimit ? [unit.text] : splitFormattedMessage(unit.text, softLimit);
+    for (const piece of pieces) {
+      if (buffer && buffer.length + 2 + piece.length > softLimit) flush();
+      buffer = buffer ? `${buffer}\n\n${piece}` : piece;
+    }
+    if (unit.files.length > 0) {
+      // Pin files under their message: flush the text, attach the first batch
+      // to it, and overflow extra batches into marker-only follow-up chunks.
+      flush();
+      const batches = batchFiles(unit.files);
+      chunks[chunks.length - 1].files = batches[0];
+      for (let b = 1; b < batches.length; b++) {
+        chunks.push({ content: '-# 📎 (continued)', files: batches[b] });
+      }
+    }
+  }
+  flush();
+
+  return chunks.flatMap(chunk => {
+    if (chunk.content.length <= hardLimit) return [chunk];
+    const slices = hardSlice(chunk.content, hardLimit);
+    return slices.map((content, i) => ({
+      content,
+      files: i === slices.length - 1 ? chunk.files : [],
+    }));
+  });
+}
+
+/**
+ * Pack already-formatted text messages into ≤`hardLimit` strings. Text-only
+ * spine of {@link chunkUnits}, kept for callers that chunk plain markdown
+ * (e.g. ticket-create answer posts).
  */
 export function chunkByMessageBoundary(
   formattedMessages: string[],
   softLimit: number = CHUNK_SOFT_LIMIT,
   hardLimit: number = CHUNK_HARD_LIMIT,
 ): string[] {
-  const chunks: string[] = [];
-  let buffer = '';
-  const flush = () => {
-    if (buffer) {
-      chunks.push(buffer);
-      buffer = '';
-    }
-  };
-
-  for (const message of formattedMessages) {
-    const pieces = message.length <= softLimit ? [message] : splitFormattedMessage(message, softLimit);
-    for (const piece of pieces) {
-      if (buffer && buffer.length + 2 + piece.length > softLimit) flush();
-      buffer = buffer ? `${buffer}\n\n${piece}` : piece;
-    }
-  }
-  flush();
-
-  return chunks.flatMap(chunk => (chunk.length <= hardLimit ? [chunk] : hardSlice(chunk, hardLimit)));
+  return chunkUnits(
+    formattedMessages.map(text => ({ text, files: [] })),
+    softLimit,
+    hardLimit,
+  ).map(chunk => chunk.content);
 }
 
 function shouldIncludeMessage(msg: TranscriptMessage): boolean {
@@ -340,29 +527,30 @@ function shouldIncludeMessage(msg: TranscriptMessage): boolean {
 }
 
 /**
- * End-to-end builder. Filters out system/UI noise, formats survivors,
- * and chunks them to fit Discord's per-message limit.
+ * End-to-end builder. Filters out system/UI noise, formats survivors
+ * chat-style, and chunks them (text + attachment payloads) to fit Discord's
+ * per-message limits.
  */
 export function buildTranscript(messages: TranscriptMessage[], metadata: TicketMetadata): TranscriptResult {
   const kept = messages.filter(shouldIncludeMessage);
   const attachmentCount = kept.reduce((sum, m) => sum + m.attachments.length, 0);
-  const header = formatHeader(metadata, kept.length, attachmentCount);
+  const headerData = buildHeaderData(metadata, kept.length, attachmentCount);
 
   if (kept.length === 0) {
     const hadAny = messages.length > 0;
     return {
-      header,
-      chunks: [hadAny ? '*(No human messages)*' : '*(No messages)*'],
+      headerData,
+      chunks: [{ content: hadAny ? '*(No human messages)*' : '*(No messages)*', files: [] }],
       messageCount: 0,
       attachmentCount: 0,
     };
   }
 
-  const formatted = kept.map(formatMessage);
-  const chunks = chunkByMessageBoundary(formatted);
+  const units = buildUnits(kept, { createdById: metadata.createdById, assignedToId: metadata.assignedToId });
+  const chunks = chunkUnits(units, CHUNK_SOFT_LIMIT, CHUNK_HARD_LIMIT);
 
   return {
-    header,
+    headerData,
     chunks,
     messageCount: kept.length,
     attachmentCount,

--- a/src/utils/ticket/transcriptBuilder.ts
+++ b/src/utils/ticket/transcriptBuilder.ts
@@ -24,6 +24,7 @@
 
 import { TEXT_LIMITS } from '../constants';
 import { toUnixSeconds } from '../time';
+import { escapeDiscordMarkdown } from '../validation/inputSanitizer';
 
 /** Per-message shape the fetcher hands to the builder. */
 export interface TranscriptMessage {
@@ -185,20 +186,25 @@ export function buildHeaderData(
   };
 }
 
+/** Escape the chars that break a markdown link label (`[name](url)`). */
+function escapeLinkLabel(name: string): string {
+  return name.replace(/\\/g, '\\\\').replace(/([[\]])/g, '\\$1');
+}
+
 function formatAttachment(a: TranscriptAttachment): string {
-  if (!a.url) return `📎 ~~${a.name}~~ (unavailable)`;
+  if (!a.url) return `📎 ~~${escapeLinkLabel(a.name)}~~ (unavailable)`;
   // <url> suppresses Discord's link preview — the re-uploaded file on the
   // same chunk is the visible copy; the link is the fallback if that fails.
-  return `📎 [${a.name}](<${a.url}>)`;
+  return `📎 [${escapeLinkLabel(a.name)}](<${a.url}>)`;
 }
 
 function formatSticker(s: TranscriptSticker): string {
-  if (!s.url) return `🏷️ Sticker: ${s.name}`;
-  return `🏷️ Sticker: [${s.name}](${s.url})`;
+  if (!s.url) return `🏷️ Sticker: ${escapeLinkLabel(s.name)}`;
+  return `🏷️ Sticker: [${escapeLinkLabel(s.name)}](${s.url})`;
 }
 
 function formatPoll(poll: TranscriptPoll): string[] {
-  const lines = [`📊 **Poll:** ${poll.question}`];
+  const lines = [`📊 **Poll:** ${escapeDiscordMarkdown(poll.question)}`];
   for (const answer of poll.answers) {
     const votes = `${answer.voteCount} vote${answer.voteCount === 1 ? '' : 's'}`;
     lines.push(`• ${answer.text} — ${votes}`);
@@ -225,6 +231,31 @@ function formatEmbedBody(embed: TranscriptEmbed): string[] {
   return blockquote(parts.join('\n')).split('\n');
 }
 
+/** A user line masquerading as our author-line chrome: optional badge, bold name, · timestamp. */
+const AUTHOR_CHROME_SPOOF_RE = /^\s*(?:👤|🛡️|🤖)?\s*\*\*.+\*\*\s*·\s*<t:\d+:[a-zA-Z]>/;
+/** A user line masquerading as our `-# ` subtext chrome (day dividers). */
+const SUBTEXT_SPOOF_RE = /^-#\s/;
+
+/**
+ * Neutralize user content lines that mimic the transcript's own chrome
+ * (author lines, day dividers). Plain bodies made spoofing possible: a user
+ * could type '🛡️ **Admin** · <t:1:t>' and fabricate a staff message in the
+ * moderation archive. A zero-width space breaks the markdown while keeping
+ * the text readable; only chrome-shaped lines are touched — everything else
+ * stays a verbatim carbon copy.
+ */
+function neutralizeChromeSpoofs(content: string): string {
+  const ZWSP = '\u200B';
+  return content
+    .split('\n')
+    .map(line => {
+      if (SUBTEXT_SPOOF_RE.test(line)) return line.replace('-#', `-${ZWSP}#`);
+      if (AUTHOR_CHROME_SPOOF_RE.test(line)) return line.replace('**', `*${ZWSP}*`);
+      return line;
+    })
+    .join('\n');
+}
+
 /** Body lines only — used for both fresh messages and grouped continuations. */
 function formatMessageBody(msg: TranscriptMessage): string {
   const bodyLines: string[] = [];
@@ -232,7 +263,7 @@ function formatMessageBody(msg: TranscriptMessage): string {
   // Full content — never truncated. Oversized messages are split across
   // chunks by the chunker so nothing is ever lost.
   if (msg.content) {
-    bodyLines.push(msg.content);
+    bodyLines.push(neutralizeChromeSpoofs(msg.content));
   }
 
   for (const embed of msg.embeds) {

--- a/src/utils/ticket/transcriptPoster.ts
+++ b/src/utils/ticket/transcriptPoster.ts
@@ -8,12 +8,18 @@
  * Attachments are DOWNLOADED and RE-UPLOADED here (v3.14.0): the original
  * CDN links are signed URLs that expire — and the source channel is deleted
  * right after archiving — so re-hosting the files on the archive thread is
- * the only way pictures/videos stay viewable. Failures degrade gracefully:
- * an oversized or undownloadable file falls back to the masked link already
- * present in the chunk text; a send that Discord rejects for its payload is
- * retried without files. Never pings (historical content), attributes a
- * failed send to its chunk index so a partial-archive failure is diagnosable,
- * and rethrows so the caller marks the archive failed.
+ * the only way pictures/videos stay viewable. Failure ladder, in order:
+ *   1. files are sent in aggregate-size-capped batches so one send never
+ *      exceeds the guild upload budget;
+ *   2. a batch Discord still rejects (40005/50035/413) is demoted to
+ *      per-file sends, so one oversized payload can't sink its neighbors;
+ *   3. a single file Discord rejects falls back to the masked CDN link
+ *      already present in the chunk text;
+ *   4. any NON-rejection error (permissions, network) rethrows so the caller
+ *      marks the archive failed and preserves the source channel for retry —
+ *      swallowing those would silently lose the files forever.
+ * Never pings (historical content) and attributes a failed send to its chunk
+ * index so a partial-archive failure is diagnosable.
  */
 import {
   AttachmentBuilder,
@@ -22,7 +28,7 @@ import {
   type ForumThreadChannel,
   type MessageCreateOptions,
 } from 'discord.js';
-import { MAX } from '../constants';
+import { MAX, TIMEOUTS } from '../constants';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import type { TranscriptAttachment, TranscriptChunk, TranscriptHeaderData } from './transcriptBuilder';
 
@@ -48,21 +54,76 @@ export interface TranscriptPosterDeps {
 
 /**
  * Fetch an attachment's bytes for re-upload. Returns null (link-only
- * fallback) when the file is over the re-upload cap or the fetch fails —
- * the chunk text already carries a masked link for exactly that case.
+ * fallback) when the file is over the re-upload cap, the fetch fails, or the
+ * CDN stalls past the timeout — the chunk text already carries a masked link
+ * for exactly that case. The cap is enforced three times: declared size,
+ * Content-Length header, and the actual buffer, so a lying header can't make
+ * us hold an arbitrarily large body in memory.
  */
-async function downloadAttachment(attachment: TranscriptAttachment): Promise<Buffer | null> {
+export async function downloadAttachment(attachment: TranscriptAttachment): Promise<Buffer | null> {
   if (attachment.size !== undefined && attachment.size > MAX.TRANSCRIPT_REUPLOAD_BYTES) return null;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUTS.TRANSCRIPT_DOWNLOAD);
   try {
-    const res = await fetch(attachment.url);
+    const res = await fetch(attachment.url, { signal: controller.signal });
     if (!res.ok) return null;
-    return Buffer.from(await res.arrayBuffer());
+    const contentLength = Number(res.headers.get('content-length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX.TRANSCRIPT_REUPLOAD_BYTES) return null;
+    const buffer = Buffer.from(await res.arrayBuffer());
+    return buffer.byteLength <= MAX.TRANSCRIPT_REUPLOAD_BYTES ? buffer : null;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
 const defaultDeps: TranscriptPosterDeps = { download: downloadAttachment };
+
+interface DownloadedFile {
+  name: string;
+  buffer: Buffer;
+}
+
+/**
+ * True when Discord rejected the payload itself (too large / invalid form) —
+ * the only failures where retrying without (some) files makes sense. Anything
+ * else (permissions, rate limit, network) must propagate to the archive-retry
+ * path instead of silently dropping files.
+ */
+export function isUploadRejection(error: unknown): boolean {
+  const code = (error as { code?: number | string })?.code;
+  if (code === 40005 || code === 50035) return true;
+  const status = (error as { status?: number })?.status;
+  return status === 413;
+}
+
+/**
+ * Greedy, order-preserving batching so no single send's aggregate file size
+ * exceeds `budget`. Discord enforces a total-request cap separate from the
+ * per-file limit — ten individually-fine files can still sink one send.
+ */
+export function batchBySize(
+  files: DownloadedFile[],
+  budget: number = MAX.TRANSCRIPT_REUPLOAD_BYTES,
+): DownloadedFile[][] {
+  const batches: DownloadedFile[][] = [];
+  let current: DownloadedFile[] = [];
+  let currentBytes = 0;
+  for (const file of files) {
+    if (current.length > 0 && currentBytes + file.buffer.byteLength > budget) {
+      batches.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(file);
+    currentBytes += file.buffer.byteLength;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+const toBuilders = (files: DownloadedFile[]) => files.map(f => new AttachmentBuilder(f.buffer, { name: f.name }));
 
 export async function postTranscriptToThread(
   thread: ForumThreadChannel,
@@ -71,48 +132,68 @@ export async function postTranscriptToThread(
   deps: TranscriptPosterDeps = defaultDeps,
 ): Promise<void> {
   const label = ctx.label ?? 'Transcript';
+  const noPing: MessageCreateOptions['allowedMentions'] = { parse: [] };
+
+  /** Per-file rescue: send each alone; a rejected single file keeps its link fallback. */
+  const sendPerFile = async (files: DownloadedFile[]): Promise<void> => {
+    for (const file of files) {
+      try {
+        await thread.send({ files: toBuilders([file]), allowedMentions: noPing });
+      } catch (error) {
+        if (!isUploadRejection(error)) throw error;
+        enhancedLogger.warn(`${label} attachment rejected by Discord — link fallback stands`, LogCategory.SYSTEM, {
+          guildId: ctx.guildId,
+          channelId: ctx.channelId,
+          attachment: file.name,
+        });
+      }
+    }
+  };
+
   for (let i = 0; i < chunks.length; i++) {
     const chunk = chunks[i];
-
-    const files: AttachmentBuilder[] = [];
-    if (chunk.files.length > 0) {
-      const buffers = await Promise.all(chunk.files.map(f => deps.download(f)));
-      for (let j = 0; j < chunk.files.length; j++) {
-        const buffer = buffers[j];
+    try {
+      const downloaded: DownloadedFile[] = [];
+      for (const attachment of chunk.files) {
+        const buffer = await deps.download(attachment);
         if (buffer) {
-          files.push(new AttachmentBuilder(buffer, { name: chunk.files[j].name }));
+          downloaded.push({ name: attachment.name, buffer });
         } else {
           // Masked link in the chunk text is the fallback copy.
           enhancedLogger.warn(`${label} attachment not re-uploaded (too large or fetch failed)`, LogCategory.SYSTEM, {
             guildId: ctx.guildId,
             channelId: ctx.channelId,
-            attachment: chunk.files[j].name,
+            attachment: attachment.name,
           });
         }
       }
-    }
+      const batches = batchBySize(downloaded);
 
-    const payload: MessageCreateOptions = { content: chunk.content, allowedMentions: { parse: [] } };
-    try {
-      if (files.length > 0) {
+      // Text (+ first file batch) — the text itself must always land.
+      const payload: MessageCreateOptions = { content: chunk.content, allowedMentions: noPing };
+      if (batches.length === 0) {
+        await thread.send(payload);
+      } else {
         try {
-          await thread.send({ ...payload, files });
-          continue;
+          await thread.send({ ...payload, files: toBuilders(batches[0]) });
         } catch (error) {
-          // Payload rejected (e.g. over the guild's upload limit) — the text
-          // with its fallback links still must land, so retry without files.
-          enhancedLogger.warn(
-            `${label} chunk ${i + 1}/${chunks.length} file upload failed — sending text only`,
-            LogCategory.SYSTEM,
-            {
-              guildId: ctx.guildId,
-              channelId: ctx.channelId,
-              error: error instanceof Error ? error.message : String(error),
-            },
-          );
+          if (!isUploadRejection(error)) throw error;
+          // Batch rejected despite the size budget (e.g. stricter guild cap):
+          // land the text, then rescue the files one by one.
+          await thread.send(payload);
+          await sendPerFile(batches[0]);
         }
       }
-      await thread.send(payload);
+
+      // Overflow batches ride as follow-up file-only sends.
+      for (const batch of batches.slice(1)) {
+        try {
+          await thread.send({ files: toBuilders(batch), allowedMentions: noPing });
+        } catch (error) {
+          if (!isUploadRejection(error)) throw error;
+          await sendPerFile(batch);
+        }
+      }
     } catch (error) {
       enhancedLogger.error(
         `${label} chunk ${i + 1}/${chunks.length} failed to post`,

--- a/src/utils/ticket/transcriptPoster.ts
+++ b/src/utils/ticket/transcriptPoster.ts
@@ -1,14 +1,30 @@
 /**
- * Posts a built transcript's chunks into a forum archive thread.
+ * Posts a built transcript into a forum archive thread.
  *
  * Shared spine of the ticket and application close workflows (near-mirror
  * archive paths). Kept separate from the pure `transcriptBuilder` so that
- * module stays Discord-client-free. Never pings (historical content),
- * attributes a failed send to its chunk index so a partial-archive failure is
- * diagnosable, and rethrows so the caller marks the archive failed.
+ * module stays Discord-client-free.
+ *
+ * Attachments are DOWNLOADED and RE-UPLOADED here (v3.14.0): the original
+ * CDN links are signed URLs that expire — and the source channel is deleted
+ * right after archiving — so re-hosting the files on the archive thread is
+ * the only way pictures/videos stay viewable. Failures degrade gracefully:
+ * an oversized or undownloadable file falls back to the masked link already
+ * present in the chunk text; a send that Discord rejects for its payload is
+ * retried without files. Never pings (historical content), attributes a
+ * failed send to its chunk index so a partial-archive failure is diagnosable,
+ * and rethrows so the caller marks the archive failed.
  */
-import type { ForumThreadChannel } from 'discord.js';
+import {
+  AttachmentBuilder,
+  type ColorResolvable,
+  EmbedBuilder,
+  type ForumThreadChannel,
+  type MessageCreateOptions,
+} from 'discord.js';
+import { MAX } from '../constants';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+import type { TranscriptAttachment, TranscriptChunk, TranscriptHeaderData } from './transcriptBuilder';
 
 export interface TranscriptPostContext {
   guildId: string;
@@ -17,15 +33,86 @@ export interface TranscriptPostContext {
   label?: string;
 }
 
+/** Turns the builder's pure header data into the archive post's embed card. */
+export function buildHeaderEmbed(data: TranscriptHeaderData, color: ColorResolvable): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(data.title)
+    .setColor(color)
+    .addFields(data.fields.map(f => ({ name: f.name, value: f.value, inline: f.inline })));
+}
+
+/** Injectable download seam so tests never hit the network. */
+export interface TranscriptPosterDeps {
+  download: (attachment: TranscriptAttachment) => Promise<Buffer | null>;
+}
+
+/**
+ * Fetch an attachment's bytes for re-upload. Returns null (link-only
+ * fallback) when the file is over the re-upload cap or the fetch fails —
+ * the chunk text already carries a masked link for exactly that case.
+ */
+async function downloadAttachment(attachment: TranscriptAttachment): Promise<Buffer | null> {
+  if (attachment.size !== undefined && attachment.size > MAX.TRANSCRIPT_REUPLOAD_BYTES) return null;
+  try {
+    const res = await fetch(attachment.url);
+    if (!res.ok) return null;
+    return Buffer.from(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+const defaultDeps: TranscriptPosterDeps = { download: downloadAttachment };
+
 export async function postTranscriptToThread(
   thread: ForumThreadChannel,
-  chunks: string[],
+  chunks: TranscriptChunk[],
   ctx: TranscriptPostContext,
+  deps: TranscriptPosterDeps = defaultDeps,
 ): Promise<void> {
   const label = ctx.label ?? 'Transcript';
   for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+
+    const files: AttachmentBuilder[] = [];
+    if (chunk.files.length > 0) {
+      const buffers = await Promise.all(chunk.files.map(f => deps.download(f)));
+      for (let j = 0; j < chunk.files.length; j++) {
+        const buffer = buffers[j];
+        if (buffer) {
+          files.push(new AttachmentBuilder(buffer, { name: chunk.files[j].name }));
+        } else {
+          // Masked link in the chunk text is the fallback copy.
+          enhancedLogger.warn(`${label} attachment not re-uploaded (too large or fetch failed)`, LogCategory.SYSTEM, {
+            guildId: ctx.guildId,
+            channelId: ctx.channelId,
+            attachment: chunk.files[j].name,
+          });
+        }
+      }
+    }
+
+    const payload: MessageCreateOptions = { content: chunk.content, allowedMentions: { parse: [] } };
     try {
-      await thread.send({ content: chunks[i], allowedMentions: { parse: [] } });
+      if (files.length > 0) {
+        try {
+          await thread.send({ ...payload, files });
+          continue;
+        } catch (error) {
+          // Payload rejected (e.g. over the guild's upload limit) — the text
+          // with its fallback links still must land, so retry without files.
+          enhancedLogger.warn(
+            `${label} chunk ${i + 1}/${chunks.length} file upload failed — sending text only`,
+            LogCategory.SYSTEM,
+            {
+              guildId: ctx.guildId,
+              channelId: ctx.channelId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      }
+      await thread.send(payload);
     } catch (error) {
       enhancedLogger.error(
         `${label} chunk ${i + 1}/${chunks.length} failed to post`,

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -68,8 +68,10 @@ function makeFakeThread(id = "new-thread-1") {
   const state = { id, sentMessages: [] as string[] };
   return {
     ...state,
-    send: jest.fn(async ({ content }: { content: string }) => {
-      state.sentMessages.push(content);
+    send: jest.fn(async ({ content, embeds }: { content?: string; embeds?: any[] }) => {
+      // Embed-only sends (header cards) are recorded as a tagged title line so
+      // assertions can distinguish them from transcript text chunks.
+      state.sentMessages.push(content ?? `[embed] ${embeds?.[0]?.data?.title ?? ""}`);
       return { id: `${id}-msg-${state.sentMessages.length}` };
     }),
   };
@@ -162,7 +164,7 @@ describe("archiveAndCloseApplication", () => {
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("re-close append: posts separator into the existing thread, no new thread", async () => {
+  test("re-close append: posts header embed into the existing thread, no new thread", async () => {
     fakeRepoState.findOneByResult = { messageId: "existing-app-thread" };
     const client = makeFakeClient(forumChannel);
     const result = await archiveAndCloseApplication(
@@ -178,7 +180,31 @@ describe("archiveAndCloseApplication", () => {
     expect(forumChannel.threads.create).not.toHaveBeenCalled();
     expect(forumChannel.threads.fetch).toHaveBeenCalledWith("existing-app-thread", { force: true });
     const thread = forumState.threadsFetched.get("existing-app-thread");
-    expect(thread.sentMessages[0]).toContain("━━━");
+    expect(thread.sentMessages[0]).toContain("[embed] 📋");
+    expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-close with a NULL messageId row: creates a thread and repoints (no silent loss)", async () => {
+    // Pre-fix, a row with messageId=null matched neither branch: `archived`
+    // stayed true and the channel was deleted with the transcript never
+    // posted anywhere. It must take the recreate path instead.
+    fakeRepoState.findOneByResult = { messageId: null };
+    const client = makeFakeClient(forumChannel);
+
+    const result = await archiveAndCloseApplication(
+      client,
+      makeApplication(),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
+    expect(forumChannel.threads.fetch).not.toHaveBeenCalled();
+    expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
+    expect(fakeRepoState.saveCalls).toHaveLength(1);
+    expect(fakeRepoState.saveCalls[0].messageId).toBe(forumState.threadsCreated[0].id);
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/utils/fetchAllMessages.test.ts
+++ b/tests/unit/utils/fetchAllMessages.test.ts
@@ -165,9 +165,9 @@ describe('fetch → build integration', () => {
 
     const result = buildTranscript(transcriptMessages, META);
     for (const chunk of result.chunks) {
-      expect(chunk.length).toBeLessThanOrEqual(2000);
+      expect(chunk.content.length).toBeLessThanOrEqual(2000);
     }
-    const flat = result.chunks.join('\n').replace(/\n> /g, '').replace(/^> /gm, '');
+    const flat = result.chunks.map(c => c.content).join('\n');
     expect(flat).toContain('START-');
     expect(flat).toContain('-END');
     expect(flat.split('q').length - 1).toBe(5000);

--- a/tests/unit/utils/fetchAllMessages.test.ts
+++ b/tests/unit/utils/fetchAllMessages.test.ts
@@ -156,6 +156,22 @@ describe('fetchMessagesAsTranscript mapping', () => {
   });
 });
 
+describe('attachment mapping', () => {
+  test('maps name, url, contentType, and size (the size gates the re-upload cap)', async () => {
+    const msg = makeMsg({
+      attachments: new Map([
+        ['1', { name: 'shot.png', url: 'https://cdn/shot.png', contentType: 'image/png', size: 12345 }],
+        ['2', { name: 'clip.mp4', url: 'https://cdn/clip.mp4', contentType: null, size: 999 }],
+      ]),
+    });
+    const [out] = await fetchMessagesAsTranscript(makeChannel([msg]), 'bot-id');
+    expect(out.attachments).toEqual([
+      { name: 'shot.png', url: 'https://cdn/shot.png', contentType: 'image/png', size: 12345 },
+      { name: 'clip.mp4', url: 'https://cdn/clip.mp4', contentType: undefined, size: 999 },
+    ]);
+  });
+});
+
 describe('fetch → build integration', () => {
   test('a single >2000-char message survives end-to-end with every chunk <= 2000', async () => {
     const body = `START-${'q'.repeat(5000)}-END`;

--- a/tests/unit/utils/ticket/closeWorkflow.test.ts
+++ b/tests/unit/utils/ticket/closeWorkflow.test.ts
@@ -406,6 +406,31 @@ describe("archiveAndCloseTicket", () => {
     });
   });
 
+  test("email ticket with an over-long sender name clamps the thread name to Discord's 100-char limit", async () => {
+    fakeBuiltinTypeInfo.mockReturnValue(null);
+    const client = makeFakeClient(forumChannel, () => null);
+    const channel = makeFakeChannel();
+    const ticket = makeTicket({
+      isEmailTicket: true,
+      emailSender: "verbose@example.com",
+      emailSenderName: "N".repeat(150),
+      emailSubject: "hi",
+    });
+
+    const result = await archiveAndCloseTicket(
+      client,
+      ticket,
+      "guild-1",
+      channel,
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
+    const createdName = forumChannel.threads.create.mock.calls[0][0].name;
+    expect(createdName).toHaveLength(100);
+  });
+
   test("regression: a normal ticket queries the createdBy namespace with isEmailTicket:false (never an email-import archive)", async () => {
     // The reported prod bug: an email-import archive's createdBy is the
     // importing admin. A normal ticket the admin opens must NOT match it —

--- a/tests/unit/utils/ticket/closeWorkflow.test.ts
+++ b/tests/unit/utils/ticket/closeWorkflow.test.ts
@@ -156,9 +156,11 @@ function makeFakeThread(
   const state: FakeThreadState = { id, sentMessages: [] };
   return {
     ...state,
-    send: jest.fn(async ({ content }: { content: string }) => {
+    send: jest.fn(async ({ content, embeds }: { content?: string; embeds?: any[] }) => {
       if (sendError) throw sendError;
-      state.sentMessages.push(content);
+      // Embed-only sends (header cards) are recorded as a tagged title line so
+      // assertions can distinguish them from transcript text chunks.
+      state.sentMessages.push(content ?? `[embed] ${embeds?.[0]?.data?.title ?? ""}`);
       return { id: `${id}-msg-${state.sentMessages.length}` };
     }),
   };
@@ -305,10 +307,11 @@ describe("archiveAndCloseTicket", () => {
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
     expect(forumState.threadsCreated).toHaveLength(1);
-    // Header is the initial create message; transcript chunks (if any) are follow-ups.
+    // Header embed is the initial create message; transcript chunks (if any)
+    // are follow-ups.
     expect(
-      forumChannel.threads.create.mock.calls[0][0].message.content,
-    ).toContain("Ticket");
+      forumChannel.threads.create.mock.calls[0][0].message.embeds[0].data.title,
+    ).toContain("Support");
     // Forum tag ensured + applied
     expect(fakeEnsureForumTag).toHaveBeenCalledWith(
       forumChannel,
@@ -437,7 +440,7 @@ describe("archiveAndCloseTicket", () => {
     });
   });
 
-  test("re-close into existing archive: appends separator + posts to existing thread", async () => {
+  test("re-close into existing archive: appends header embed + posts to existing thread", async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
       typeId: "general",
       displayName: "General",
@@ -471,8 +474,8 @@ describe("archiveAndCloseTicket", () => {
     );
     const existingThread = forumState.threadsFetched.get("existing-thread-9");
     expect(existingThread.sentMessages.length).toBeGreaterThan(0);
-    // First sent message starts with the separator
-    expect(existingThread.sentMessages[0]).toContain("━━━");
+    // First sent message is the header embed — the visual divider between closes
+    expect(existingThread.sentMessages[0]).toContain("[embed] 🎫");
     // Tag already in existing array — no extra applyForumTags or save
     expect(fakeApplyForumTags).not.toHaveBeenCalled();
     expect(fakeRepoState.saveCalls).toHaveLength(0);
@@ -670,6 +673,42 @@ describe("archiveAndCloseTicket", () => {
     expect(saved.forumTagIds).toEqual(["tag-old", "tag-123"]);
     // Recovery succeeded → channel deleted as normal.
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-close with a NULL messageId row: creates a thread and repoints (no silent loss)", async () => {
+    // Pre-fix, a row with messageId=null matched neither branch: `archived`
+    // stayed true and the channel was deleted with the transcript never
+    // posted anywhere. It must take the recreate path instead.
+    fakeBuiltinTypeInfo.mockReturnValue({
+      typeId: "general",
+      displayName: "General",
+      emoji: null,
+    });
+    fakeRepoState.findOneByResult = { messageId: null, forumTagIds: [] };
+    const client = makeFakeClient(forumChannel, () => ({
+      username: "creator",
+    }));
+    const channel = makeFakeChannel();
+    const ticket = makeTicket({ type: "general" });
+
+    const result = await archiveAndCloseTicket(
+      client,
+      ticket,
+      "guild-1",
+      channel,
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
+    expect(forumChannel.threads.fetch).not.toHaveBeenCalled();
+    expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
+    expect(fakeRepoState.saveCalls).toHaveLength(1);
+    expect(fakeRepoState.saveCalls[0].messageId).toBe(
+      forumState.threadsCreated[0].id,
+    );
+    // Transcript landed in the new thread (header embed + at least one chunk).
+    expect(forumState.threadsCreated[0].sentMessages.length).toBeGreaterThan(0);
   });
 
   test("re-close where thread fetch fails NON-10003: bubbles, archive fails, channel preserved", async () => {

--- a/tests/unit/utils/ticket/transcriptBuilder.test.ts
+++ b/tests/unit/utils/ticket/transcriptBuilder.test.ts
@@ -3,15 +3,15 @@
  *
  * The builder is pure over TranscriptMessage[] — no Discord client — so
  * these tests can drive it with synthetic arrays and assert on the exact
- * markdown output.
+ * markdown output (chat-style format, v3.14.0).
  */
 
 import { describe, expect, test } from "bun:test";
 import {
+  buildHeaderData,
   buildTranscript,
   chunkByMessageBoundary,
   formatDurationShort,
-  formatHeader,
   formatMessage,
   type TicketMetadata,
   type TranscriptMessage,
@@ -43,6 +43,11 @@ const META: TicketMetadata = {
   assignedToUsername: "staff_bob",
 };
 
+/** Joined text of all chunk contents — the "what does the archive say" view. */
+function joinedContent(result: ReturnType<typeof buildTranscript>): string {
+  return result.chunks.map((c) => c.content).join("\n");
+}
+
 describe("formatDurationShort()", () => {
   test("under a minute renders as <1m", () => {
     expect(formatDurationShort(5_000)).toBe("<1m");
@@ -71,52 +76,105 @@ describe("formatDurationShort()", () => {
   });
 });
 
-// truncateLongMessage was removed in v3.2.1 — content is split across chunks,
-// never truncated. The carbon-copy guarantees are covered by the formatMessage
-// and chunkByMessageBoundary suites below.
-
-describe("formatHeader()", () => {
-  test("contains all required metadata lines", () => {
-    const header = formatHeader(META, 5, 2);
-    expect(header).toContain("# 🎫 Ticket: Ban Appeal");
-    expect(header).toContain("**Created by:** alice");
-    expect(header).toContain("**Type:** Ban Appeal");
-    expect(header).toContain("**Assigned to:** staff_bob");
-    expect(header).toContain("**Messages:** 5");
-    expect(header).toContain("**Attachments:** 2");
-    expect(header).toContain("**Duration:** 2h 14m");
+describe("buildHeaderData()", () => {
+  test("ticket header carries all metadata fields", () => {
+    const header = buildHeaderData(META, 5, 2);
+    expect(header.title).toBe("🎫 Ban Appeal");
+    const byName = Object.fromEntries(
+      header.fields.map((f) => [f.name, f.value]),
+    );
+    expect(byName["Created by"]).toBe("alice");
+    expect(byName.Type).toBe("Ban Appeal");
+    expect(byName["Assigned to"]).toBe("staff_bob");
+    expect(byName.Duration).toBe("2h 14m");
+    expect(byName.Messages).toBe("5 · 2 📎");
+    expect(byName.Opened).toMatch(/^<t:\d+:f>$/);
+    expect(byName.Closed).toMatch(/^<t:\d+:f>$/);
   });
 
-  test("omits the attachments line when count is zero", () => {
-    const header = formatHeader(META, 3, 0);
-    expect(header).not.toContain("**Attachments:**");
+  test("messages field omits the attachment count when zero", () => {
+    const header = buildHeaderData(META, 3, 0);
+    const messages = header.fields.find((f) => f.name === "Messages");
+    expect(messages?.value).toBe("3");
   });
 
-  test("renders Unassigned when assigneeUsername is null", () => {
-    const header = formatHeader({ ...META, assignedToUsername: null }, 1, 0);
-    expect(header).toContain("**Assigned to:** Unassigned");
+  test("unassigned ticket renders Unassigned", () => {
+    const header = buildHeaderData({ ...META, assignedToUsername: null }, 1, 0);
+    const assigned = header.fields.find((f) => f.name === "Assigned to");
+    expect(assigned?.value).toBe("Unassigned");
+  });
+
+  test("application kind gets the 📋 emoji and omits the empty assignee row", () => {
+    const header = buildHeaderData(
+      { ...META, kind: "application", assignedToUsername: null },
+      1,
+      0,
+    );
+    expect(header.title).toBe("📋 Ban Appeal");
+    expect(header.fields.find((f) => f.name === "Assigned to")).toBeUndefined();
   });
 });
 
 describe("formatMessage()", () => {
-  test("plain text becomes a blockquote", () => {
+  test("plain text renders unquoted under a name + short-time line", () => {
     const out = formatMessage(makeMessage({ content: "Hello\nWorld" }));
-    expect(out).toContain("**alice**");
-    expect(out).toContain("> Hello");
-    expect(out).toContain("> World");
+    expect(out).toMatch(/^\*\*alice\*\* · <t:\d+:t>\nHello\nWorld$/);
   });
 
-  test("reply adds ↩️ suffix with original author", () => {
+  test("bot author gets a 🤖 badge", () => {
+    const out = formatMessage(
+      makeMessage({ author: { username: "cogworks", id: "999", bot: true } }),
+    );
+    expect(out).toContain("🤖 **cogworks** ·");
+  });
+
+  test("opener and assignee get 👤 / 🛡️ badges, others none", () => {
+    const badges = { createdById: "111", assignedToId: "222" };
+    expect(formatMessage(makeMessage(), badges)).toContain("👤 **alice**");
+    expect(
+      formatMessage(
+        makeMessage({ author: { username: "staff_bob", id: "222", bot: false } }),
+        badges,
+      ),
+    ).toContain("🛡️ **staff_bob**");
+    expect(
+      formatMessage(
+        makeMessage({ author: { username: "carol", id: "333", bot: false } }),
+        badges,
+      ),
+    ).toStartWith("**carol**");
+  });
+
+  test("reply adds ↳ marker with a context snippet", () => {
     const out = formatMessage(
       makeMessage({
         content: "got it",
         replyTo: { author: "staff_bob", content: "please confirm" },
       }),
     );
-    expect(out).toContain("↩️ *replying to staff_bob*");
+    expect(out).toContain('↳ *to staff_bob: "please confirm"*');
   });
 
-  test("multiple attachments render each on its own line", () => {
+  test("reply snippet strips markdown, collapses whitespace, and truncates", () => {
+    const out = formatMessage(
+      makeMessage({
+        content: "ok",
+        replyTo: { author: "bob", content: `**bold**\nand ${"x".repeat(80)}` },
+      }),
+    );
+    expect(out).toContain('↳ *to bob: "bold and x');
+    expect(out).toContain("…");
+    expect(out).not.toContain("**bold**");
+  });
+
+  test("reply to an empty-bodied message falls back to the bare marker", () => {
+    const out = formatMessage(
+      makeMessage({ content: "ok", replyTo: { author: "bob", content: "" } }),
+    );
+    expect(out).toContain("↳ *to bob*");
+  });
+
+  test("multiple attachments render each as a preview-suppressed link line", () => {
     const out = formatMessage(
       makeMessage({
         content: "",
@@ -130,8 +188,8 @@ describe("formatMessage()", () => {
         ],
       }),
     );
-    expect(out).toContain("> 📎 [img.png](https://cdn/img.png)");
-    expect(out).toContain("> 📎 [log.txt](https://cdn/log.txt)");
+    expect(out).toContain("📎 [img.png](<https://cdn/img.png>)");
+    expect(out).toContain("📎 [log.txt](<https://cdn/log.txt>)");
   });
 
   test("attachment with empty URL renders as unavailable", () => {
@@ -141,17 +199,16 @@ describe("formatMessage()", () => {
         attachments: [{ name: "gone.pdf", url: "" }],
       }),
     );
-    expect(out).toContain("> 📎 ~~gone.pdf~~ (unavailable)");
+    expect(out).toContain("📎 ~~gone.pdf~~ (unavailable)");
   });
 
-  test("code block content is preserved inside the blockquote", () => {
+  test("code block content is preserved verbatim", () => {
     const content = "```js\nconst x = 1;\n```";
     const out = formatMessage(makeMessage({ content }));
-    expect(out).toContain("> ```js");
-    expect(out).toContain("> const x = 1;");
+    expect(out).toContain("```js\nconst x = 1;\n```");
   });
 
-  test("embed with title + description renders indented under the message", () => {
+  test("embed with title + description renders blockquoted under the message", () => {
     const out = formatMessage(
       makeMessage({
         content: "",
@@ -160,8 +217,8 @@ describe("formatMessage()", () => {
         ],
       }),
     );
-    expect(out).toContain("**Heads up**");
-    expect(out).toContain("This is important");
+    expect(out).toContain("> **Heads up**");
+    expect(out).toContain("> This is important");
   });
 
   test("empty message falls back to placeholder so the header still lines up", () => {
@@ -173,8 +230,6 @@ describe("formatMessage()", () => {
     const body = "x".repeat(2000);
     const out = formatMessage(makeMessage({ content: body }));
     expect(out).not.toContain("… (truncated)");
-    // Every original character survives (blockquote prefixes add `> ` but the
-    // body text itself is intact).
     expect(out).toContain(body);
   });
 
@@ -185,7 +240,7 @@ describe("formatMessage()", () => {
         stickers: [{ name: "party", url: "https://cdn/sticker.png" }],
       }),
     );
-    expect(out).toContain("> 🏷️ Sticker: [party](https://cdn/sticker.png)");
+    expect(out).toContain("🏷️ Sticker: [party](https://cdn/sticker.png)");
   });
 
   test("renders a poll with question + per-answer vote counts", () => {
@@ -201,9 +256,9 @@ describe("formatMessage()", () => {
         },
       }),
     );
-    expect(out).toContain("> 📊 **Poll:** Best color?");
-    expect(out).toContain("> • Red — 3 votes");
-    expect(out).toContain("> • Blue — 1 vote");
+    expect(out).toContain("📊 **Poll:** Best color?");
+    expect(out).toContain("• Red — 3 votes");
+    expect(out).toContain("• Blue — 1 vote");
   });
 
   test("renders embed image + footer + author + linked title", () => {
@@ -253,7 +308,7 @@ describe("chunkByMessageBoundary()", () => {
     // must split across chunks with zero content loss.
     const lines = Array.from(
       { length: 30 },
-      (_, i) => `> line ${i} ${"y".repeat(190)}`,
+      (_, i) => `line ${i} ${"y".repeat(190)}`,
     );
     const oversize = lines.join("\n");
     const chunks = chunkByMessageBoundary([oversize], 1900, 2000);
@@ -283,11 +338,9 @@ describe("chunkByMessageBoundary()", () => {
     // Force a split mid-fence: a long fenced block as one formatted message.
     const codeLines = Array.from(
       { length: 40 },
-      (_, i) => `> const v${i} = ${"a".repeat(60)};`,
+      (_, i) => `const v${i} = ${"a".repeat(60)};`,
     );
-    const message = ["**alice** ts", "> ```js", ...codeLines, "> ```"].join(
-      "\n",
-    );
+    const message = ["**alice** ts", "```js", ...codeLines, "```"].join("\n");
     const chunks = chunkByMessageBoundary([message], 1900, 2000);
     expect(chunks.length).toBeGreaterThan(1);
     // Each chunk has a balanced number of ``` fences (so each renders cleanly).
@@ -297,19 +350,16 @@ describe("chunkByMessageBoundary()", () => {
     }
   });
 
-  test("balances a fence nested inside a double blockquote (embed code block)", () => {
-    // Embed bodies are double-quoted (`> > `). A fence there must still toggle
-    // and rebalance at the right depth (Copilot review finding).
+  test("balances a fence nested inside a blockquote (embed code block)", () => {
+    // Embed bodies are blockquoted (`> `). A fence there must still toggle
+    // and rebalance at the right depth.
     const codeLines = Array.from(
       { length: 40 },
-      (_, i) => `> > const v${i} = ${"b".repeat(60)};`,
+      (_, i) => `> const v${i} = ${"b".repeat(60)};`,
     );
-    const message = [
-      "**author** ts",
-      "> > ```js",
-      ...codeLines,
-      "> > ```",
-    ].join("\n");
+    const message = ["**author** ts", "> ```js", ...codeLines, "> ```"].join(
+      "\n",
+    );
     const chunks = chunkByMessageBoundary([message], 1900, 2000);
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
@@ -319,9 +369,9 @@ describe("chunkByMessageBoundary()", () => {
   });
 
   test("hard-sliced long blockquoted line keeps its `> ` prefix on every continuation", () => {
-    // A 5000-char single blockquoted line (e.g. a long URL/base64). Each emitted
-    // segment must retain the `> ` prefix so continuations stay blockquoted, and
-    // nothing is dropped (Copilot review finding).
+    // A 5000-char single blockquoted line (e.g. inside an embed). Each emitted
+    // segment must retain the `> ` prefix so continuations stay blockquoted,
+    // and nothing is dropped.
     const longLine = `> ${"a".repeat(5000)}`;
     const chunks = chunkByMessageBoundary([longLine], 1900, 2000);
     const lines = chunks
@@ -354,8 +404,8 @@ describe("buildTranscript()", () => {
     ];
     const result = buildTranscript(messages, META);
     expect(result.messageCount).toBe(2);
-    expect(result.chunks.join("\n")).toContain("real message from alice");
-    expect(result.chunks.join("\n")).toContain("another real message");
+    expect(joinedContent(result)).toContain("real message from alice");
+    expect(joinedContent(result)).toContain("another real message");
   });
 
   test("counts attachments across surviving messages", () => {
@@ -380,7 +430,7 @@ describe("buildTranscript()", () => {
   test("empty ticket produces a placeholder chunk", () => {
     const result = buildTranscript([], META);
     expect(result.messageCount).toBe(0);
-    expect(result.chunks).toEqual(["*(No messages)*"]);
+    expect(result.chunks).toEqual([{ content: "*(No messages)*", files: [] }]);
   });
 
   test("bot-only ticket (only system/component noise) returns the human-empty placeholder", () => {
@@ -390,7 +440,9 @@ describe("buildTranscript()", () => {
     ];
     const result = buildTranscript(messages, META);
     expect(result.messageCount).toBe(0);
-    expect(result.chunks).toEqual(["*(No human messages)*"]);
+    expect(result.chunks).toEqual([
+      { content: "*(No human messages)*", files: [] },
+    ]);
   });
 
   test("preserves chronological ordering", () => {
@@ -410,9 +462,108 @@ describe("buildTranscript()", () => {
       }),
     ];
     const result = buildTranscript(messages, META);
-    const joined = result.chunks.join("\n");
+    const joined = joinedContent(result);
     expect(joined.indexOf("first")).toBeLessThan(joined.indexOf("second"));
     expect(joined.indexOf("second")).toBeLessThan(joined.indexOf("third"));
+  });
+
+  test("opens with a day divider and adds one per UTC day change", () => {
+    const messages: TranscriptMessage[] = [
+      makeMessage({
+        content: "day one",
+        timestamp: new Date("2026-04-01T12:00:00Z"),
+      }),
+      makeMessage({
+        content: "day two",
+        timestamp: new Date("2026-04-02T09:00:00Z"),
+      }),
+    ];
+    const result = buildTranscript(messages, META);
+    const joined = joinedContent(result);
+    expect(joined).toContain("-# ── Wednesday, April 1, 2026 ──");
+    expect(joined).toContain("-# ── Thursday, April 2, 2026 ──");
+    // Exactly two dividers — none repeated within a day.
+    expect(joined.split("-# ──").length - 1).toBe(2);
+  });
+
+  test("groups consecutive same-author messages under one name line", () => {
+    const messages: TranscriptMessage[] = [
+      makeMessage({
+        content: "part one",
+        timestamp: new Date("2026-04-01T12:00:00Z"),
+      }),
+      makeMessage({
+        content: "part two",
+        timestamp: new Date("2026-04-01T12:03:00Z"),
+      }),
+    ];
+    const result = buildTranscript(messages, META);
+    const joined = joinedContent(result);
+    expect(joined.split("**alice**").length - 1).toBe(1);
+    expect(joined).toContain("part one\npart two");
+  });
+
+  test("does NOT group across the 7-minute window, replies, or author changes", () => {
+    const messages: TranscriptMessage[] = [
+      makeMessage({
+        content: "one",
+        timestamp: new Date("2026-04-01T12:00:00Z"),
+      }),
+      makeMessage({
+        content: "fifteen minutes later",
+        timestamp: new Date("2026-04-01T12:15:00Z"),
+      }),
+      makeMessage({
+        content: "a reply",
+        timestamp: new Date("2026-04-01T12:16:00Z"),
+        replyTo: { author: "bob", content: "hi" },
+      }),
+    ];
+    const result = buildTranscript(messages, META);
+    const joined = joinedContent(result);
+    expect(joined.split("**alice**").length - 1).toBe(3);
+  });
+
+  test("attachments ride on the chunk holding their message", () => {
+    const messages: TranscriptMessage[] = [
+      makeMessage({ content: "look at this" }),
+      makeMessage({
+        content: "the screenshot",
+        timestamp: new Date("2026-04-01T12:20:00Z"),
+        attachments: [
+          { name: "a.png", url: "https://cdn/a.png", size: 100 },
+          { name: "gone.png", url: "" },
+        ],
+      }),
+      makeMessage({
+        author: { username: "bob", id: "222", bot: false },
+        content: "nice",
+        timestamp: new Date("2026-04-01T12:21:00Z"),
+      }),
+    ];
+    const result = buildTranscript(messages, META);
+    // The attachment-bearing chunk is flushed so files sit under their text.
+    const withFiles = result.chunks.filter((c) => c.files.length > 0);
+    expect(withFiles).toHaveLength(1);
+    expect(withFiles[0].content).toContain("the screenshot");
+    // Only uploadable (url-bearing) attachments become file payloads.
+    expect(withFiles[0].files).toEqual([
+      { name: "a.png", url: "https://cdn/a.png", size: 100 },
+    ]);
+  });
+
+  test("more than 10 attachments overflow into continued file-only chunks", () => {
+    const attachments = Array.from({ length: 13 }, (_, i) => ({
+      name: `f${i}.png`,
+      url: `https://cdn/f${i}.png`,
+    }));
+    const messages = [makeMessage({ content: "dump", attachments })];
+    const result = buildTranscript(messages, META);
+    const withFiles = result.chunks.filter((c) => c.files.length > 0);
+    expect(withFiles).toHaveLength(2);
+    expect(withFiles[0].files).toHaveLength(10);
+    expect(withFiles[1].files).toHaveLength(3);
+    expect(withFiles[1].content).toBe("-# 📎 (continued)");
   });
 
   test("keeps a sticker-only message (no longer filtered)", () => {
@@ -424,7 +575,7 @@ describe("buildTranscript()", () => {
     ];
     const result = buildTranscript(messages, META);
     expect(result.messageCount).toBe(1);
-    expect(result.chunks.join("\n")).toContain("Sticker: [wave]");
+    expect(joinedContent(result)).toContain("Sticker: [wave]");
   });
 
   test("keeps a poll-only message (no longer filtered)", () => {
@@ -436,7 +587,7 @@ describe("buildTranscript()", () => {
     ];
     const result = buildTranscript(messages, META);
     expect(result.messageCount).toBe(1);
-    expect(result.chunks.join("\n")).toContain("📊 **Poll:** Q?");
+    expect(joinedContent(result)).toContain("📊 **Poll:** Q?");
   });
 
   test("keeps an author/footer-only embed message (filter aligned with renderer)", () => {
@@ -448,7 +599,7 @@ describe("buildTranscript()", () => {
     ];
     const result = buildTranscript(messages, META);
     expect(result.messageCount).toBe(1);
-    const joined = result.chunks.join("\n");
+    const joined = joinedContent(result);
     expect(joined).toContain("ci-bot");
     expect(joined).toContain("v1.2.3");
   });
@@ -465,14 +616,9 @@ describe("buildTranscript()", () => {
     );
     const result = buildTranscript(messages, META);
     for (const chunk of result.chunks) {
-      expect(chunk.length).toBeLessThanOrEqual(2000);
+      expect(chunk.content.length).toBeLessThanOrEqual(2000);
     }
-    // Strip the `> ` blockquote prefixes and chunk joins, then assert every
-    // message's start and end markers survived.
-    const flat = result.chunks
-      .join("\n")
-      .replace(/\n> /g, "")
-      .replace(/^> /gm, "");
+    const flat = joinedContent(result);
     for (let i = 0; i < 8; i++) {
       expect(flat).toContain(`MSG${i}-`);
       expect(flat).toContain(`-END${i}`);

--- a/tests/unit/utils/ticket/transcriptBuilder.test.ts
+++ b/tests/unit/utils/ticket/transcriptBuilder.test.ts
@@ -113,6 +113,12 @@ describe("buildHeaderData()", () => {
     expect(header.title).toBe("📋 Ban Appeal");
     expect(header.fields.find((f) => f.name === "Assigned to")).toBeUndefined();
   });
+
+  test("titles over Discord's 256-char embed limit are clamped (long email subjects)", () => {
+    const header = buildHeaderData({ ...META, title: "s".repeat(400) }, 1, 0);
+    expect(header.title.length).toBeLessThanOrEqual(256);
+    expect(header.title.endsWith("…")).toBe(true);
+  });
 });
 
 describe("formatMessage()", () => {
@@ -200,6 +206,27 @@ describe("formatMessage()", () => {
       }),
     );
     expect(out).toContain("📎 ~~gone.pdf~~ (unavailable)");
+  });
+
+  test("attachment names with brackets can't break the link markup", () => {
+    const out = formatMessage(
+      makeMessage({
+        content: "",
+        attachments: [{ name: "a](https://evil).png", url: "https://cdn/a.png" }],
+      }),
+    );
+    expect(out).toContain("📎 [a\\](https://evil).png](<https://cdn/a.png>)");
+  });
+
+  test("user lines mimicking author chrome or day dividers are neutralized", () => {
+    const spoof = "🛡️ **Admin** · <t:1750000000:t>\n-# ── Fake Divider ──\nnormal text";
+    const out = formatMessage(makeMessage({ content: spoof }));
+    // The zero-width space breaks the fake bold/subtext markup.
+    expect(out).toContain("🛡️ *​*Admin** · <t:1750000000:t>");
+    expect(out).toContain("-​# ── Fake Divider ──");
+    expect(out).toContain("normal text");
+    // Genuine chrome from the builder itself is untouched.
+    expect(out).toMatch(/^\*\*alice\*\* · <t:\d+:t>/);
   });
 
   test("code block content is preserved verbatim", () => {

--- a/tests/unit/utils/ticket/transcriptPoster.test.ts
+++ b/tests/unit/utils/ticket/transcriptPoster.test.ts
@@ -3,31 +3,43 @@
  *
  * Drives the shared archive spine with a fake thread that records sends and
  * can be made to throw, plus an injected download fake so no test touches the
- * network. Covers post-every-chunk, no-ping, file re-upload, the text-only
- * fallback when an upload is rejected, and rethrow-on-failure behavior both
- * close workflows rely on.
+ * network. Covers post-every-chunk, no-ping, file re-upload, aggregate-size
+ * batching, the per-file rescue when Discord rejects a payload (40005), the
+ * rethrow-on-anything-else contract both close workflows rely on, and the
+ * hardened real download path (size caps, timeout seam, lying Content-Length).
  */
 
-import { describe, expect, test } from 'bun:test';
-import { buildHeaderEmbed, postTranscriptToThread } from '../../../../src/utils/ticket/transcriptPoster';
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  batchBySize,
+  buildHeaderEmbed,
+  downloadAttachment,
+  isUploadRejection,
+  postTranscriptToThread,
+} from '../../../../src/utils/ticket/transcriptPoster';
 import type { TranscriptChunk } from '../../../../src/utils/ticket/transcriptBuilder';
+import { MAX } from '../../../../src/utils/constants';
 
 interface SentPayload {
-  content: string;
+  content?: string;
   files?: unknown[];
   allowedMentions: unknown;
 }
 
-function makeThread(opts: { failAt?: number; rejectFiles?: boolean } = {}) {
+function uploadRejection(): Error {
+  return Object.assign(new Error('Request entity too large'), { code: 40005 });
+}
+
+function makeThread(opts: { failAt?: number; rejectFileSends?: 'always' | 'batch-only' } = {}) {
   const calls: SentPayload[] = [];
   let attempts = 0;
   const thread = {
     send: async (payload: SentPayload) => {
       if (opts.failAt !== undefined && attempts === opts.failAt) throw new Error('send failed');
       attempts++;
-      if (opts.rejectFiles && payload.files && payload.files.length > 0) {
-        throw new Error('Request entity too large');
-      }
+      const fileCount = payload.files?.length ?? 0;
+      if (opts.rejectFileSends === 'always' && fileCount > 0) throw uploadRejection();
+      if (opts.rejectFileSends === 'batch-only' && fileCount > 1) throw uploadRejection();
       calls.push(payload);
       return {};
     },
@@ -79,17 +91,145 @@ describe('postTranscriptToThread', () => {
 
   test('failed download degrades to a text-only send (link fallback lives in the content)', async () => {
     const { thread, calls } = makeThread();
-    await postTranscriptToThread(thread, [chunk('text', [{ name: 'a.png', url: 'https://cdn/a.png' }])], ctx, failDownload);
+    await postTranscriptToThread(
+      thread,
+      [chunk('text', [{ name: 'a.png', url: 'https://cdn/a.png' }])],
+      ctx,
+      failDownload,
+    );
     expect(calls).toHaveLength(1);
     expect(calls[0].files).toBeUndefined();
   });
 
-  test('rejected file upload retries the chunk as text-only instead of failing the archive', async () => {
-    const { thread, calls } = makeThread({ rejectFiles: true });
-    await postTranscriptToThread(thread, [chunk('big one', [{ name: 'huge.mov', url: 'https://cdn/huge.mov' }])], ctx, okDownload);
-    expect(calls).toHaveLength(1);
-    expect(calls[0].content).toBe('big one');
+  test('40005 batch rejection lands the text, then rescues each file individually', async () => {
+    const { thread, calls } = makeThread({ rejectFileSends: 'batch-only' });
+    const files = [
+      { name: 'a.png', url: 'https://cdn/a.png' },
+      { name: 'b.png', url: 'https://cdn/b.png' },
+    ];
+    await postTranscriptToThread(thread, [chunk('big batch', files)], ctx, okDownload);
+    // text-only send + one send per file
+    expect(calls).toHaveLength(3);
+    expect(calls[0].content).toBe('big batch');
     expect(calls[0].files).toBeUndefined();
+    expect(calls[1].files).toHaveLength(1);
+    expect(calls[2].files).toHaveLength(1);
+  });
+
+  test('a file Discord rejects even alone is skipped — its link fallback stands', async () => {
+    const { thread, calls } = makeThread({ rejectFileSends: 'always' });
+    await postTranscriptToThread(
+      thread,
+      [chunk('text', [{ name: 'cursed.bin', url: 'https://cdn/cursed.bin' }])],
+      ctx,
+      okDownload,
+    );
+    // batch send rejected → text lands → per-file send also rejected → skipped
+    expect(calls).toHaveLength(1);
+    expect(calls[0].content).toBe('text');
+  });
+
+  test('NON-rejection file-send errors rethrow so the archive retries (files are never silently lost)', async () => {
+    const thread = {
+      send: async (payload: SentPayload) => {
+        if ((payload.files?.length ?? 0) > 0) throw new Error('Missing Permissions');
+        return {};
+      },
+    };
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal test double
+      postTranscriptToThread(thread as any, [chunk('t', [{ name: 'a.png', url: 'https://cdn/a.png' }])], ctx, okDownload),
+    ).rejects.toThrow('Missing Permissions');
+  });
+});
+
+describe('isUploadRejection', () => {
+  test('recognizes payload rejections and nothing else', () => {
+    expect(isUploadRejection(Object.assign(new Error('x'), { code: 40005 }))).toBe(true);
+    expect(isUploadRejection(Object.assign(new Error('x'), { code: 50035 }))).toBe(true);
+    expect(isUploadRejection(Object.assign(new Error('x'), { status: 413 }))).toBe(true);
+    expect(isUploadRejection(Object.assign(new Error('x'), { code: 50013 }))).toBe(false);
+    expect(isUploadRejection(new Error('network'))).toBe(false);
+    expect(isUploadRejection(undefined)).toBe(false);
+  });
+});
+
+describe('batchBySize', () => {
+  const file = (name: string, bytes: number) => ({ name, buffer: Buffer.alloc(bytes) });
+
+  test('packs greedily under the budget, preserving order', () => {
+    const batches = batchBySize([file('a', 4), file('b', 4), file('c', 4)], 10);
+    expect(batches.map(b => b.map(f => f.name))).toEqual([['a', 'b'], ['c']]);
+  });
+
+  test('a single file over budget still gets its own batch (send decides its fate)', () => {
+    const batches = batchBySize([file('big', 20), file('a', 2)], 10);
+    expect(batches.map(b => b.map(f => f.name))).toEqual([['big'], ['a']]);
+  });
+
+  test('empty input produces no batches', () => {
+    expect(batchBySize([], 10)).toEqual([]);
+  });
+});
+
+describe('downloadAttachment (real path, mocked fetch)', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  const mockFetch = (fn: () => Promise<unknown>) => {
+    // biome-ignore lint/suspicious/noExplicitAny: fetch test double
+    globalThis.fetch = fn as any;
+  };
+
+  const okResponse = (bytes: number, contentLength?: number) => ({
+    ok: true,
+    headers: { get: (h: string) => (h === 'content-length' ? String(contentLength ?? bytes) : null) },
+    arrayBuffer: async () => new ArrayBuffer(bytes),
+  });
+
+  test('declared size over the cap skips the fetch entirely', async () => {
+    let fetched = false;
+    mockFetch(async () => {
+      fetched = true;
+      return okResponse(1);
+    });
+    const result = await downloadAttachment({
+      name: 'huge.mov',
+      url: 'https://cdn/huge.mov',
+      size: MAX.TRANSCRIPT_REUPLOAD_BYTES + 1,
+    });
+    expect(result).toBeNull();
+    expect(fetched).toBe(false);
+  });
+
+  test('happy path returns the buffer', async () => {
+    mockFetch(async () => okResponse(16));
+    const result = await downloadAttachment({ name: 'a.png', url: 'https://cdn/a.png', size: 16 });
+    expect(result?.byteLength).toBe(16);
+  });
+
+  test('non-ok response returns null', async () => {
+    mockFetch(async () => ({ ...okResponse(4), ok: false }));
+    expect(await downloadAttachment({ name: 'a.png', url: 'https://cdn/a.png' })).toBeNull();
+  });
+
+  test('Content-Length over the cap returns null before buffering', async () => {
+    mockFetch(async () => okResponse(4, MAX.TRANSCRIPT_REUPLOAD_BYTES + 1));
+    expect(await downloadAttachment({ name: 'a.png', url: 'https://cdn/a.png' })).toBeNull();
+  });
+
+  test('a lying Content-Length is caught by the final buffer check', async () => {
+    mockFetch(async () => okResponse(MAX.TRANSCRIPT_REUPLOAD_BYTES + 1, 4));
+    expect(await downloadAttachment({ name: 'a.png', url: 'https://cdn/a.png' })).toBeNull();
+  });
+
+  test('fetch failure returns null', async () => {
+    mockFetch(async () => {
+      throw new Error('ECONNRESET');
+    });
+    expect(await downloadAttachment({ name: 'a.png', url: 'https://cdn/a.png' })).toBeNull();
   });
 });
 

--- a/tests/unit/utils/ticket/transcriptPoster.test.ts
+++ b/tests/unit/utils/ticket/transcriptPoster.test.ts
@@ -1,19 +1,33 @@
 /**
  * postTranscriptToThread unit tests.
  *
- * Drives the shared archive spine with a fake thread that records sends and can
- * be made to throw, covering the post-every-chunk, no-ping, and rethrow-on-
- * failure behavior both close workflows rely on.
+ * Drives the shared archive spine with a fake thread that records sends and
+ * can be made to throw, plus an injected download fake so no test touches the
+ * network. Covers post-every-chunk, no-ping, file re-upload, the text-only
+ * fallback when an upload is rejected, and rethrow-on-failure behavior both
+ * close workflows rely on.
  */
 
 import { describe, expect, test } from 'bun:test';
-import { postTranscriptToThread } from '../../../../src/utils/ticket/transcriptPoster';
+import { buildHeaderEmbed, postTranscriptToThread } from '../../../../src/utils/ticket/transcriptPoster';
+import type { TranscriptChunk } from '../../../../src/utils/ticket/transcriptBuilder';
 
-function makeThread(opts: { failAt?: number } = {}) {
-  const calls: Array<{ content: string; allowedMentions: unknown }> = [];
+interface SentPayload {
+  content: string;
+  files?: unknown[];
+  allowedMentions: unknown;
+}
+
+function makeThread(opts: { failAt?: number; rejectFiles?: boolean } = {}) {
+  const calls: SentPayload[] = [];
+  let attempts = 0;
   const thread = {
-    send: async (payload: { content: string; allowedMentions: unknown }) => {
-      if (opts.failAt !== undefined && calls.length === opts.failAt) throw new Error('send failed');
+    send: async (payload: SentPayload) => {
+      if (opts.failAt !== undefined && attempts === opts.failAt) throw new Error('send failed');
+      attempts++;
+      if (opts.rejectFiles && payload.files && payload.files.length > 0) {
+        throw new Error('Request entity too large');
+      }
       calls.push(payload);
       return {};
     },
@@ -22,19 +36,27 @@ function makeThread(opts: { failAt?: number } = {}) {
   return { thread: thread as any, calls };
 }
 
+function chunk(content: string, files: TranscriptChunk['files'] = []): TranscriptChunk {
+  return { content, files };
+}
+
 const ctx = { guildId: 'g1', channelId: 'c1' };
+const okDownload = { download: async () => Buffer.from('bytes') };
+const failDownload = { download: async () => null };
 
 describe('postTranscriptToThread', () => {
   test('sends every chunk in order and never pings', async () => {
     const { thread, calls } = makeThread();
-    await postTranscriptToThread(thread, ['a', 'b', 'c'], ctx);
+    await postTranscriptToThread(thread, [chunk('a'), chunk('b'), chunk('c')], ctx);
     expect(calls.map(c => c.content)).toEqual(['a', 'b', 'c']);
     expect(calls.every(c => JSON.stringify(c.allowedMentions) === JSON.stringify({ parse: [] }))).toBe(true);
   });
 
   test('rethrows and stops at the first chunk that fails to send', async () => {
     const { thread, calls } = makeThread({ failAt: 1 });
-    await expect(postTranscriptToThread(thread, ['a', 'b', 'c'], ctx)).rejects.toThrow('send failed');
+    await expect(postTranscriptToThread(thread, [chunk('a'), chunk('b'), chunk('c')], ctx)).rejects.toThrow(
+      'send failed',
+    );
     expect(calls.map(c => c.content)).toEqual(['a']);
   });
 
@@ -42,5 +64,50 @@ describe('postTranscriptToThread', () => {
     const { thread, calls } = makeThread();
     await postTranscriptToThread(thread, [], ctx);
     expect(calls).toHaveLength(0);
+  });
+
+  test('re-uploads downloaded attachments with their chunk', async () => {
+    const { thread, calls } = makeThread();
+    const files = [
+      { name: 'a.png', url: 'https://cdn/a.png' },
+      { name: 'b.mp4', url: 'https://cdn/b.mp4' },
+    ];
+    await postTranscriptToThread(thread, [chunk('with files', files)], ctx, okDownload);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].files).toHaveLength(2);
+  });
+
+  test('failed download degrades to a text-only send (link fallback lives in the content)', async () => {
+    const { thread, calls } = makeThread();
+    await postTranscriptToThread(thread, [chunk('text', [{ name: 'a.png', url: 'https://cdn/a.png' }])], ctx, failDownload);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].files).toBeUndefined();
+  });
+
+  test('rejected file upload retries the chunk as text-only instead of failing the archive', async () => {
+    const { thread, calls } = makeThread({ rejectFiles: true });
+    await postTranscriptToThread(thread, [chunk('big one', [{ name: 'huge.mov', url: 'https://cdn/huge.mov' }])], ctx, okDownload);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].content).toBe('big one');
+    expect(calls[0].files).toBeUndefined();
+  });
+});
+
+describe('buildHeaderEmbed', () => {
+  test('maps header data onto an embed with title, color, and fields', () => {
+    const embed = buildHeaderEmbed(
+      {
+        title: '🎫 Support',
+        fields: [
+          { name: 'Opened', value: '<t:1:f>', inline: true },
+          { name: 'Messages', value: '4', inline: true },
+        ],
+      },
+      '#5865F2',
+    );
+    const json = embed.toJSON();
+    expect(json.title).toBe('🎫 Support');
+    expect(json.fields).toHaveLength(2);
+    expect(json.color).toBe(0x5865f2);
   });
 });


### PR DESCRIPTION
## Summary

Archive forum posts are now **chat-style and easily readable**, and **attachments stay viewable permanently**.

### Readability
- Colored **embed header card** (Opened / Closed / Duration / Type / Created by / Assigned to / Messages) replaces the flat markdown header — and doubles as the visual divider between re-closes
- **Day dividers** (`-# ── Wednesday, June 25, 2026 ──`) + short time-only `<t:..:t>` timestamps
- **Author grouping**: consecutive messages from one author within 7 min collapse under a single name line
- **Role badges**: 👤 opener, 🛡️ assignee, 🤖 bots
- **Reply context**: `↳ to staff_bob: "which rank did you buy…"`
- Plain message bodies — only foreign-bot embeds stay blockquoted
- Carbon-copy fidelity contract unchanged: content is never truncated

### Attachments (the big one)
The old format posted links to Discord CDN URLs, which are signed and **expire** — and the source channel is deleted right after archiving. Files are now **downloaded and re-uploaded into the archive thread**, so pictures/videos render inline forever. Oversized (>10 MB) or failed downloads fall back to the masked link; a send rejected for its payload retries text-only so the archive never fails because of a file.

### Bugs fixed along the way
- **Silent transcript loss**: an archive row with a NULL `messageId` matched neither close branch — `archived` stayed true and the channel was deleted with the transcript never posted anywhere. Now takes the recreate path (both workflows, regression-tested)
- Application headers rendered as "🎫 Ticket: Application: name" — applications get their own 📋 card
- Thread-name (100 char) and embed-title (256 char) clamps for long email senders/subjects

## Test plan

- [x] `bun test` — 1399 pass (was 1394; new coverage: badges, reply snippets, day dividers, grouping, file-chunk pinning, >10-file batching, download fallbacks, text-only retry, NULL-messageId recreate in both workflows)
- [x] `bun run build` + `bun run check` clean; `bun run check:changelog` green
- [ ] Eyeball one real ticket close on the dev bot (upload limits + embed rendering are live-environment behaviors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archived transcripts now render in a chat-style layout with embed header cards, role badges, contextual reply prefixes, and improved close/re-close behavior.
  * Attachments from transcripts can be re-uploaded into archive threads (up to the configured size limit) to improve availability.

* **Bug Fixes**
  * Improved archive resilience when archive threads are recreated or re-closed, including cases where message references are missing.
  * Fixed header rendering and prevented silent transcript loss during re-close.
  * Improved robustness for email-import tickets with long sender names/subjects (including safe thread-title clamping).

* **Documentation / Chores**
  * Updated release metadata/version references to **3.14.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->