### PR TITLE
fix: v3.14.3 — wire the dead autocomplete (audit findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.3] - 2026-07-05
+
+Autocomplete that never worked, now wired.
+
+### Fixed
+
+- **/automod autocomplete works**: all eight rule-picker options (rule
+  edit/delete, keyword add/remove, regex add/remove, exempt add/remove)
+  declared autocomplete but the handler was never registered — the dropdown
+  silently never responded. It now suggests the guild's AutoMod rules by name.
+- **/event autocomplete works** (broken since v3.0.0): template names now
+  autocomplete on `from-template`, `recurring`, and `template edit/delete`,
+  and `cancel`/`remind` suggest the server's live scheduled events by name.
+- **/automod template choices** are now derived from the template catalog
+  instead of a hand-synced list, so new templates appear automatically.
+
 ## [3.14.2] - 2026-07-05
 
 Archive close-path bugs from the audit deep-dive.

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.2",
+  "botVersion": "3.14.3",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.2",
+  "version": "3.14.3",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/builders/automod.ts
+++ b/src/commands/builders/automod.ts
@@ -65,8 +65,10 @@ const templateGroup = new SlashCommandSubcommandGroupBuilder()
           .setDescription(tl.template.apply.template)
           .setRequired(true)
           // Derived from the template catalog — a new template shows up here
-          // without hand-syncing this list.
-          .addChoices(...TEMPLATE_IDS.map(id => ({ name: AUTOMOD_TEMPLATES[id].name, value: id }))),
+          // without hand-syncing this list. slice(25): Discord caps choices at
+          // 25 per option, and an oversized list would crash command
+          // registration for the whole bot, not just this command.
+          .addChoices(...TEMPLATE_IDS.slice(0, 25).map(id => ({ name: AUTOMOD_TEMPLATES[id].name, value: id }))),
       ),
   );
 

--- a/src/commands/builders/automod.ts
+++ b/src/commands/builders/automod.ts
@@ -1,5 +1,6 @@
 import { PermissionFlagsBits, SlashCommandBuilder, SlashCommandSubcommandGroupBuilder } from 'discord.js';
 import { lang } from '../../utils';
+import { AUTOMOD_TEMPLATES, TEMPLATE_IDS } from '../../utils/automod/templates';
 
 const tl = lang.automod.builder;
 
@@ -63,12 +64,9 @@ const templateGroup = new SlashCommandSubcommandGroupBuilder()
           .setName('template')
           .setDescription(tl.template.apply.template)
           .setRequired(true)
-          .addChoices(
-            { name: 'Anti-Spam', value: 'anti-spam' },
-            { name: 'Anti-Phishing', value: 'anti-phishing' },
-            { name: 'Family-Friendly', value: 'family-friendly' },
-            { name: 'Gaming', value: 'gaming' },
-          ),
+          // Derived from the template catalog — a new template shows up here
+          // without hand-syncing this list.
+          .addChoices(...TEMPLATE_IDS.map(id => ({ name: AUTOMOD_TEMPLATES[id].name, value: id }))),
       ),
   );
 

--- a/src/commands/handlers/event/create.ts
+++ b/src/commands/handlers/event/create.ts
@@ -273,7 +273,14 @@ export async function scheduledEventAutocomplete(interaction: AutocompleteIntera
     const focused = interaction.options.getFocused().toLowerCase();
     const filtered = focused ? events.filter(e => e.name.toLowerCase().includes(focused)) : events;
     await interaction.respond([...filtered.values()].slice(0, 25).map(e => ({ name: e.name, value: e.id })));
-  } catch {
+  } catch (error) {
+    // Best-effort: an empty dropdown is the correct UX, but the failure is
+    // still worth a trace (debug — routine permission misses would spam
+    // anything louder).
+    enhancedLogger.debug('Scheduled-event autocomplete fetch failed', LogCategory.COMMAND_EXECUTION, {
+      guildId: interaction.guildId ?? undefined,
+      reason: error instanceof Error ? error.message : String(error),
+    });
     await interaction.respond([]).catch(() => null);
   }
 }

--- a/src/commands/handlers/event/create.ts
+++ b/src/commands/handlers/event/create.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  type AutocompleteInteraction,
   type CacheType,
   type ChatInputCommandInteraction,
   type Client,
@@ -256,6 +257,26 @@ export async function handleFromTemplate(
 // ============================================================================
 // Cancel
 // ============================================================================
+
+/**
+ * Autocomplete for the 'event' option on /event cancel + /event remind —
+ * suggests the guild's live scheduled events by name, resolving to the id
+ * the handlers fetch with.
+ */
+export async function scheduledEventAutocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  if (!interaction.guild) {
+    await interaction.respond([]);
+    return;
+  }
+  try {
+    const events = await interaction.guild.scheduledEvents.fetch();
+    const focused = interaction.options.getFocused().toLowerCase();
+    const filtered = focused ? events.filter(e => e.name.toLowerCase().includes(focused)) : events;
+    await interaction.respond([...filtered.values()].slice(0, 25).map(e => ({ name: e.name, value: e.id })));
+  } catch {
+    await interaction.respond([]).catch(() => null);
+  }
+}
 
 export async function handleEventCancel(
   _client: Client,

--- a/src/commands/handlers/event/template.ts
+++ b/src/commands/handlers/event/template.ts
@@ -389,10 +389,16 @@ export async function eventTemplateAutocomplete(
   const filtered = templates
     .filter(t => t.name.includes(focused) || t.title.toLowerCase().includes(focused))
     .slice(0, 25)
-    .map(t => ({
-      name: `${t.title} (${t.entityType})`,
-      value: t.name,
-    }));
+    .map(t => {
+      // Discord caps autocomplete choice names at 100 chars; titles alone can
+      // be 100 (modal max) and the suffix pushes past — one over-long template
+      // would make Discord reject the whole payload and blank the dropdown.
+      const name = `${t.title} (${t.entityType})`;
+      return {
+        name: name.length > 100 ? `${name.slice(0, 99)}…` : name,
+        value: t.name,
+      };
+    });
 
   await respond(filtered);
 }

--- a/src/events/autocomplete.ts
+++ b/src/events/autocomplete.ts
@@ -5,7 +5,10 @@ import {
   applicationRemovableStatusAutocomplete,
   applicationWorkflowStatusAutocomplete,
 } from '../commands/handlers/application/workflow';
+import { handleAutomodAutocomplete } from '../commands/handlers/automod';
 import { handleKeywordAutocomplete } from '../commands/handlers/baitChannel/keywords';
+import { scheduledEventAutocomplete } from '../commands/handlers/event/create';
+import { eventTemplateAutocomplete } from '../commands/handlers/event/template';
 import { memoryAutocomplete } from '../commands/handlers/memory';
 import { memoryTagAutocomplete } from '../commands/handlers/memory/manageTags';
 import { reactionRoleMenuAutocomplete } from '../commands/handlers/reactionRole';
@@ -58,6 +61,16 @@ const AUTOCOMPLETE_ROUTES: Record<string, AutocompleteHandler> = {
   'memory-setup//tag-edit': memoryTagAutocomplete,
   // /baitchannel detection *
   'baitchannel/detection/keywords': handleKeywordAutocomplete,
+  // /event * — template-name options (never wired until v3.14.3)
+  'event//from-template': interaction =>
+    eventTemplateAutocomplete(interaction, choices => interaction.respond(choices)),
+  'event//recurring': interaction => eventTemplateAutocomplete(interaction, choices => interaction.respond(choices)),
+  'event/template/edit': interaction => eventTemplateAutocomplete(interaction, choices => interaction.respond(choices)),
+  'event/template/delete': interaction =>
+    eventTemplateAutocomplete(interaction, choices => interaction.respond(choices)),
+  // /event * — live scheduled-event options
+  'event//cancel': scheduledEventAutocomplete,
+  'event//remind': scheduledEventAutocomplete,
 };
 
 /**
@@ -67,6 +80,8 @@ const AUTOCOMPLETE_ROUTES: Record<string, AutocompleteHandler> = {
 const COMMAND_AUTOCOMPLETE_ROUTES: Record<string, AutocompleteHandler> = {
   reactionrole: reactionRoleMenuAutocomplete,
   announcement: interaction => templateAutocomplete(interaction, choices => interaction.respond(choices)),
+  // Every flagged /automod option is a 'rule' picker (never wired until v3.14.3)
+  automod: handleAutomodAutocomplete,
 };
 
 /** Handles autocomplete interactions for all commands. */

--- a/tests/unit/handlers/event/scheduledEventAutocomplete.test.ts
+++ b/tests/unit/handlers/event/scheduledEventAutocomplete.test.ts
@@ -1,0 +1,78 @@
+/**
+ * scheduledEventAutocomplete unit tests — the /event cancel + /event remind
+ * 'event' option picker, wired for the first time in v3.14.3.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { scheduledEventAutocomplete } from '../../../../src/commands/handlers/event/create';
+
+function makeInteraction(opts: { events?: Array<{ id: string; name: string }>; focused?: string; noGuild?: boolean }) {
+  const responses: Array<Array<{ name: string; value: string }>> = [];
+  const collection = new Map((opts.events ?? []).map(e => [e.id, e]));
+  const interaction = {
+    guild: opts.noGuild
+      ? null
+      : {
+          scheduledEvents: {
+            fetch: async () => ({
+              filter: (fn: (e: { id: string; name: string }) => boolean) => {
+                const kept = new Map([...collection.entries()].filter(([, e]) => fn(e)));
+                return { values: () => kept.values() };
+              },
+              values: () => collection.values(),
+            }),
+          },
+        },
+    options: { getFocused: () => opts.focused ?? '' },
+    respond: async (choices: Array<{ name: string; value: string }>) => {
+      responses.push(choices);
+    },
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: minimal AutocompleteInteraction test double
+  return { interaction: interaction as any, responses };
+}
+
+describe('scheduledEventAutocomplete', () => {
+  test('suggests live scheduled events as name → id choices', async () => {
+    const { interaction, responses } = makeInteraction({
+      events: [
+        { id: 'e1', name: 'Movie Night' },
+        { id: 'e2', name: 'Game Tournament' },
+      ],
+    });
+    await scheduledEventAutocomplete(interaction);
+    expect(responses).toEqual([
+      [
+        { name: 'Movie Night', value: 'e1' },
+        { name: 'Game Tournament', value: 'e2' },
+      ],
+    ]);
+  });
+
+  test('filters by the focused value, case-insensitively', async () => {
+    const { interaction, responses } = makeInteraction({
+      events: [
+        { id: 'e1', name: 'Movie Night' },
+        { id: 'e2', name: 'Game Tournament' },
+      ],
+      focused: 'movie',
+    });
+    await scheduledEventAutocomplete(interaction);
+    expect(responses).toEqual([[{ name: 'Movie Night', value: 'e1' }]]);
+  });
+
+  test('no guild → empty response', async () => {
+    const { interaction, responses } = makeInteraction({ noGuild: true });
+    await scheduledEventAutocomplete(interaction);
+    expect(responses).toEqual([[]]);
+  });
+
+  test('fetch failure → empty response, no throw', async () => {
+    const { interaction, responses } = makeInteraction({});
+    interaction.guild.scheduledEvents.fetch = async () => {
+      throw new Error('Missing Access');
+    };
+    await scheduledEventAutocomplete(interaction);
+    expect(responses).toEqual([[]]);
+  });
+});


### PR DESCRIPTION
## Summary

Patch 3 of the cleanup roadmap — the audit found two whole autocomplete surfaces that declared `setAutocomplete(true)` but never registered a handler, so Discord showed a spinner that never resolved:

- **/automod** (8 rule-picker options): `handleAutomodAutocomplete` existed but had zero importers. Wired as the command-wide fallback — every flagged option is a 'rule' picker suggesting the guild's AutoMod rules by name.
- **/event** (6 options, broken since v3.0.0): template names now autocomplete on `from-template`, `recurring`, `template edit`, `template delete`; new `scheduledEventAutocomplete` suggests live scheduled events (name → id) for `cancel`/`remind`, which previously required pasting a raw event ID.
- **`TEMPLATE_IDS` consumed**: `/automod template apply` choices are now derived from the template catalog instead of a hand-synced literal list (the audit flagged the export as dead — it was built for exactly this).

## Test plan

- [x] `bun test` — 1434 pass (new scheduledEventAutocomplete suite: suggestions, filtering, no-guild, fetch-failure)
- [x] `bun run build`, `bun run check`, `bun run check:changelog` green; contract regenerated for 3.14.3
- [ ] Dev-bot spot check: type `/automod rule edit` and `/event cancel` and confirm the dropdowns populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved autocomplete for event commands, including template-based flows and scheduled event actions.
  * Automod template choices now update automatically when new templates are added.

* **Bug Fixes**
  * Restored autocomplete suggestions for automod rule selection.
  * Fixed event autocomplete so it works again across create, edit, delete, cancel, and remind workflows.

* **Chores**
  * Updated the release version to 3.14.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->