### PR TITLE
fix: v3.14.2 — archive close-path bugs (audit deep-dive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.2] - 2026-07-05
+
+Archive close-path bugs from the audit deep-dive.
+
+### Fixed
+
+- **Forum tags accumulate again**: applying archive tags used to REPLACE a
+  thread's tags, wiping anything a moderator had added by hand. Tags now merge
+  with what's live on the thread, and when the 5-tag Discord cap drops one,
+  it's logged instead of vanishing silently.
+- **Dashboard close/archive can't strand tickets**: an unexpected error inside
+  the close workflow now reverts the ticket/application status (channel
+  preserved for retry) instead of leaving it marked closed with a live channel
+  — the API paths now match what the Discord close button already did.
+- **Double-close race fixed**: two near-simultaneous closes (double-click, or
+  button racing the dashboard) could both pass the "already closed" guard.
+  The status flip is now atomic — the loser is told the ticket is already
+  closed instead of both attempting to archive.
+
 ## [3.14.1] - 2026-07-04
 
 No interaction left hanging: errors that happen after the bot has already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,16 @@ Archive close-path bugs from the audit deep-dive.
   the close workflow now reverts the ticket/application status (channel
   preserved for retry) instead of leaving it marked closed with a live channel
   — the API paths now match what the Discord close button already did.
-- **Double-close race fixed**: two near-simultaneous closes (double-click, or
-  button racing the dashboard) could both pass the "already closed" guard.
-  The status flip is now atomic — the loser is told the ticket is already
-  closed instead of both attempting to archive.
+- **Double-close race fixed** in all four close paths (ticket + application,
+  Discord button + dashboard API): two near-simultaneous closes could both
+  pass the "already closed" guard. The status flip is now atomic (shared
+  `claimClose` helper) — the loser is told it's already closed instead of both
+  archiving. Reverts after a failed close are conditional too (`releaseClose`),
+  so they can't clobber a status a concurrent request wrote in between, and
+  approve/deny can no longer overwrite `closed` mid-archive.
+- **Dropped forum tags stay retryable**: when the 5-tag cap keeps an archive
+  tag off the thread, it's no longer recorded as applied — the next re-close
+  tries again instead of skipping it forever.
 
 ## [3.14.1] - 2026-07-04
 

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.1",
+  "botVersion": "3.14.2",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/migrate.ts
+++ b/src/commands/handlers/migrate.ts
@@ -108,13 +108,18 @@ export async function migrateTicketTagsHandler(interaction: ChatInputCommandInte
             skipped++;
             continue;
           }
-          await applyForumTags(forumChannel, archived.messageId, mergedTags);
+          const applied = await applyForumTags(forumChannel, archived.messageId, mergedTags);
 
-          // Update database with merged tags
-          archived.forumTagIds = mergedTags;
-          await archivedTicketRepo.save(archived);
-
-          updated++;
+          // Persist only if the tag actually reached the thread — otherwise the
+          // includes-guard above would skip every future attempt while the
+          // thread never shows the tag (5-tag cap / apply failure).
+          if (applied?.includes(tagId)) {
+            archived.forumTagIds = mergedTags;
+            await archivedTicketRepo.save(archived);
+            updated++;
+          } else {
+            skipped++;
+          }
         }
       } catch (error) {
         enhancedLogger.error(`Error migrating ticket ${archived.id}`, error as Error, LogCategory.DATABASE);

--- a/src/events/application/close.ts
+++ b/src/events/application/close.ts
@@ -9,7 +9,7 @@ import {
 } from 'discord.js';
 import { Application } from '../../typeorm/entities/application/Application';
 import { ArchivedApplicationConfig } from '../../typeorm/entities/application/ArchivedApplicationConfig';
-import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../../utils';
+import { claimClose, enhancedLogger, LogCategory, lang, releaseClose, replyEphemeralError } from '../../utils';
 import { type ArchiveApplicationResult, archiveAndCloseApplication } from '../../utils/application/closeWorkflow';
 import { lazyRepo } from '../../utils/database/lazyRepo';
 
@@ -53,7 +53,19 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
     return;
   }
 
-  await applicationRepo.update({ id: application.id, guildId }, { status: 'closed' });
+  // Atomic flip — the status guard above is check-then-set, so a button
+  // confirm racing the dashboard's archive (or a double-click) could pass it;
+  // whoever loses the conditional UPDATE bails as a duplicate. Mirrors
+  // events/ticket/close.ts.
+  if (!(await claimClose(applicationRepo, application.id, guildId))) {
+    enhancedLogger.warn(
+      'Application close lost the flip race — concurrent close already in progress',
+      LogCategory.SYSTEM,
+      { guildId, channelId },
+    );
+    await replyEphemeralError(interaction, tl.alreadyClosed);
+    return;
+  }
 
   let result: ArchiveApplicationResult;
   try {
@@ -62,7 +74,7 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
     // Unexpected throw escaped the workflow. Status was flipped to 'closed'
     // above but the channel still exists — revert (otherwise the dup-close guard
     // strands it) and tell the user instead of leaving "Closing application...".
-    await applicationRepo.update({ id: application.id, guildId }, { status: application.status });
+    await releaseClose(applicationRepo, application.id, guildId, application.status);
     enhancedLogger.error(
       'Application close threw unexpectedly — status reverted, channel preserved for retry',
       error instanceof Error ? error : undefined,
@@ -77,7 +89,7 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
     // Close did not complete (transcript fetch or forum post failed). The
     // workflow preserved the channel; revert the status so the close can be
     // retried instead of stranding a 'closed' application with a live channel.
-    await applicationRepo.update({ id: application.id, guildId }, { status: application.status });
+    await releaseClose(applicationRepo, application.id, guildId, application.status);
     enhancedLogger.warn(
       'Application close reverted — archive failed, channel + application preserved for retry',
       LogCategory.SYSTEM,

--- a/src/events/ticket/close.ts
+++ b/src/events/ticket/close.ts
@@ -7,6 +7,7 @@ import {
   type GuildTextBasedChannel,
   MessageFlags,
 } from 'discord.js';
+import { Not } from 'typeorm';
 import { ArchivedTicketConfig } from '../../typeorm/entities/ticket/ArchivedTicketConfig';
 import { Ticket } from '../../typeorm/entities/ticket/Ticket';
 import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../../utils';
@@ -76,8 +77,19 @@ export const ticketCloseEvent = async (
     return;
   }
 
-  // Immediately mark as closed to prevent concurrent close attempts
-  await deps.ticketRepo.update({ id: ticket.id, guildId }, { status: 'closed' });
+  // Immediately mark as closed to prevent concurrent close attempts. The
+  // status guard above is check-then-set — two near-simultaneous confirms
+  // could both pass it — so the flip itself is conditional: whoever loses
+  // the UPDATE gets affected=0 and bails as a duplicate.
+  const flip = await deps.ticketRepo.update({ id: ticket.id, guildId, status: Not('closed') }, { status: 'closed' });
+  if (flip?.affected === 0) {
+    enhancedLogger.warn('Ticket close lost the flip race — concurrent close already in progress', LogCategory.SYSTEM, {
+      guildId,
+      channelId,
+    });
+    await deps.replyEphemeralError(interaction, tl.alreadyClosed);
+    return;
+  }
 
   let result: ArchiveTicketResult;
   try {

--- a/src/events/ticket/close.ts
+++ b/src/events/ticket/close.ts
@@ -7,10 +7,9 @@ import {
   type GuildTextBasedChannel,
   MessageFlags,
 } from 'discord.js';
-import { Not } from 'typeorm';
 import { ArchivedTicketConfig } from '../../typeorm/entities/ticket/ArchivedTicketConfig';
 import { Ticket } from '../../typeorm/entities/ticket/Ticket';
-import { enhancedLogger, LogCategory, lang, replyEphemeralError } from '../../utils';
+import { claimClose, enhancedLogger, LogCategory, lang, releaseClose, replyEphemeralError } from '../../utils';
 import { lazyRepo } from '../../utils/database/lazyRepo';
 import { type ArchiveTicketResult, archiveAndCloseTicket } from '../../utils/ticket/closeWorkflow';
 
@@ -79,10 +78,9 @@ export const ticketCloseEvent = async (
 
   // Immediately mark as closed to prevent concurrent close attempts. The
   // status guard above is check-then-set — two near-simultaneous confirms
-  // could both pass it — so the flip itself is conditional: whoever loses
-  // the UPDATE gets affected=0 and bails as a duplicate.
-  const flip = await deps.ticketRepo.update({ id: ticket.id, guildId, status: Not('closed') }, { status: 'closed' });
-  if (flip?.affected === 0) {
+  // could both pass it — so the flip itself is atomic (claimClose): whoever
+  // loses the UPDATE bails as a duplicate.
+  if (!(await claimClose(deps.ticketRepo, ticket.id, guildId))) {
     enhancedLogger.warn('Ticket close lost the flip race — concurrent close already in progress', LogCategory.SYSTEM, {
       guildId,
       channelId,
@@ -101,7 +99,7 @@ export const ticketCloseEvent = async (
     // channel still exists, so revert the status (otherwise the dup-close guard
     // strands it permanently) and tell the user instead of leaving them on
     // "Closing ticket...".
-    await deps.ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+    await releaseClose(deps.ticketRepo, ticket.id, guildId, ticket.status);
     enhancedLogger.error(
       'Ticket close threw unexpectedly — status reverted, channel preserved for retry',
       error instanceof Error ? error : undefined,
@@ -117,7 +115,7 @@ export const ticketCloseEvent = async (
     // workflow deliberately preserved the channel, so revert the status —
     // otherwise the ticket is stranded 'closed' with a live channel and the
     // dup-close guard blocks any retry.
-    await deps.ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+    await releaseClose(deps.ticketRepo, ticket.id, guildId, ticket.status);
     enhancedLogger.warn(
       'Ticket close reverted — archive failed, channel + ticket preserved for retry',
       LogCategory.SYSTEM,

--- a/src/utils/api/handlers/applicationHandlers.ts
+++ b/src/utils/api/handlers/applicationHandlers.ts
@@ -1,4 +1,5 @@
 import type { Client, GuildTextBasedChannel } from 'discord.js';
+import { Not } from 'typeorm';
 import { Application } from '../../../typeorm/entities/application/Application';
 import { ArchivedApplicationConfig } from '../../../typeorm/entities/application/ArchivedApplicationConfig';
 import { archiveAndCloseApplication as defaultArchiveAndCloseApplication } from '../../application/closeWorkflow';
@@ -79,8 +80,10 @@ export function registerApplicationHandlers(
     const archivedConfig = await archivedAppConfigRepo.findOneBy({ guildId });
     if (!archivedConfig) throw ApiError.notFound('Archive config not found');
 
-    // Mark closed
-    await applicationRepo.update({ id: app.id, guildId }, { status: 'closed' });
+    // Mark closed — conditional so a concurrent close loses cleanly instead
+    // of both proceeding.
+    const flip = await applicationRepo.update({ id: app.id, guildId, status: Not('closed') }, { status: 'closed' });
+    if (flip?.affected === 0) throw ApiError.conflict('Application already closed');
 
     // Distinguish a genuinely-gone channel (10003 → nothing to archive, terminal
     // close) from a transient/permission fetch failure (→ revert so a retry can
@@ -100,13 +103,22 @@ export function registerApplicationHandlers(
       return { success: true, archived: false };
     }
 
-    const result = await archiveAndCloseApplication(
-      client,
-      app,
-      guildId,
-      channel as GuildTextBasedChannel,
-      archivedConfig.channelId,
-    );
+    let result: Awaited<ReturnType<typeof archiveAndCloseApplication>>;
+    try {
+      result = await archiveAndCloseApplication(
+        client,
+        app,
+        guildId,
+        channel as GuildTextBasedChannel,
+        archivedConfig.channelId,
+      );
+    } catch (error) {
+      // Unexpected throw — the channel still exists; revert so the archive can
+      // be retried, then rethrow so the API reports the failure (mirrors the
+      // ticket close handler + events/application/close.ts).
+      await applicationRepo.update({ id: app.id, guildId }, { status: app.status });
+      throw error;
+    }
 
     if (!result.archived) {
       // Archive failed — the workflow preserved the channel; revert the status

--- a/src/utils/api/handlers/applicationHandlers.ts
+++ b/src/utils/api/handlers/applicationHandlers.ts
@@ -4,6 +4,7 @@ import { Application } from '../../../typeorm/entities/application/Application';
 import { ArchivedApplicationConfig } from '../../../typeorm/entities/application/ArchivedApplicationConfig';
 import { archiveAndCloseApplication as defaultArchiveAndCloseApplication } from '../../application/closeWorkflow';
 import { lazyRepo } from '../../database/lazyRepo';
+import { claimClose, releaseClose } from '../../database/statusFlip';
 import { ApiError } from '../apiError';
 import { getAndValidateEntity, optionalString, requireString } from '../helpers';
 import type { RouteHandler } from '../router';
@@ -33,7 +34,10 @@ export function registerApplicationHandlers(
     });
     if (app.status === 'closed') throw ApiError.conflict('Application already closed');
 
-    await applicationRepo.update({ id: app.id, guildId }, { status: 'accepted' });
+    // Conditional — an approve racing a concurrent archive must not overwrite
+    // 'closed' and resurrect an application that is mid-archive.
+    const flip = await applicationRepo.update({ id: app.id, guildId, status: Not('closed') }, { status: 'accepted' });
+    if (flip?.affected === 0) throw ApiError.conflict('Application already closed');
 
     // Send approval message in channel if accessible
     const channel = app.channelId ? await client.channels.fetch(app.channelId).catch(() => null) : null;
@@ -57,7 +61,10 @@ export function registerApplicationHandlers(
     });
     if (app.status === 'closed') throw ApiError.conflict('Application already closed');
 
-    await applicationRepo.update({ id: app.id, guildId }, { status: 'rejected' });
+    // Conditional — a deny racing a concurrent archive must not overwrite
+    // 'closed' (see approve above).
+    const flip = await applicationRepo.update({ id: app.id, guildId, status: Not('closed') }, { status: 'rejected' });
+    if (flip?.affected === 0) throw ApiError.conflict('Application already closed');
 
     const channel = app.channelId ? await client.channels.fetch(app.channelId).catch(() => null) : null;
     if (channel?.isTextBased()) {
@@ -80,10 +87,11 @@ export function registerApplicationHandlers(
     const archivedConfig = await archivedAppConfigRepo.findOneBy({ guildId });
     if (!archivedConfig) throw ApiError.notFound('Archive config not found');
 
-    // Mark closed — conditional so a concurrent close loses cleanly instead
-    // of both proceeding.
-    const flip = await applicationRepo.update({ id: app.id, guildId, status: Not('closed') }, { status: 'closed' });
-    if (flip?.affected === 0) throw ApiError.conflict('Application already closed');
+    // Mark closed — atomic flip so a concurrent close (or the Discord close
+    // button) loses cleanly instead of both proceeding.
+    if (!(await claimClose(applicationRepo, app.id, guildId))) {
+      throw ApiError.conflict('Application already closed');
+    }
 
     // Distinguish a genuinely-gone channel (10003 → nothing to archive, terminal
     // close) from a transient/permission fetch failure (→ revert so a retry can
@@ -96,7 +104,7 @@ export function registerApplicationHandlers(
         })
       : null;
     if (channelFetchFailed) {
-      await applicationRepo.update({ id: app.id, guildId }, { status: app.status });
+      await releaseClose(applicationRepo, app.id, guildId, app.status);
       return { success: false, archived: false };
     }
     if (!channel?.isTextBased()) {
@@ -116,14 +124,14 @@ export function registerApplicationHandlers(
       // Unexpected throw — the channel still exists; revert so the archive can
       // be retried, then rethrow so the API reports the failure (mirrors the
       // ticket close handler + events/application/close.ts).
-      await applicationRepo.update({ id: app.id, guildId }, { status: app.status });
+      await releaseClose(applicationRepo, app.id, guildId, app.status);
       throw error;
     }
 
     if (!result.archived) {
       // Archive failed — the workflow preserved the channel; revert the status
       // so the archive can be retried instead of stranding it 'closed'.
-      await applicationRepo.update({ id: app.id, guildId }, { status: app.status });
+      await releaseClose(applicationRepo, app.id, guildId, app.status);
       return { success: false, archived: false };
     }
 

--- a/src/utils/api/handlers/ticketHandlers.ts
+++ b/src/utils/api/handlers/ticketHandlers.ts
@@ -1,8 +1,8 @@
 import type { Client, GuildTextBasedChannel } from 'discord.js';
-import { Not } from 'typeorm';
 import { ArchivedTicketConfig } from '../../../typeorm/entities/ticket/ArchivedTicketConfig';
 import { Ticket } from '../../../typeorm/entities/ticket/Ticket';
 import { lazyRepo } from '../../database/lazyRepo';
+import { claimClose, releaseClose } from '../../database/statusFlip';
 import { archiveAndCloseTicket as defaultArchiveAndCloseTicket } from '../../ticket/closeWorkflow';
 import { ApiError } from '../apiError';
 import { getAndValidateEntity, isValidSnowflake, requireString } from '../helpers';
@@ -36,11 +36,12 @@ export function registerTicketHandlers(
     });
     if (!archivedConfig) throw ApiError.notFound('Archive config not found');
 
-    // Mark closed immediately — conditional so a concurrent close (button
+    // Mark closed immediately — atomic flip so a concurrent close (button
     // click racing the dashboard) loses cleanly instead of both proceeding
     // past the guard above.
-    const flip = await ticketRepo.update({ id: ticket.id, guildId, status: Not('closed') }, { status: 'closed' });
-    if (flip?.affected === 0) throw ApiError.conflict('Ticket already closed');
+    if (!(await claimClose(ticketRepo, ticket.id, guildId))) {
+      throw ApiError.conflict('Ticket already closed');
+    }
 
     // Get channel. Distinguish a genuinely-gone channel (Discord 10003 →
     // nothing to archive, terminal close) from a transient/permission fetch
@@ -54,7 +55,7 @@ export function registerTicketHandlers(
         })
       : null;
     if (channelFetchFailed) {
-      await ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+      await releaseClose(ticketRepo, ticket.id, guildId, ticket.status);
       return { success: false, ticketId: ticket.id, archived: false };
     }
     if (!channel?.isTextBased()) {
@@ -75,14 +76,14 @@ export function registerTicketHandlers(
       // inside its try blocks). The channel still exists — revert the status
       // so the close can be retried instead of stranding it 'closed', then
       // rethrow so the API reports the failure (mirrors events/ticket/close.ts).
-      await ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+      await releaseClose(ticketRepo, ticket.id, guildId, ticket.status);
       throw error;
     }
 
     if (!result.archived) {
       // Archive failed — the workflow preserved the channel; revert the status
       // so the close can be retried instead of stranding it 'closed'.
-      await ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+      await releaseClose(ticketRepo, ticket.id, guildId, ticket.status);
       return { success: false, ticketId: ticket.id, archived: false };
     }
 

--- a/src/utils/api/handlers/ticketHandlers.ts
+++ b/src/utils/api/handlers/ticketHandlers.ts
@@ -1,4 +1,5 @@
 import type { Client, GuildTextBasedChannel } from 'discord.js';
+import { Not } from 'typeorm';
 import { ArchivedTicketConfig } from '../../../typeorm/entities/ticket/ArchivedTicketConfig';
 import { Ticket } from '../../../typeorm/entities/ticket/Ticket';
 import { lazyRepo } from '../../database/lazyRepo';
@@ -35,8 +36,11 @@ export function registerTicketHandlers(
     });
     if (!archivedConfig) throw ApiError.notFound('Archive config not found');
 
-    // Mark closed immediately
-    await ticketRepo.update({ id: ticket.id, guildId }, { status: 'closed' });
+    // Mark closed immediately — conditional so a concurrent close (button
+    // click racing the dashboard) loses cleanly instead of both proceeding
+    // past the guard above.
+    const flip = await ticketRepo.update({ id: ticket.id, guildId, status: Not('closed') }, { status: 'closed' });
+    if (flip?.affected === 0) throw ApiError.conflict('Ticket already closed');
 
     // Get channel. Distinguish a genuinely-gone channel (Discord 10003 →
     // nothing to archive, terminal close) from a transient/permission fetch
@@ -57,13 +61,23 @@ export function registerTicketHandlers(
       return { success: true, ticketId: ticket.id, archived: false };
     }
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      guildId,
-      channel as GuildTextBasedChannel,
-      archivedConfig.channelId,
-    );
+    let result: Awaited<ReturnType<typeof archiveAndCloseTicket>>;
+    try {
+      result = await archiveAndCloseTicket(
+        client,
+        ticket,
+        guildId,
+        channel as GuildTextBasedChannel,
+        archivedConfig.channelId,
+      );
+    } catch (error) {
+      // An unexpected throw escaped the workflow (its metadata region isn't
+      // inside its try blocks). The channel still exists — revert the status
+      // so the close can be retried instead of stranding it 'closed', then
+      // rethrow so the API reports the failure (mirrors events/ticket/close.ts).
+      await ticketRepo.update({ id: ticket.id, guildId }, { status: ticket.status });
+      throw error;
+    }
 
     if (!result.archived) {
       // Archive failed — the workflow preserved the channel; revert the status

--- a/src/utils/database/statusFlip.ts
+++ b/src/utils/database/statusFlip.ts
@@ -1,0 +1,47 @@
+/**
+ * Atomic close-status transitions, shared by every close/archive path
+ * (ticket + application, Discord button + internal API).
+ *
+ * The "already closed" guards in those paths are check-then-set: two
+ * near-simultaneous closes can both pass the read. The flip here is the
+ * arbiter — a conditional UPDATE where the loser sees affected=0 and bails
+ * as a duplicate. The revert is conditional too: it only un-closes a row
+ * that is still 'closed' (i.e. the close this caller owns), so a failed
+ * close can never clobber a status a concurrent request wrote in between.
+ */
+
+import { Not } from 'typeorm';
+
+/** Minimal structural slice of a TypeORM repository the flip needs. */
+interface StatusRepo {
+  update(
+    criteria: Record<string, unknown>,
+    partial: Record<string, unknown>,
+  ): Promise<{ affected?: number | null } | undefined>;
+}
+
+/**
+ * Atomically flip an entity to 'closed'. Returns false when a concurrent
+ * close already won the race — the caller should treat that as a duplicate
+ * and NOT proceed to archive. (A fake repo returning undefined counts as a
+ * win: only an explicit affected=0 signals a lost race.)
+ */
+export async function claimClose(repo: StatusRepo, id: number, guildId: string): Promise<boolean> {
+  const result = await repo.update({ id, guildId, status: Not('closed') }, { status: 'closed' });
+  return result?.affected !== 0;
+}
+
+/**
+ * Revert a failed close to its original status — conditionally, so it only
+ * touches the row while it is still 'closed'. If a concurrent request has
+ * already moved the status on (re-close, approve, workflow change), the
+ * revert is a no-op instead of resurrecting stale state.
+ */
+export async function releaseClose(
+  repo: StatusRepo,
+  id: number,
+  guildId: string,
+  originalStatus: string,
+): Promise<void> {
+  await repo.update({ id, guildId, status: 'closed' }, { status: originalStatus });
+}

--- a/src/utils/forumTagManager.ts
+++ b/src/utils/forumTagManager.ts
@@ -106,29 +106,45 @@ export async function ensureForumTag(
 }
 
 /**
- * Applies forum tags to a forum post/thread
+ * Applies forum tags to a forum post/thread, ACCUMULATING onto whatever tags
+ * the thread already carries (the "Forum Tag System" rule in CLAUDE.md) —
+ * `setAppliedTags` replaces, so passing only the caller's list used to wipe
+ * any tag a moderator had added to the thread by hand.
  * @param forumChannel - The forum channel containing the thread
  * @param threadId - The thread/post ID to apply tags to
- * @param tagIds - Array of tag IDs to apply
+ * @param tagIds - Array of tag IDs to add (order-preserving, deduped)
  */
 export async function applyForumTags(forumChannel: ForumChannel, threadId: string, tagIds: string[]): Promise<void> {
   try {
-    // Filter out empty tag IDs and ensure we don't exceed 5 tags (Discord API limit)
-    const validTagIds = tagIds.filter(id => id.length > 0).slice(0, 5);
-
-    if (validTagIds.length === 0) {
+    const incoming = tagIds.filter(id => id.length > 0);
+    if (incoming.length === 0) {
       enhancedLogger.info('No valid tags to apply to forum post', LogCategory.SYSTEM, { threadId });
       return;
     }
 
     const thread = await forumChannel.threads.fetch(threadId);
-    if (thread) {
-      await thread.setAppliedTags(validTagIds);
-      enhancedLogger.info(`Applied ${validTagIds.length} tags to forum post`, LogCategory.SYSTEM, {
+    if (!thread) return;
+
+    // Live thread tags first (manual additions survive), then new ones.
+    const merged = [...(thread.appliedTags ?? [])];
+    for (const id of incoming) {
+      if (!merged.includes(id)) merged.push(id);
+    }
+
+    // Discord caps applied tags at 5 per thread — don't hide what fell off.
+    const applied = merged.slice(0, 5);
+    if (merged.length > applied.length) {
+      enhancedLogger.warn('Forum post is at the 5-tag limit — some tags were not applied', LogCategory.SYSTEM, {
         threadId,
-        tagCount: validTagIds.length,
+        dropped: merged.slice(5),
       });
     }
+
+    await thread.setAppliedTags(applied);
+    enhancedLogger.info(`Applied ${applied.length} tags to forum post`, LogCategory.SYSTEM, {
+      threadId,
+      tagCount: applied.length,
+    });
   } catch (error) {
     enhancedLogger.error('Failed to apply forum tags to post', error as Error, LogCategory.ERROR, {
       threadId,

--- a/src/utils/forumTagManager.ts
+++ b/src/utils/forumTagManager.ts
@@ -113,17 +113,25 @@ export async function ensureForumTag(
  * @param forumChannel - The forum channel containing the thread
  * @param threadId - The thread/post ID to apply tags to
  * @param tagIds - Array of tag IDs to add (order-preserving, deduped)
+ * @returns The tag ids actually applied to the thread, or null on failure /
+ * no-op. Callers that persist tag state must check this — the 5-tag Discord
+ * cap can drop an incoming tag, and persisting it anyway makes the DB claim
+ * a tag the thread will never show.
  */
-export async function applyForumTags(forumChannel: ForumChannel, threadId: string, tagIds: string[]): Promise<void> {
+export async function applyForumTags(
+  forumChannel: ForumChannel,
+  threadId: string,
+  tagIds: string[],
+): Promise<string[] | null> {
   try {
     const incoming = tagIds.filter(id => id.length > 0);
     if (incoming.length === 0) {
       enhancedLogger.info('No valid tags to apply to forum post', LogCategory.SYSTEM, { threadId });
-      return;
+      return null;
     }
 
     const thread = await forumChannel.threads.fetch(threadId);
-    if (!thread) return;
+    if (!thread) return null;
 
     // Live thread tags first (manual additions survive), then new ones.
     const merged = [...(thread.appliedTags ?? [])];
@@ -145,10 +153,12 @@ export async function applyForumTags(forumChannel: ForumChannel, threadId: strin
       threadId,
       tagCount: applied.length,
     });
+    return applied;
   } catch (error) {
     enhancedLogger.error('Failed to apply forum tags to post', error as Error, LogCategory.ERROR, {
       threadId,
       tagIds,
     });
+    return null;
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,6 +24,7 @@ export * from './constants';
 export * from './database/ensureDefaultTicketTypes';
 export * from './database/guildQueries';
 export * from './database/legacyMigration';
+export * from './database/statusFlip';
 // Discord verified deletion utilities
 export * from './discord/partialFetch';
 export * from './discord/verifiedDelete';

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -198,6 +198,9 @@ export async function archiveAndCloseTicket(
     type: typeInfo?.displayName || ticket.type || 'Unknown',
     createdByUsername:
       (ticket.isEmailTicket && ticket.emailSenderName) || creatorUser?.username || ticket.emailSender || 'Unknown',
+    // Fallback only — the channel's createdAt (set below when available) is the
+    // real open time. Ticket has no createdAt column, so lastActivityAt is the
+    // closest approximation when the channel object can't provide one.
     openedAt: ticket.lastActivityAt ? new Date(Math.min(ticket.lastActivityAt.getTime(), Date.now())) : new Date(),
     closedAt: new Date(),
     assignedToUsername: assignedUser?.username ?? null,

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -327,9 +327,14 @@ export async function archiveAndCloseTicket(
           const newTagId = forumTagIds[0];
           if (!existingTags.includes(newTagId)) {
             const mergedTags = [...existingTags, newTagId];
-            await deps.applyForumTags(forumChannel, post.id, mergedTags);
-            existingArchive.forumTagIds = mergedTags;
-            await deps.archivedTicketRepo.save(existingArchive);
+            const applied = await deps.applyForumTags(forumChannel, post.id, mergedTags);
+            // Persist only if the tag actually reached the thread — the 5-tag
+            // cap can drop it, and recording it anyway would make this guard
+            // skip every future attempt while the thread never shows the tag.
+            if (applied?.includes(newTagId)) {
+              existingArchive.forumTagIds = mergedTags;
+              await deps.archivedTicketRepo.save(existingArchive);
+            }
           }
         }
       }

--- a/tests/unit/events/ticket/close.test.ts
+++ b/tests/unit/events/ticket/close.test.ts
@@ -105,7 +105,13 @@ describe('ticketCloseEvent', () => {
       { id: 7, guildId: 'guild1', status: Not('closed') },
       { status: 'closed' },
     );
-    expect(ticketRepo.update).toHaveBeenNthCalledWith(2, { id: 7, guildId: 'guild1' }, { status: 'opened' });
+    // Revert is conditional too — only un-closes the row while it's still
+    // 'closed' (a concurrent status change must not be clobbered).
+    expect(ticketRepo.update).toHaveBeenNthCalledWith(
+      2,
+      { id: 7, guildId: 'guild1', status: 'closed' },
+      { status: 'opened' },
+    );
     expect(replyEphemeralError).toHaveBeenCalledTimes(1);
     expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.transcriptCreate.error);
   });
@@ -117,7 +123,11 @@ describe('ticketCloseEvent', () => {
     await ticketCloseEvent(client, makeInteraction(), deps);
 
     expect(ticketRepo.update).toHaveBeenCalledTimes(2);
-    expect(ticketRepo.update).toHaveBeenNthCalledWith(2, { id: 7, guildId: 'guild1' }, { status: 'opened' });
+    expect(ticketRepo.update).toHaveBeenNthCalledWith(
+      2,
+      { id: 7, guildId: 'guild1', status: 'closed' },
+      { status: 'opened' },
+    );
     expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.transcriptCreate.error);
   });
 

--- a/tests/unit/events/ticket/close.test.ts
+++ b/tests/unit/events/ticket/close.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, expect, jest, test } from 'bun:test';
+import { Not } from 'typeorm';
 import ticketLang from '../../../../src/lang/en/ticket.json';
 import { type TicketCloseDeps, ticketCloseEvent } from '../../../../src/events/ticket/close';
 
@@ -96,9 +97,14 @@ describe('ticketCloseEvent', () => {
 
     await ticketCloseEvent(client, makeInteraction(), deps);
 
-    // First update flips to 'closed', second reverts to the original 'opened'.
+    // First update flips to 'closed' (conditionally — the race fix), second
+    // reverts to the original 'opened'.
     expect(ticketRepo.update).toHaveBeenCalledTimes(2);
-    expect(ticketRepo.update).toHaveBeenNthCalledWith(1, { id: 7, guildId: 'guild1' }, { status: 'closed' });
+    expect(ticketRepo.update).toHaveBeenNthCalledWith(
+      1,
+      { id: 7, guildId: 'guild1', status: Not('closed') },
+      { status: 'closed' },
+    );
     expect(ticketRepo.update).toHaveBeenNthCalledWith(2, { id: 7, guildId: 'guild1' }, { status: 'opened' });
     expect(replyEphemeralError).toHaveBeenCalledTimes(1);
     expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.transcriptCreate.error);
@@ -122,8 +128,21 @@ describe('ticketCloseEvent', () => {
 
     expect(archiveAndCloseTicket).toHaveBeenCalledTimes(1);
     expect(ticketRepo.update).toHaveBeenCalledTimes(1);
-    expect(ticketRepo.update).toHaveBeenCalledWith({ id: 7, guildId: 'guild1' }, { status: 'closed' });
+    expect(ticketRepo.update).toHaveBeenCalledWith(
+      { id: 7, guildId: 'guild1', status: Not('closed') },
+      { status: 'closed' },
+    );
     expect(replyEphemeralError).not.toHaveBeenCalled();
+  });
+
+  test('flip race lost (affected=0) → treated as duplicate close, no archive attempt', async () => {
+    const { deps, ticketRepo, archiveAndCloseTicket, replyEphemeralError } = makeDeps();
+    ticketRepo.update.mockResolvedValue({ affected: 0 });
+
+    await ticketCloseEvent(client, makeInteraction(), deps);
+
+    expect(archiveAndCloseTicket).not.toHaveBeenCalled();
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.alreadyClosed);
   });
 
   test('archived but channel delete failed → notifies user instead of leaving a live channel hanging', async () => {

--- a/tests/unit/utils/api/applicationHandlers.test.ts
+++ b/tests/unit/utils/api/applicationHandlers.test.ts
@@ -24,6 +24,7 @@ import {
   test,
 } from "bun:test";
 import type { Client } from "discord.js";
+import { Not } from "typeorm";
 
 // Injected into registerApplicationHandlers (3rd arg) — NOT mock.module'd.
 // Mocking the shared application/closeWorkflow module here would leak
@@ -177,7 +178,7 @@ describe("POST /applications/:id/approve", () => {
 
     expect(result).toEqual({ success: true, applicationId: 7 });
     expect(applicationRepoState.updateCalls[0]).toEqual({
-      criteria: { id: 7, guildId: "guild-1" },
+      criteria: { id: 7, guildId: "guild-1", status: Not("closed") },
       partial: { status: "accepted" },
     });
     expect(fakeChannelSend).toHaveBeenCalledTimes(1);
@@ -344,8 +345,10 @@ describe("POST /applications/:id/archive", () => {
     );
 
     expect(result).toEqual({ success: true, archived: true });
-    expect(applicationRepoState.updateCalls[0].partial).toEqual({
-      status: "closed",
+    // Atomic flip (claimClose): conditional on not-already-closed
+    expect(applicationRepoState.updateCalls[0]).toEqual({
+      criteria: { id: 7, guildId: "guild-1", status: Not("closed") },
+      partial: { status: "closed" },
     });
     expect(fakeArchiveAndCloseApp).toHaveBeenCalledTimes(1);
     expect(fakeArchiveAndCloseApp.mock.calls[0][4]).toBe("archive-forum-1");
@@ -355,6 +358,62 @@ describe("POST /applications/:id/archive", () => {
       "application.archive",
       { applicationId: 7 },
     );
+  });
+
+  test("flip race lost (affected=0) → 409, no archive attempt", async () => {
+    applicationRepoState.findOneByResult = {
+      id: 7,
+      guildId: "guild-1",
+      status: "pending",
+      channelId: "app-channel-1",
+    };
+    archivedAppConfigRepoState.findOneByResult = {
+      guildId: "guild-1",
+      channelId: "archive-forum-1",
+    };
+    applicationRepo.update.mockResolvedValueOnce({ affected: 0 });
+
+    await expect(
+      getRoute("POST /applications/:id/archive")(
+        "guild-1",
+        {},
+        "/applications/7/archive",
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message: "Application already closed",
+    });
+    expect(fakeArchiveAndCloseApp).not.toHaveBeenCalled();
+  });
+
+  test("workflow throws unexpectedly → status conditionally reverted, error propagates", async () => {
+    applicationRepoState.findOneByResult = {
+      id: 7,
+      guildId: "guild-1",
+      status: "pending",
+      channelId: "app-channel-1",
+    };
+    archivedAppConfigRepoState.findOneByResult = {
+      guildId: "guild-1",
+      channelId: "archive-forum-1",
+    };
+    fakeArchiveAndCloseApp.mockRejectedValueOnce(new Error("transient DB error"));
+
+    await expect(
+      getRoute("POST /applications/:id/archive")(
+        "guild-1",
+        {},
+        "/applications/7/archive",
+      ),
+    ).rejects.toThrow("transient DB error");
+
+    // Flip to closed, then a CONDITIONAL revert (only while still 'closed').
+    expect(applicationRepoState.updateCalls).toHaveLength(2);
+    expect(applicationRepoState.updateCalls[1]).toEqual({
+      criteria: { id: 7, guildId: "guild-1", status: "closed" },
+      partial: { status: "pending" },
+    });
+    expect(fakeWriteAuditAction).not.toHaveBeenCalled();
   });
 
   test("returns 404 when archive config missing", async () => {

--- a/tests/unit/utils/api/ticketHandlers.test.ts
+++ b/tests/unit/utils/api/ticketHandlers.test.ts
@@ -264,10 +264,11 @@ describe("POST /tickets/:id/close", () => {
       getCloseHandler()("guild-1", {}, "/tickets/42/close"),
     ).rejects.toThrow("transient DB error");
 
-    // Flip to closed, then revert to the original status.
+    // Flip to closed, then a CONDITIONAL revert to the original status (only
+    // while still 'closed' — a concurrent status change must not be clobbered).
     expect(ticketRepoState.updateCalls).toHaveLength(2);
     expect(ticketRepoState.updateCalls[1]).toEqual({
-      criteria: { id: 42, guildId: "guild-1" },
+      criteria: { id: 42, guildId: "guild-1", status: "closed" },
       partial: { status: "open" },
     });
     expect(fakeWriteAuditAction).not.toHaveBeenCalled();

--- a/tests/unit/utils/api/ticketHandlers.test.ts
+++ b/tests/unit/utils/api/ticketHandlers.test.ts
@@ -27,6 +27,7 @@ import {
   test,
 } from "bun:test";
 import type { Client } from "discord.js";
+import { Not } from "typeorm";
 
 // ---------------------------------------------------------------------------
 // Mocks for non-repo deps
@@ -197,9 +198,9 @@ describe("POST /tickets/:id/close", () => {
       guildId: "guild-1",
       id: 42,
     });
-    // Status flip happens BEFORE the archive call
+    // Status flip happens BEFORE the archive call, conditionally (race fix)
     expect(ticketRepoState.updateCalls[0]).toEqual({
-      criteria: { id: 42, guildId: "guild-1" },
+      criteria: { id: 42, guildId: "guild-1", status: Not("closed") },
       partial: { status: "closed" },
     });
     // Archive helper called with the right channel + archive config
@@ -244,6 +245,32 @@ describe("POST /tickets/:id/close", () => {
     });
     expect(ticketRepoState.updateCalls).toHaveLength(0);
     expect(fakeArchiveAndClose).not.toHaveBeenCalled();
+  });
+
+  test("workflow throws unexpectedly → status reverted, error propagates (no stranded close)", async () => {
+    ticketRepoState.findOneByResult = {
+      id: 42,
+      guildId: "guild-1",
+      status: "open",
+      channelId: "ticket-channel-1",
+    };
+    archivedTicketConfigRepoState.findOneByResult = {
+      guildId: "guild-1",
+      channelId: "archive-forum-1",
+    };
+    fakeArchiveAndClose.mockRejectedValueOnce(new Error("transient DB error"));
+
+    await expect(
+      getCloseHandler()("guild-1", {}, "/tickets/42/close"),
+    ).rejects.toThrow("transient DB error");
+
+    // Flip to closed, then revert to the original status.
+    expect(ticketRepoState.updateCalls).toHaveLength(2);
+    expect(ticketRepoState.updateCalls[1]).toEqual({
+      criteria: { id: 42, guildId: "guild-1" },
+      partial: { status: "open" },
+    });
+    expect(fakeWriteAuditAction).not.toHaveBeenCalled();
   });
 
   test("returns 404 when archive config missing — no status flip, no archive call", async () => {

--- a/tests/unit/utils/forumTagManager.test.ts
+++ b/tests/unit/utils/forumTagManager.test.ts
@@ -29,10 +29,11 @@ function makeForum(liveTags: string[] | null, opts: { threadMissing?: boolean } 
 }
 
 describe('applyForumTags', () => {
-  test('accumulates onto the thread\'s live tags (manual tags survive)', async () => {
+  test("accumulates onto the thread's live tags (manual tags survive) and returns what was applied", async () => {
     const { forum, applied } = makeForum(['manual-1']);
-    await applyForumTags(forum, 't1', ['db-1', 'db-2']);
+    const result = await applyForumTags(forum, 't1', ['db-1', 'db-2']);
     expect(applied).toEqual([['manual-1', 'db-1', 'db-2']]);
+    expect(result).toEqual(['manual-1', 'db-1', 'db-2']);
   });
 
   test('dedupes incoming tags already on the thread', async () => {
@@ -41,21 +42,23 @@ describe('applyForumTags', () => {
     expect(applied).toEqual([['a', 'b', 'c']]);
   });
 
-  test('caps at 5 tags, keeping live tags first and dropping the overflow', async () => {
+  test('caps at 5 tags, keeping live tags first — the return value reveals the drop', async () => {
     const { forum, applied } = makeForum(['l1', 'l2', 'l3', 'l4']);
-    await applyForumTags(forum, 't1', ['n1', 'n2']);
+    const result = await applyForumTags(forum, 't1', ['n1', 'n2']);
     expect(applied).toEqual([['l1', 'l2', 'l3', 'l4', 'n1']]);
+    expect(result).toEqual(['l1', 'l2', 'l3', 'l4', 'n1']);
+    expect(result).not.toContain('n2');
   });
 
-  test('empty/blank incoming tags are a no-op (no fetch, no write)', async () => {
+  test('empty/blank incoming tags are a no-op returning null (no fetch, no write)', async () => {
     const { forum, applied } = makeForum(['a']);
-    await applyForumTags(forum, 't1', ['']);
+    expect(await applyForumTags(forum, 't1', [''])).toBeNull();
     expect(applied).toHaveLength(0);
   });
 
-  test('missing thread is a silent no-op', async () => {
+  test('missing thread is a silent no-op returning null', async () => {
     const { forum, applied } = makeForum(null, { threadMissing: true });
-    await applyForumTags(forum, 't1', ['a']);
+    expect(await applyForumTags(forum, 't1', ['a'])).toBeNull();
     expect(applied).toHaveLength(0);
   });
 

--- a/tests/unit/utils/forumTagManager.test.ts
+++ b/tests/unit/utils/forumTagManager.test.ts
@@ -1,0 +1,67 @@
+/**
+ * applyForumTags unit tests — pins the v3.14.2 accumulation fix.
+ *
+ * setAppliedTags REPLACES a thread's tags, so the pre-fix implementation
+ * wiped any tag a moderator had added by hand whenever a re-close applied the
+ * DB-tracked list. These tests lock in: live tags survive, incoming tags
+ * dedupe against them, and the 5-tag Discord cap drops the overflow (logged)
+ * rather than throwing.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { applyForumTags } from '../../../src/utils/forumTagManager';
+
+function makeForum(liveTags: string[] | null, opts: { threadMissing?: boolean } = {}) {
+  const applied: string[][] = [];
+  const thread = {
+    appliedTags: liveTags,
+    setAppliedTags: async (tags: string[]) => {
+      applied.push(tags);
+    },
+  };
+  const forum = {
+    threads: {
+      fetch: async () => (opts.threadMissing ? null : thread),
+    },
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: minimal ForumChannel test double
+  return { forum: forum as any, applied };
+}
+
+describe('applyForumTags', () => {
+  test('accumulates onto the thread\'s live tags (manual tags survive)', async () => {
+    const { forum, applied } = makeForum(['manual-1']);
+    await applyForumTags(forum, 't1', ['db-1', 'db-2']);
+    expect(applied).toEqual([['manual-1', 'db-1', 'db-2']]);
+  });
+
+  test('dedupes incoming tags already on the thread', async () => {
+    const { forum, applied } = makeForum(['a', 'b']);
+    await applyForumTags(forum, 't1', ['b', 'c']);
+    expect(applied).toEqual([['a', 'b', 'c']]);
+  });
+
+  test('caps at 5 tags, keeping live tags first and dropping the overflow', async () => {
+    const { forum, applied } = makeForum(['l1', 'l2', 'l3', 'l4']);
+    await applyForumTags(forum, 't1', ['n1', 'n2']);
+    expect(applied).toEqual([['l1', 'l2', 'l3', 'l4', 'n1']]);
+  });
+
+  test('empty/blank incoming tags are a no-op (no fetch, no write)', async () => {
+    const { forum, applied } = makeForum(['a']);
+    await applyForumTags(forum, 't1', ['']);
+    expect(applied).toHaveLength(0);
+  });
+
+  test('missing thread is a silent no-op', async () => {
+    const { forum, applied } = makeForum(null, { threadMissing: true });
+    await applyForumTags(forum, 't1', ['a']);
+    expect(applied).toHaveLength(0);
+  });
+
+  test('null appliedTags on the thread is treated as empty', async () => {
+    const { forum, applied } = makeForum(null);
+    await applyForumTags(forum, 't1', ['a']);
+    expect(applied).toEqual([['a']]);
+  });
+});

--- a/tests/unit/utils/ticket/closeWorkflow.test.ts
+++ b/tests/unit/utils/ticket/closeWorkflow.test.ts
@@ -81,7 +81,7 @@ const fakeVerifiedChannelDelete = jest.fn(async () => ({
 const fakeFetchMessages = jest.fn(async () => [] as any[]);
 
 const fakeEnsureForumTag = jest.fn(async () => "tag-123");
-const fakeApplyForumTags = jest.fn(async () => undefined);
+const fakeApplyForumTags = jest.fn(async (_forum: unknown, _threadId: unknown, tags: string[]) => tags);
 
 const fakeResolveTicketType = jest.fn();
 // Default implementation = real `builtinTypeInfo` shape so other test files
@@ -264,7 +264,9 @@ describe("archiveAndCloseTicket", () => {
     fakeEnsureForumTag.mockClear();
     fakeEnsureForumTag.mockImplementation(async () => "tag-123");
     fakeApplyForumTags.mockClear();
-    fakeApplyForumTags.mockImplementation(async () => undefined);
+    // New contract: returns the tags actually applied (callers only persist
+    // tags that reached the thread). Default = everything applied.
+    fakeApplyForumTags.mockImplementation(async (_forum: unknown, _threadId: unknown, tags: string[]) => tags);
     fakeResolveTicketType.mockReset();
     fakeBuiltinTypeInfo.mockReset();
     // Restore the real-impl default so cross-suite imports get correct
@@ -545,6 +547,39 @@ describe("archiveAndCloseTicket", () => {
       "tag-old-support",
       "tag-bug",
     ]);
+  });
+
+  test("re-close: tag dropped by the 5-tag cap is NOT persisted (retryable next re-close)", async () => {
+    fakeBuiltinTypeInfo.mockReturnValue({
+      typeId: "bug",
+      displayName: "Bug Report",
+      emoji: "🐛",
+    });
+    fakeEnsureForumTag.mockResolvedValue("tag-bug");
+    // applyForumTags reports the new tag did NOT reach the thread (cap/failure).
+    fakeApplyForumTags.mockResolvedValue(["manual-1", "manual-2", "manual-3", "manual-4", "tag-old-support"]);
+    fakeRepoState.findOneByResult = {
+      messageId: "existing-thread-9",
+      forumTagIds: ["tag-old-support"],
+    };
+    const client = makeFakeClient(forumChannel, () => ({
+      username: "creator",
+    }));
+
+    const result = await archiveAndCloseTicket(
+      client,
+      makeTicket({ type: "bug" }),
+      "guild-1",
+      makeFakeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
+    expect(fakeApplyForumTags).toHaveBeenCalledTimes(1);
+    // Persisting the dropped tag would make the includes-guard skip every
+    // future attempt while the thread never shows it — so no save.
+    expect(fakeRepoState.saveCalls).toHaveLength(0);
   });
 
   test("transcript fetch failure: short-circuits before any forum write or channel delete", async () => {


### PR DESCRIPTION
## Summary

Patch 2 of the cleanup roadmap (`.plans/2026-07-03/codebase-improvements.md`) — the archive/close-path defects the audit's deep-dive confirmed.

- **Forum tag accumulation restored**: `applyForumTags` used `setAppliedTags` with only the DB-tracked list, silently wiping tags moderators added by hand. It now merges with the thread's live tags (live first, incoming deduped) and logs anything the 5-tag Discord cap drops. New `forumTagManager.test.ts` pins the behavior.
- **API close/archive revert-on-throw**: `POST /tickets/:id/close` and `POST /applications/:id/archive` called the close workflow unwrapped — an unexpected throw stranded the entity `status='closed'` with a live channel and no retry path. Both now revert the status and rethrow, matching the Discord-button flow.
- **Atomic close flip**: the "already closed" guard was check-then-set in both the button event and the API handlers; two near-simultaneous closes could both pass it. The flip is now `UPDATE ... WHERE status != 'closed'` with an affected-rows check — the loser is told it's already closed.

## Test plan

- [x] `bun test` — 1427 pass (new: flip-race lost path in event + API suites, revert-on-throw API test, full forumTagManager suite)
- [x] `bun run build`, `bun run check`, `bun run check:changelog`, contract regenerated for 3.14.2
- [ ] Dev-bot spot check: double-click Confirm Close rapidly; re-close a ticket into a thread with a manually-added tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ