### PR TITLE
fix: v3.14.1 — no interaction left hanging (error-safety sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ replied or deferred now always reach the user instead of leaving a frozen
 - **Global command error net** used a bare reply that failed whenever the
   crashing command had already deferred/replied — exactly the case it exists
   for. It now picks reply/edit/follow-up based on interaction state.
+- **No false failure messages either**: an announcement whose bookkeeping
+  fails *after* it posted no longer tells the operator "Failed to send"
+  (which invited a duplicate, double-pinging re-send), and an application
+  that breaks after "submitted!" now says so — instead of "please try again",
+  which caused duplicate applications.
 - **Field-editor buttons/menus/modals** (ticket types + application positions)
   that hit an error used to swallow it entirely; they now show the standard
   error message with a bug-report link.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.1] - 2026-07-04
+
+No interaction left hanging: errors that happen after the bot has already
+replied or deferred now always reach the user instead of leaving a frozen
+"thinking" state.
+
+### Fixed
+
+- **Global command error net** used a bare reply that failed whenever the
+  crashing command had already deferred/replied — exactly the case it exists
+  for. It now picks reply/edit/follow-up based on interaction state.
+- **Field-editor buttons/menus/modals** (ticket types + application positions)
+  that hit an error used to swallow it entirely; they now show the standard
+  error message with a bug-report link.
+- **Announcement send**: a failure after you click Send in the preview (e.g.
+  the bot can't post in the target channel) is now reported instead of
+  freezing the preview. The error log also captures the actual stack again.
+- **Application submit**: failures after the "submitted!" confirmation (e.g.
+  the welcome message couldn't be posted) are now surfaced to the applicant.
+- **/bot-setup**: errors after the dashboard is shown are now reported, and a
+  system-configure flow that fails mid-way tells you instead of silently
+  redrawing the dashboard. Setup-thread pin failures are logged, not ignored.
+- **Context menus**: same fix as the global net — errors after a reply/defer
+  no longer disappear.
+- **Confirm dialogs** that time out now say "Operation timed out" like every
+  other helper, instead of silently removing the buttons.
+- **Reaction handlers** (reaction roles, rules, starboard) no longer silently
+  swallow partial-fetch failures — they log at debug level via a shared
+  `fetchPartial` helper.
+
 ## [3.14.0] - 2026-07-03
 
 Archive transcripts got a full readability overhaul — and attachments now

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.0",
+  "botVersion": "3.14.1",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -259,16 +259,11 @@ export const handleSlashCommand = async (client: Client, interaction: ChatInputC
       commandName,
     });
 
-    try {
-      await interaction.reply({
-        content: '❌ An error occurred while executing this command. Please try again later.',
-        flags: [MessageFlags.Ephemeral],
-      });
-    } catch (replyError) {
-      enhancedLogger.warn('Failed to send error reply to user', LogCategory.COMMAND_EXECUTION, {
-        reason: replyError instanceof Error ? replyError.message : String(replyError),
-      });
-    }
+    // State-aware: a handler that deferred/replied before throwing used to
+    // make a bare reply() here throw InteractionAlreadyReplied, leaving the
+    // user stranded on the "thinking" state forever. replyEphemeralError picks
+    // reply/editReply/followUp and swallows secondary delivery failures.
+    await replyEphemeralError(interaction, 'An error occurred while executing this command. Please try again later.');
   }
 };
 

--- a/src/commands/handlers/announcement/handler.ts
+++ b/src/commands/handlers/announcement/handler.ts
@@ -258,21 +258,37 @@ async function previewAndSend(
     }
   }
 
-  const newLog = new AnnouncementLog();
-  newLog.guildId = guildId;
-  newLog.channelId = targetChannel.id;
-  newLog.messageId = sentMessage.id;
-  newLog.type = template.name;
-  newLog.sentBy = interaction.user.id;
-  newLog.scheduledTime = params.time ? new Date(params.time * 1000) : null;
-  newLog.version = params.version || null;
-  await announcementLogRepo.save(newLog);
+  // Past this point the announcement IS live in the channel. Bookkeeping
+  // failures (log row, ack edit) must never bubble to the outer catch — its
+  // "Failed to send announcement" would tell the operator to re-send and
+  // double-ping the role.
+  try {
+    const newLog = new AnnouncementLog();
+    newLog.guildId = guildId;
+    newLog.channelId = targetChannel.id;
+    newLog.messageId = sentMessage.id;
+    newLog.type = template.name;
+    newLog.sentBy = interaction.user.id;
+    newLog.scheduledTime = params.time ? new Date(params.time * 1000) : null;
+    newLog.version = params.version || null;
+    await announcementLogRepo.save(newLog);
 
-  await result.interaction.editReply({
-    content: `Announcement sent to ${targetChannel}!`,
-    embeds: [],
-    components: [],
-  });
+    await result.interaction.editReply({
+      content: `Announcement sent to ${targetChannel}!`,
+      embeds: [],
+      components: [],
+    });
+  } catch (error) {
+    enhancedLogger.error(
+      'Announcement sent but post-send bookkeeping failed (log row / ack)',
+      error instanceof Error ? error : new Error(String(error)),
+      LogCategory.COMMAND_EXECUTION,
+      { guildId, channelId: targetChannel.id, messageId: sentMessage.id },
+    );
+    await result.interaction
+      .editReply({ content: `Announcement sent to ${targetChannel}!`, embeds: [], components: [] })
+      .catch(() => null);
+  }
 
   enhancedLogger.info(
     `User ${interaction.user.username} sent ${template.name} announcement`,

--- a/src/commands/handlers/announcement/handler.ts
+++ b/src/commands/handlers/announcement/handler.ts
@@ -81,10 +81,18 @@ export async function announcementHandler(client: Client, interaction: ChatInput
 
     await replyEphemeralError(interaction, tlErr.unknownSubcommand);
   } catch (error) {
-    enhancedLogger.error(tl.error + error, undefined, LogCategory.COMMAND_EXECUTION);
-    if (!interaction.replied && !interaction.deferred) {
-      await replyEphemeralError(interaction, tl.fail);
-    }
+    enhancedLogger.error(
+      tl.error,
+      error instanceof Error ? error : new Error(String(error)),
+      LogCategory.COMMAND_EXECUTION,
+      {
+        guildId,
+      },
+    );
+    // Unconditional: replyEphemeralError follows up when the preview already
+    // replied — the old !replied && !deferred guard left the user stranded on
+    // the frozen preview when the send failed after they clicked Send.
+    await replyEphemeralError(interaction, tl.fail);
   }
 }
 

--- a/src/commands/handlers/botSetup/index.ts
+++ b/src/commands/handlers/botSetup/index.ts
@@ -13,12 +13,12 @@ import { BotConfig } from '../../../typeorm/entities/BotConfig';
 import { SetupState, type SystemStates } from '../../../typeorm/entities/SetupState';
 import {
   createButtonCollector,
-  createErrorEmbed,
   enhancedLogger,
   extractModalField,
   guardAdminRateLimit,
   LogCategory,
   RateLimits,
+  replyEphemeralError,
   showAndAwaitModal,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
@@ -91,12 +91,9 @@ export async function botSetupHandler(
     await showDashboard(interaction, client, guildId, setupState);
   } catch (error) {
     enhancedLogger.error('Bot setup handler failed', error as Error, LogCategory.COMMAND_EXECUTION, { guildId });
-    if (!interaction.replied && !interaction.deferred) {
-      await interaction.reply({
-        embeds: [createErrorEmbed('Setup failed. Please try again.')],
-        flags: [MessageFlags.Ephemeral],
-      });
-    }
+    // Unconditional + state-aware: an error thrown after the dashboard was
+    // shown used to be invisible (the !replied && !deferred guard skipped it).
+    await replyEphemeralError(interaction, 'Setup failed. Please try again.');
   }
 }
 
@@ -236,6 +233,15 @@ async function collectDashboardInteractions(
   selectCollector.on('collect', async (selectInteraction: any) => {
     const systemId = selectInteraction.values[0];
     const result = await runSystemFlow(systemId, selectInteraction, client, guildId, setupState);
+
+    if (result.failed) {
+      // Surface on the dashboard's own interaction — the select interaction may
+      // only have been acknowledged via showModal, where a reply can't land.
+      await replyEphemeralError(
+        interaction,
+        `Configuring **${systemId}** failed — check the bot's permissions and try again.`,
+      );
+    }
 
     // Always refresh the dashboard (restores it from any intermediate state)
     setupState.systemStates = result.states;

--- a/src/commands/handlers/botSetup/systemFlows.ts
+++ b/src/commands/handlers/botSetup/systemFlows.ts
@@ -73,6 +73,15 @@ import { buildApplicationMessage } from '../application/applicationPosition';
 
 const VALID_BAIT_ACTIONS: BaitActionType[] = ['ban', 'kick', 'timeout', 'log-only'];
 
+/** Best-effort thread pin — logs instead of silently swallowing (max pins / missing perms). */
+async function pinThreadBestEffort(thread: { pin: () => Promise<unknown> }): Promise<void> {
+  try {
+    await thread.pin();
+  } catch {
+    enhancedLogger.info('Could not pin setup welcome thread (max pins may be reached)', LogCategory.SYSTEM);
+  }
+}
+
 /**
  * Route a system selection to its configuration flow.
  * Returns updated system states after the flow completes.
@@ -83,7 +92,7 @@ export async function runSystemFlow(
   client: Client,
   guildId: string,
   setupState: SetupState,
-): Promise<{ updated: boolean; states: SystemStates }> {
+): Promise<{ updated: boolean; states: SystemStates; failed?: boolean }> {
   const states = { ...(setupState.systemStates || DEFAULT_SYSTEM_STATES) };
 
   try {
@@ -116,7 +125,9 @@ export async function runSystemFlow(
     }
   } catch (error) {
     enhancedLogger.error(`System flow failed: ${systemId}`, error as Error, LogCategory.COMMAND_EXECUTION, { guildId });
-    return { updated: false, states };
+    // failed:true lets the dashboard tell the user instead of silently
+    // redrawing as if nothing happened (e.g. Missing Permissions mid-flow).
+    return { updated: false, states, failed: true };
   }
 }
 
@@ -286,9 +297,7 @@ async function configureForumSystem(
           name: cfg.archiveThreadName,
           message: { content: cfg.archiveInitialMsg },
         });
-        try {
-          await thread.pin();
-        } catch {}
+        await pinThreadBestEffort(thread);
         data.archiveMessageId = thread.id;
       } catch (_error) {
         enhancedLogger.warn(
@@ -353,9 +362,7 @@ async function configureForumSystem(
         name: cfg.archiveThreadName,
         message: { content: cfg.archiveInitialMsg },
       });
-      try {
-        await thread.pin();
-      } catch {}
+      await pinThreadBestEffort(thread);
       data.archiveMessageId = thread.id;
     } catch {
       enhancedLogger.warn(
@@ -928,9 +935,7 @@ async function createMemoryWelcomeThread(forum: ForumChannel): Promise<string | 
       message: { embeds: [embed] },
     });
 
-    try {
-      await thread.pin();
-    } catch {}
+    await pinThreadBestEffort(thread);
 
     return thread.id;
   } catch {

--- a/src/commands/handlers/contextMenus/index.ts
+++ b/src/commands/handlers/contextMenus/index.ts
@@ -10,7 +10,7 @@ import {
   MessageFlags,
   type UserContextMenuCommandInteraction,
 } from 'discord.js';
-import { enhancedLogger, LogCategory } from '../../../utils';
+import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../../../utils';
 import { captureToMemoryHandler } from './captureToMemory';
 import { manageRestrictionsHandler } from './manageRestrictions';
 import { openTicketForUserHandler } from './openTicketForUser';
@@ -74,12 +74,8 @@ export async function handleContextMenuCommand(
       guildId: interaction.guildId,
     });
 
-    try {
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({ content: 'An error occurred. Please try again.', flags: [MessageFlags.Ephemeral] });
-      }
-    } catch {
-      // Interaction may have expired
-    }
+    // Unconditional + state-aware: a handler that replied/deferred before
+    // throwing used to leave the user with no feedback at all.
+    await replyEphemeralError(interaction, lang.general.fatalError, { bugReport: true });
   }
 }

--- a/src/events/application/apply.ts
+++ b/src/events/application/apply.ts
@@ -337,7 +337,10 @@ export const submitApplicationModal = async (_client: Client, interaction: Modal
 
     // Unconditional: a failure AFTER the "submitted!" reply (welcome/header
     // sends, the status update) used to be invisible to the applicant —
-    // replyEphemeralError follows up when already replied.
-    await replyEphemeralError(interaction, tl.failCreate);
+    // replyEphemeralError follows up when already replied. Post-submit
+    // failures get their own message: the application row + channel already
+    // exist, so "please try again" would cause duplicate applications and
+    // burn the applicant's rate-limit allowance.
+    await replyEphemeralError(interaction, interaction.replied ? tl.failPostCreate : tl.failCreate);
   }
 };

--- a/src/events/application/apply.ts
+++ b/src/events/application/apply.ts
@@ -335,8 +335,9 @@ export const submitApplicationModal = async (_client: Client, interaction: Modal
       },
     );
 
-    if (!interaction.replied && !interaction.deferred) {
-      await replyEphemeralError(interaction, tl.failCreate);
-    }
+    // Unconditional: a failure AFTER the "submitted!" reply (welcome/header
+    // sends, the status update) used to be invisible to the applicant —
+    // replyEphemeralError follows up when already replied.
+    await replyEphemeralError(interaction, tl.failCreate);
   }
 };

--- a/src/events/applicationFieldsInteraction.ts
+++ b/src/events/applicationFieldsInteraction.ts
@@ -6,7 +6,7 @@ import {
   handleAppFieldSelectMenu,
   handleAppPreviewModal,
 } from '../commands/handlers/application/applicationFields';
-import { enhancedLogger, LogCategory } from '../utils';
+import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../utils';
 
 /**
  * Event handler for application field interactions (buttons, select menus, modals).
@@ -91,6 +91,12 @@ export const applicationFieldsInteraction = async (_client: Client, interaction:
       LogCategory.COMMAND_EXECUTION,
       { userId: interaction.user.id, guildId },
     );
+    // Returning true claims the interaction and disarms the router's
+    // safety-net reply — so surface the failure here, or the user is
+    // stranded on a stale loading state with no feedback.
+    if (interaction.isRepliable()) {
+      await replyEphemeralError(interaction, lang.general.fatalError, { bugReport: true });
+    }
     return true;
   }
 

--- a/src/events/reactionRoleHandler.ts
+++ b/src/events/reactionRoleHandler.ts
@@ -1,5 +1,5 @@
 import type { Client, MessageReaction, PartialMessageReaction, PartialUser, User } from 'discord.js';
-import { enhancedLogger, getCachedMenu, getOptionByEmoji, LogCategory, lang } from '../utils';
+import { enhancedLogger, fetchPartial, getCachedMenu, getOptionByEmoji, LogCategory, lang } from '../utils';
 import { ReactionCooldown } from '../utils/reactionCooldown';
 
 const tl = lang.reactionRole.reaction;
@@ -25,20 +25,8 @@ export async function handleReactionRoleAdd(
 
   try {
     // Fetch partials
-    if (reaction.partial) {
-      try {
-        await reaction.fetch();
-      } catch {
-        return;
-      }
-    }
-    if (user.partial) {
-      try {
-        await user.fetch();
-      } catch {
-        return;
-      }
-    }
+    if (reaction.partial && !(await fetchPartial(reaction, 'reaction'))) return;
+    if (user.partial && !(await fetchPartial(user, 'user'))) return;
 
     const message = reaction.message;
     if (!message.guild) return;
@@ -144,20 +132,8 @@ export async function handleReactionRoleRemove(
 
   try {
     // Fetch partials
-    if (reaction.partial) {
-      try {
-        await reaction.fetch();
-      } catch {
-        return;
-      }
-    }
-    if (user.partial) {
-      try {
-        await user.fetch();
-      } catch {
-        return;
-      }
-    }
+    if (reaction.partial && !(await fetchPartial(reaction, 'reaction'))) return;
+    if (user.partial && !(await fetchPartial(user, 'user'))) return;
 
     const message = reaction.message;
     if (!message.guild) return;

--- a/src/events/rulesReaction.ts
+++ b/src/events/rulesReaction.ts
@@ -1,6 +1,6 @@
 import type { Client, MessageReaction, PartialMessageReaction, PartialUser, User } from 'discord.js';
 import { RulesConfig } from '../typeorm/entities/rules';
-import { enhancedLogger, LogCategory, lang } from '../utils';
+import { enhancedLogger, fetchPartial, LogCategory, lang } from '../utils';
 import { lazyRepo } from '../utils/database/lazyRepo';
 import { ReactionCooldown } from '../utils/reactionCooldown';
 import { getCachedRulesConfig, setCachedRulesConfig } from '../utils/rules/rulesCache';
@@ -43,20 +43,8 @@ export async function handleRulesReactionAdd(
 
   try {
     // Fetch partials if needed
-    if (reaction.partial) {
-      try {
-        await reaction.fetch();
-      } catch {
-        return;
-      }
-    }
-    if (user.partial) {
-      try {
-        await user.fetch();
-      } catch {
-        return;
-      }
-    }
+    if (reaction.partial && !(await fetchPartial(reaction, 'reaction'))) return;
+    if (user.partial && !(await fetchPartial(user, 'user'))) return;
 
     const message = reaction.message;
     if (!message.guild) return;
@@ -110,20 +98,8 @@ export async function handleRulesReactionRemove(
 
   try {
     // Fetch partials if needed
-    if (reaction.partial) {
-      try {
-        await reaction.fetch();
-      } catch {
-        return;
-      }
-    }
-    if (user.partial) {
-      try {
-        await user.fetch();
-      } catch {
-        return;
-      }
-    }
+    if (reaction.partial && !(await fetchPartial(reaction, 'reaction'))) return;
+    if (user.partial && !(await fetchPartial(user, 'user'))) return;
 
     const message = reaction.message;
     if (!message.guild) return;

--- a/src/events/starboardReaction.ts
+++ b/src/events/starboardReaction.ts
@@ -2,7 +2,7 @@ import type { Client, MessageReaction, PartialMessageReaction, PartialUser, Text
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from 'discord.js';
 import { StarboardConfig } from '../typeorm/entities/starboard/StarboardConfig';
 import { StarboardEntry } from '../typeorm/entities/starboard/StarboardEntry';
-import { enhancedLogger, LogCategory } from '../utils';
+import { enhancedLogger, fetchPartial, LogCategory } from '../utils';
 import { CACHE_TTL } from '../utils/constants';
 import { lazyRepo } from '../utils/database/lazyRepo';
 
@@ -86,20 +86,8 @@ export async function handleStarboardReactionAdd(
 
   try {
     // Fetch partials if needed
-    if (reaction.partial) {
-      try {
-        await reaction.fetch();
-      } catch {
-        return;
-      }
-    }
-    if (reaction.message.partial) {
-      try {
-        await reaction.message.fetch();
-      } catch {
-        return;
-      }
-    }
+    if (reaction.partial && !(await fetchPartial(reaction, 'reaction'))) return;
+    if (reaction.message.partial && !(await fetchPartial(reaction.message, 'message'))) return;
 
     const message = reaction.message;
     if (!message.guild) return;
@@ -230,20 +218,8 @@ export async function handleStarboardReactionRemove(
 
   try {
     // Fetch partials if needed
-    if (reaction.partial) {
-      try {
-        await reaction.fetch();
-      } catch {
-        return;
-      }
-    }
-    if (reaction.message.partial) {
-      try {
-        await reaction.message.fetch();
-      } catch {
-        return;
-      }
-    }
+    if (reaction.partial && !(await fetchPartial(reaction, 'reaction'))) return;
+    if (reaction.message.partial && !(await fetchPartial(reaction.message, 'message'))) return;
 
     const message = reaction.message;
     if (!message.guild) return;

--- a/src/events/typeFieldsInteraction.ts
+++ b/src/events/typeFieldsInteraction.ts
@@ -5,7 +5,7 @@ import {
   handleFieldSelectMenu,
   handlePreviewModal,
 } from '../commands/handlers/ticket/typeFields';
-import { enhancedLogger, LogCategory } from '../utils';
+import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../utils';
 
 /**
  * Event handler for type-fields interactions (buttons, select menus, modals).
@@ -100,6 +100,12 @@ export const typeFieldsInteraction = async (_client: Client, interaction: Intera
       LogCategory.COMMAND_EXECUTION,
       { userId: interaction.user.id, guildId },
     );
+    // Returning true claims the interaction and disarms the router's
+    // safety-net reply — so surface the failure here, or the user is
+    // stranded on a stale loading state with no feedback.
+    if (interaction.isRepliable()) {
+      await replyEphemeralError(interaction, lang.general.fatalError, { bugReport: true });
+    }
     return true; // we tried; don't fall through to other handlers
   }
 

--- a/src/lang/en/application.json
+++ b/src/lang/en/application.json
@@ -1,6 +1,7 @@
 {
   "error": "Could not create create application!",
   "failCreate": "Could not create application! Please try again.",
+  "failPostCreate": "Your application was submitted, but something went wrong while setting up your channel. Please contact staff instead of re-applying.",
   "applicationConfigNotFound": "Application Config does not exist!",
   "applicationCategoryNotFound": "Application Category does not exist!",
   "archiveApplicationConfigNotFound": "Archived Application Config does not exist!",

--- a/src/lang/types.ts
+++ b/src/lang/types.ts
@@ -746,6 +746,7 @@ export interface LangTicket {
 export interface LangApplication {
   error: string;
   failCreate: string;
+  failPostCreate: string;
   setup: {
     cmdDescrp: string;
     options: {

--- a/src/utils/discord/partialFetch.ts
+++ b/src/utils/discord/partialFetch.ts
@@ -1,0 +1,35 @@
+/**
+ * Best-effort partial hydration for reaction events.
+ *
+ * Reaction handlers receive partial reactions/users/messages and must fetch
+ * them before use. A failed fetch (typically 10008 — the message was deleted
+ * before we got to it) means the event can't be processed; that's expected
+ * churn, so it's logged at debug level rather than swallowed silently — the
+ * old bare `catch { return; }` blocks hid real permission/API failures too.
+ */
+
+import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+
+/**
+ * Fetch a partial entity. Returns false when the fetch fails (caller bails).
+ *
+ * @example
+ * if (reaction.partial && !(await fetchPartial(reaction, 'reaction'))) return;
+ * if (user.partial && !(await fetchPartial(user, 'user'))) return;
+ */
+export async function fetchPartial(entity: { fetch: () => Promise<unknown> }, label: string): Promise<boolean> {
+  try {
+    await entity.fetch();
+    return true;
+  } catch (error) {
+    enhancedLogger.debug(
+      `Skipping reaction event — partial ${label} fetch failed (likely deleted)`,
+      LogCategory.SYSTEM,
+      {
+        label,
+        reason: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return false;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,6 +25,7 @@ export * from './database/ensureDefaultTicketTypes';
 export * from './database/guildQueries';
 export * from './database/legacyMigration';
 // Discord verified deletion utilities
+export * from './discord/partialFetch';
 export * from './discord/verifiedDelete';
 export * from './embedBuilders';
 export * from './emojis';

--- a/src/utils/interactions/confirmHelper.ts
+++ b/src/utils/interactions/confirmHelper.ts
@@ -113,9 +113,10 @@ export async function awaitConfirmation(
     });
     return { interaction: btn as ButtonInteraction, response };
   } catch {
-    // Timeout — silently remove buttons
+    // Timeout — tell the user, matching the sibling helpers
+    // (awaitSelectMenuChoice / notifyModalTimeout), and remove the buttons.
     try {
-      await interaction.editReply({ components: [] });
+      await interaction.editReply({ content: lang.errors.timeout, embeds: [], components: [] });
     } catch {
       /* expired */
     }

--- a/tests/unit/utils/interactions/confirmHelper.test.ts
+++ b/tests/unit/utils/interactions/confirmHelper.test.ts
@@ -1,0 +1,77 @@
+/**
+ * awaitConfirmation unit tests.
+ *
+ * Drives the helper with a fake interaction whose reply returns a response
+ * that resolves (confirm / cancel button) or rejects (timeout), asserting the
+ * v3.14.1 contract: a timeout tells the user instead of silently stripping
+ * the buttons.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { awaitConfirmation } from '../../../../src/utils/interactions/confirmHelper';
+import { lang } from '../../../../src/lang';
+
+function makeInteraction(behavior: { resolve?: unknown; reject?: boolean }) {
+  const edits: Array<{ content?: string; components?: unknown[] }> = [];
+  const interaction = {
+    reply: async () => ({
+      awaitMessageComponent: async () => {
+        if (behavior.reject) throw new Error('timeout');
+        return behavior.resolve;
+      },
+    }),
+    editReply: async (o: { content?: string; components?: unknown[] }) => {
+      edits.push(o);
+    },
+  };
+  return { interaction, edits };
+}
+
+function makeButton(customId: string) {
+  const updates: Array<{ content?: string; components?: unknown[] }> = [];
+  return {
+    button: {
+      customId,
+      update: async (o: { content?: string; components?: unknown[] }) => {
+        updates.push(o);
+      },
+    },
+    updates,
+  };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: narrow interaction test doubles
+const call = (interaction: unknown) => awaitConfirmation(interaction as any, { message: 'Sure?' });
+
+describe('awaitConfirmation', () => {
+  test('returns the acknowledged button interaction on confirm', async () => {
+    const { button } = makeButton('confirm_yes');
+    const { interaction } = makeInteraction({ resolve: button });
+
+    const result = await call(interaction);
+
+    expect(result?.interaction).toBe(button as never);
+  });
+
+  test('returns null and shows the cancelled message on cancel', async () => {
+    const { button, updates } = makeButton('confirm_no');
+    const { interaction } = makeInteraction({ resolve: button });
+
+    const result = await call(interaction);
+
+    expect(result).toBeNull();
+    expect(updates).toHaveLength(1);
+    expect(updates[0].content).toBe(lang.errors.cancelled);
+  });
+
+  test('timeout tells the user and clears the buttons (not a silent strip)', async () => {
+    const { interaction, edits } = makeInteraction({ reject: true });
+
+    const result = await call(interaction);
+
+    expect(result).toBeNull();
+    expect(edits).toHaveLength(1);
+    expect(edits[0].content).toBe(lang.errors.timeout);
+    expect(edits[0].components).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Patch 1 of the cleanup roadmap (`.plans/2026-07-03/codebase-improvements.md`): every confirmed error-handling finding where an error after reply/defer left the user staring at a frozen interaction with no feedback.

> **Stacked on #19** (v3.14.0) — merge that first; this PR auto-retargets to `main` when the base branch is deleted.

### The anti-pattern
`catch` blocks either called bare `interaction.reply()` (throws `InteractionAlreadyReplied` post-defer) or guarded the user notice behind `!replied && !deferred` (exactly wrong: the post-reply case is when the user is stranded). All sites now use the state-aware, swallow-safe `replyEphemeralError`.

### Sites fixed
- **Global command error net** (`commands.ts`) — the big one; covered every slash command
- **Field-editor dispatchers** (`typeFieldsInteraction`, `applicationFieldsInteraction`) — their `return true` claims the interaction and disarms the router's safety net, so they must surface errors themselves
- **Announcement send** — post-preview failure notice + the error object is actually logged again (was `undefined`)
- **Application apply** — failures after the "submitted!" confirmation now follow up
- **`/bot-setup`** — post-dashboard errors surfaced; `runSystemFlow` returns `failed: true` and the dashboard reports it (on the dashboard's own interaction, since the select interaction may only be modal-acknowledged); `thread.pin()` best-effort now logs via `pinThreadBestEffort`
- **Context menus** — unconditional state-aware error reply (`lang.general.fatalError` + bug-report link)
- **`awaitConfirmation` timeout** — says "Operation timed out" like `awaitSelectMenuChoice`/`notifyModalTimeout`, instead of silently stripping buttons
- **Reaction handlers** (reaction roles / rules / starboard) — 10 bare `catch { return; }` partial-fetch swallows replaced with a shared `fetchPartial()` helper (`utils/discord/partialFetch.ts`) that logs at debug level

### Review
CodeRabbit (`--agent`, uncommitted): 3 minor findings — 1 applied (contextMenus lang key), 2 skipped with reasons (expired-interaction swallow is intentional + matches siblings; botSetup lang key belongs to the planned v3.15.0 i18n sweep).

## Test plan

- [x] `bun test` — 1402 pass (new: `confirmHelper.test.ts` pinning confirm / cancel / timeout-message behavior)
- [x] `bun run build` + `bun run check` clean; `bun run check:changelog` green
- [ ] Dev-bot spot check: force an error in a deferred command and confirm the ephemeral error lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ