### PR TITLE
chore: v3.14.4 — docs drift sweep (audit findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.4] - 2026-07-06
+
+Documentation catch-up — no code changes.
+
+### Changed
+
+- CLAUDE.md and README brought back in line with reality: current test runner
+  (`bun test`, not Jest), TypeScript 6, per-locale language files, the full
+  environment-variable list, all 15 internal API handler groups, corrected
+  directory trees (`logger.ts` → `time.ts`, `featurePermission` under
+  `validation/`, `utils/application/` added), and the real `baitchannel`
+  subcommand-group count.
+
 ## [3.14.3] - 2026-07-05
 
 Autocomplete that never worked, now wired.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,8 +303,11 @@ await runner.runAll(guildIds);
 - `APPEAL_HMAC_SECRET` — 32+ byte random secret (v3.2.0). Required only when any guild has `BaitChannelConfig.enableAppealLink=true`; signed appeal URLs are silently omitted from DMs when missing.
 - `ERROR_WEBHOOK_URL` / `ERROR_REPORTING_ENABLED` — Discord error-reporter webhook (v3.1.1; default on in prod, off in dev)
 - `STATUS_CHANNEL_ID` — Channel for the status manager's persistent embed
-- `MEMORY_ALERT_CHANNEL_ID` / `MEMORY_THRESHOLD_MB` — Memory watchdog alerts
-- `API_URL` / `DASHBOARD_URL` — External dashboard endpoints (apiConnector)
+- `MEMORY_ALERT_CHANNEL_ID` — Memory watchdog alert channel (falls back to `STATUS_CHANNEL_ID`); tunables: `MEMORY_WARN_HEAP_PCT`, `MEMORY_CRIT_HEAP_PCT`, `MEMORY_MAP_WARN_SIZE`
+- `MEMORY_THRESHOLD_MB` — Health-check memory threshold (healthMonitor/healthServer, default 512)
+- `API_URL` — External dashboard API endpoint (apiConnector + guild webhooks)
+- `DASHBOARD_URL` — Base URL for user-facing dashboard links (`/dashboard` command, profile embeds)
+- `NODE_ENV` — Log level / file logging / colorization (enhancedLogger)
 
 ### Build & Run
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 - **Runtime**: Bun
 - **Deployment**: Docker containers
 - **Branches**: `main` (production)
-- **Version**: 3.14.0 (see `package.json` — this line drifts; trust the package)
+- **Version**: 3.14.4 (see `package.json` — this line drifts; trust the package)
 
 ## Critical Rules
 
@@ -80,7 +80,7 @@ const group = interaction.options.getSubcommandGroup(true);
 const subcommand = interaction.options.getSubcommand();
 const handler = TICKET_GROUP_ROUTES[group]?.[subcommand];
 ```
-Commands using groups: `ticket` (5 groups), `baitchannel` (5 groups), `application`, `event`, `announcement`, `automod`, `role`.
+Commands using groups: `ticket` (5 groups), `baitchannel` (6 groups), `application`, `event`, `announcement`, `automod`, `role`.
 
 ### Language System
 Use centralized `lang` module (NOT hardcoded strings):
@@ -89,7 +89,7 @@ import { lang } from '../utils';
 lang.ticket.created;          // Direct access
 lang.ticketSetup.createTicket; // Setup strings are under ticketSetup/applicationSetup keys
 ```
-Translation files: `src/lang/*.json` with types in `src/lang/types.ts`.
+Translation files: per-locale dirs `src/lang/<locale>/*.json` (en, es, fr, de, pt-BR — English is the Proxy fallback) with types in `src/lang/types.ts`.
 
 ### Error Handling
 ```typescript
@@ -293,19 +293,25 @@ await runner.runAll(guildIds);
 ### Environment Variables
 - `RELEASE=dev` → `DEV_BOT_TOKEN` + `DEV_CLIENT_ID` (separate bot)
 - `RELEASE=prod` → `BOT_TOKEN` + `CLIENT_ID` (production)
+- `MYSQL_DB_HOST` / `MYSQL_DB_PORT` / `MYSQL_DB_USERNAME` / `MYSQL_DB_PASSWORD` / `MYSQL_DB_DATABASE` — DataSource connection
 - `MAINTENANCE_MODE=true` — Lightweight mode, no DB, replies with maintenance message (see `src/maintenance.ts`)
 - `BOT_OWNER_ID` — Required for `/status` commands
 - `DEV_GUILD_ID` — Skips API webhooks and join velocity for this guild
 - `COGWORKS_INTERNAL_API_TOKEN` — Bearer token for internal API
 - `BOT_INTERNAL_PORT` — Internal API port (default: 3002)
+- `HEALTH_PORT` — Health server port
 - `APPEAL_HMAC_SECRET` — 32+ byte random secret (v3.2.0). Required only when any guild has `BaitChannelConfig.enableAppealLink=true`; signed appeal URLs are silently omitted from DMs when missing.
+- `ERROR_WEBHOOK_URL` / `ERROR_REPORTING_ENABLED` — Discord error-reporter webhook (v3.1.1; default on in prod, off in dev)
+- `STATUS_CHANNEL_ID` — Channel for the status manager's persistent embed
+- `MEMORY_ALERT_CHANNEL_ID` / `MEMORY_THRESHOLD_MB` — Memory watchdog alerts
+- `API_URL` / `DASHBOARD_URL` — External dashboard endpoints (apiConnector)
 
 ### Build & Run
 ```bash
 bun run dev        # Development with watch mode
 bun run build      # Compile TypeScript to dist/
 bun run start      # Production: run directly with Bun
-bun test           # Jest unit tests
+bun test           # Unit tests (Bun test runner)
 ```
 
 ### Linting & Formatting (Biome)
@@ -379,10 +385,11 @@ src/
 │   ├── analytics/          # activityTracker, snapshot query helpers
 │   ├── announcement/       # preview builders, send orchestration
 │   ├── api/                # Internal API server, router, handlers, guildWebhook, helpers
+│   ├── application/        # closeWorkflow (archiveAndCloseApplication)
 │   ├── archive/            # archiveExporter (export + delete archived data)
 │   ├── automod/            # automod rules + feature setup
 │   ├── baitChannel/        # BaitChannelManager + whitelist + keyword helpers
-│   ├── database/           # guildQueries, logCleanup, legacyMigration, lazyRepo, safeDbOperation
+│   ├── database/           # guildQueries, logCleanup, legacyMigration, lazyRepo, statusFlip, configCache
 │   ├── discord/            # verifiedDelete (deletion with verification + bug report)
 │   ├── event/              # event template + reminder helpers
 │   ├── import/             # mee6 / bot-import helpers (some deferred)
@@ -392,11 +399,11 @@ src/
 │   ├── onboarding/         # onboarding flow helpers
 │   ├── reactionRole/       # menu + option persistence helpers
 │   ├── rules/              # rulesCache (invalidateRulesCache lives here — v3.1.6)
-│   ├── security/           # rateLimiter, featurePermission (v3.1.3)
+│   ├── security/           # rateLimiter
 │   ├── setup/              # channelCreator, channelDefaults, channelFormatDetector, configStatusEmbed
 │   ├── status/             # statusManager (client-attached)
-│   ├── ticket/             # autoClose, slaChecker, smartRouter, closeWorkflow, builtinTypes, routingTypes, transcriptBuilder
-│   ├── validation/         # permissionValidator, inputSanitizer, validators
+│   ├── ticket/             # autoClose, slaChecker, smartRouter, closeWorkflow, builtinTypes, transcriptBuilder, transcriptPoster
+│   ├── validation/         # permissionValidator, featurePermission, inputSanitizer, validators
 │   ├── workflow/           # cross-feature workflow helpers
 │   ├── xp/                 # xp calc + role reward helpers
 │   ├── apiConnector.ts     # External API client (dashboard sync)
@@ -408,7 +415,7 @@ src/
 │   ├── errorHandler.ts     # classifyError, handleInteractionError
 │   ├── fetchAllMessages.ts # fetchMessagesAsTranscript (v3.1.8)
 │   ├── forumTagManager.ts  # ensureForumTag helpers
-│   ├── logger.ts           # Direct logger (breaks utils/index.ts cycle)
+│   ├── time.ts             # sleep, toUnixSeconds, nowUnixSeconds (v3.11.1)
 │   ├── modalComponents.ts  # Shared modal field helpers
 │   ├── profileFunctions.ts # Per-request performance profiling
 │   ├── reactionCooldown.ts # Reaction add throttling
@@ -479,7 +486,7 @@ thread.edit({ appliedTags: mergedTags });
 ### Internal API (v3.0.0)
 HTTP server on port 3002 for dashboard. Auth: Bearer token with timing-safe comparison.
 - Pattern: `POST /internal/guilds/:guildId/<feature>/<action>`
-- Handlers: `src/utils/api/handlers/` — tickets, applications, announcements, memory, rules, reactionRoles, guilds, config, setup
+- Handlers: `src/utils/api/handlers/` — tickets, applications, announcements, memory, rules, reactionRoles, guilds, config, setup, analytics, baitChannel, commands, maintenance, permissions, status
 - **Body field validation**: Use helpers from `src/utils/api/helpers.ts` — never use `as string` casts on `body` fields:
 ```typescript
 import { requireString, optionalString, requireNumber, optionalNumber, requireBoolean, optionalStringArray } from '../helpers';
@@ -522,9 +529,9 @@ const triggeredBy = optionalString(body, 'triggeredBy');   // for audit logs
 
 ## Testing
 
-- Runner: `bun test` (no separate config). Setup: `tests/setup.ts` (`import 'reflect-metadata'`).
+- Runner: `bun test` (no separate config or preload — `tests/setup.ts` exists but is not wired).
 - Run: `bun test` or `bun run test:watch`
-- Tests: `tests/unit/` — events, utils, handlers
+- Tests: `tests/unit/` — commands, contract, events, handlers, utils (plus `tests/integration/` and `tests/manual/`)
 - Imports: use `from 'bun:test'` (NOT `from '@jest/globals'` — Jest was removed in v3.1.35).
 - Mocking: prefer hand-rolled fakes / `mock.module(...)` from `bun:test`. `jest.fn()` / `jest.spyOn()` work via Bun's compatibility shim. `jest.mock()` is NOT supported — use `mock.module()` instead.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ All-in-one Discord server management. Tickets, applications, XP, reaction roles,
 <p>
   <img src="https://img.shields.io/github/package-json/v/NindroidA/cogworks-bot?style=flat-square&color=blue" alt="Version" />
   <img src="https://img.shields.io/badge/discord.js-v14-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord.js" />
-  <img src="https://img.shields.io/badge/TypeScript-5.9-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/TypeScript-6.0-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
   <img src="https://img.shields.io/badge/runtime-Bun-f9f1e1?style=flat-square&logo=bun&logoColor=white" alt="Bun" />
   <img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-green?style=flat-square" alt="License" />
   <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/NindroidA/cogworks-bot/main/.github/badges/loc.json&style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBvbHlsaW5lIHBvaW50cz0iMTYgMTggMjIgMTIgMTYgNiIvPjxwb2x5bGluZSBwb2ludHM9IjggNiAyIDEyIDggMTgiLz48L3N2Zz4=" alt="Lines of Code" />
@@ -104,13 +104,13 @@ Plus: AutoMod integration, context menus, outage status, role management, MEE6 i
 
 | Component | Technology |
 |-----------|------------|
-| Language | TypeScript 5.9 |
+| Language | TypeScript 6.0 |
 | Runtime | Bun (Node.js compatible) |
 | Framework | Discord.js v14 |
 | Database | MySQL + TypeORM |
 | Deployment | Docker |
 | Linting | Biome |
-| Testing | Jest + ts-jest |
+| Testing | `bun test` (Bun test runner) |
 | Monitoring | Structured logging + HTTP health endpoints |
 
 ## Codebase Health

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.3",
+  "botVersion": "3.14.4",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.3",
+  "version": "3.14.4",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch 4 of the cleanup roadmap — all 13 remaining docs-drift findings from the audit, each **verified against the code before editing** (env-var sweep via grep of `process.env.*`, handler/dir listings, builder group counts, package.json).

Doc-only: CLAUDE.md + README.md (+ version/contract bump). Highlights:
- Env-var list now covers everything the code actually reads (was missing ~10 including all `MYSQL_DB_*`)
- Internal API handler list: 15 groups, not 9
- Directory trees corrected (`logger.ts` never existed → `time.ts`; `featurePermission` is in `validation/`; `utils/application/` added; `routingTypes` moved in v3.1.31)
- Test-runner claims fixed (`bun test`, not Jest; `tests/setup.ts` is not actually wired)
- README: TypeScript 6.0, bun test

## Test plan

- [x] `bun test` — 1434 pass (no code changes)
- [x] Build, Biome, changelog gate, contract gate all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ