### PR TITLE
fix: v3.14.5 — guard + API validation consistency (audit findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.5] - 2026-07-06
+
+Permission-guard and API-validation consistency.
+
+### Changed
+
+- **`/ticket-setup` and `/memory-setup` now honor webapp permissions**: both
+  used the legacy admin-only guard even though their features are in the
+  permission catalog — a webapp-granted tickets/memory manager couldn't run
+  them. Behavior for guilds without permission overrides is unchanged
+  (admin-only fallback).
+- **`/dev` archive-deletion commands** (bulk-close tickets, delete archived
+  tickets/applications) moved to feature-scoped `admin`-level guards, so the
+  webapp permission UI governs them like every other destructive action.
+
+### Fixed
+
+- **Internal API validation**: the announcement send route validated its
+  `params` object instead of blind-casting it (a non-object now returns 400),
+  and reaction-role `mode` is checked against `normal`/`unique`/`lock` — a
+  garbage mode used to be persisted verbatim and then silently never match at
+  reaction time. New `optionalRecord`/`optionalEnum` helpers with tests.
+- **Bait-channel pending-ban cleanup is always guild-scoped**: the delete
+  criteria's guild filter was optional; it's now required (data-isolation
+  invariant).
+
 ## [3.14.4] - 2026-07-06
 
 Documentation catch-up — no code changes.

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.4",
+  "botVersion": "3.14.5",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.4",
+  "version": "3.14.5",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/dev/applicationDev.ts
+++ b/src/commands/handlers/dev/applicationDev.ts
@@ -1,7 +1,7 @@
 import { type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 import { AppDataSource } from '../../../typeorm';
 import { ArchivedApplication } from '../../../typeorm/entities/application/ArchivedApplication';
-import { enhancedLogger, guardAdmin, handleInteractionError, LogCategory, lang } from '../../../utils';
+import { enhancedLogger, guardFeatureAccess, handleInteractionError, LogCategory, lang } from '../../../utils';
 
 /**
  * Delete a specific archived application by user
@@ -9,7 +9,7 @@ import { enhancedLogger, guardAdmin, handleInteractionError, LogCategory, lang }
  */
 export async function deleteArchivedApplicationHandler(interaction: ChatInputCommandInteraction): Promise<void> {
   try {
-    const guard = await guardAdmin(interaction);
+    const guard = await guardFeatureAccess(interaction, 'applications', 'admin');
     if (!guard.allowed) return;
 
     const user = interaction.options.getUser('user', true);
@@ -62,7 +62,7 @@ export async function deleteArchivedApplicationHandler(interaction: ChatInputCom
  */
 export async function deleteAllArchivedApplicationsHandler(interaction: ChatInputCommandInteraction): Promise<void> {
   try {
-    const guard = await guardAdmin(interaction);
+    const guard = await guardFeatureAccess(interaction, 'applications', 'admin');
     if (!guard.allowed) return;
 
     await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });

--- a/src/commands/handlers/dev/ticketDev.ts
+++ b/src/commands/handlers/dev/ticketDev.ts
@@ -2,7 +2,7 @@ import { type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 import { AppDataSource } from '../../../typeorm';
 import { ArchivedTicket } from '../../../typeorm/entities/ticket/ArchivedTicket';
 import { Ticket } from '../../../typeorm/entities/ticket/Ticket';
-import { enhancedLogger, guardAdmin, handleInteractionError, LogCategory, lang } from '../../../utils';
+import { enhancedLogger, guardFeatureAccess, handleInteractionError, LogCategory, lang } from '../../../utils';
 import { findManyByGuild } from '../../../utils/database/guildQueries';
 
 /**
@@ -11,7 +11,7 @@ import { findManyByGuild } from '../../../utils/database/guildQueries';
  */
 export async function bulkCloseTicketsHandler(interaction: ChatInputCommandInteraction): Promise<void> {
   try {
-    const guard = await guardAdmin(interaction);
+    const guard = await guardFeatureAccess(interaction, 'tickets', 'admin');
     if (!guard.allowed) return;
 
     await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });
@@ -72,7 +72,7 @@ export async function bulkCloseTicketsHandler(interaction: ChatInputCommandInter
  */
 export async function deleteArchivedTicketHandler(interaction: ChatInputCommandInteraction): Promise<void> {
   try {
-    const guard = await guardAdmin(interaction);
+    const guard = await guardFeatureAccess(interaction, 'tickets', 'admin');
     if (!guard.allowed) return;
 
     const user = interaction.options.getUser('user', true);
@@ -125,7 +125,7 @@ export async function deleteArchivedTicketHandler(interaction: ChatInputCommandI
  */
 export async function deleteAllArchivedTicketsHandler(interaction: ChatInputCommandInteraction): Promise<void> {
   try {
-    const guard = await guardAdmin(interaction);
+    const guard = await guardFeatureAccess(interaction, 'tickets', 'admin');
     if (!guard.allowed) return;
 
     await interaction.deferReply({ flags: [MessageFlags.Ephemeral] });

--- a/src/commands/handlers/memorySetup.ts
+++ b/src/commands/handlers/memorySetup.ts
@@ -19,7 +19,7 @@ import {
   Colors,
   E,
   enhancedLogger,
-  guardAdminRateLimit,
+  guardFeatureRateLimit,
   LogCategory,
   lang,
   RateLimits,
@@ -51,7 +51,9 @@ const DEFAULT_STATUS_TAGS = [
 ];
 
 export async function memorySetupHandler(client: Client, interaction: ChatInputCommandInteraction) {
-  const guard = await guardAdminRateLimit(interaction, {
+  // 'memory' is in the FEATURES catalog — all eight handlers in memory/ are
+  // already feature-guarded; this was the odd one out.
+  const guard = await guardFeatureRateLimit(interaction, 'memory', 'manage', {
     action: 'memory-setup',
     limit: RateLimits.BOT_SETUP,
     scope: 'guild',

--- a/src/commands/handlers/ticketSetup.ts
+++ b/src/commands/handlers/ticketSetup.ts
@@ -16,7 +16,7 @@ import {
   buildConfigStatusEmbed,
   cleanupOldMessage,
   enhancedLogger,
-  guardAdminRateLimit,
+  guardFeatureRateLimit,
   LogCategory,
   lang,
   RateLimits,
@@ -170,7 +170,9 @@ function buildTicketStatusEmbed(
 }
 
 export async function ticketSetupHandler(_client: Client, interaction: ChatInputCommandInteraction<CacheType>) {
-  const guard = await guardAdminRateLimit(interaction, {
+  // 'tickets' is in the FEATURES catalog — feature-scoped guard so the webapp
+  // permission UI is load-bearing (matches every sibling setup handler).
+  const guard = await guardFeatureRateLimit(interaction, 'tickets', 'manage', {
     action: 'ticket-setup',
     limit: RateLimits.TICKET_SETUP,
     scope: 'guild',

--- a/src/utils/api/handlers/announcementHandlers.ts
+++ b/src/utils/api/handlers/announcementHandlers.ts
@@ -8,7 +8,7 @@ import { MAX } from '../../constants';
 import { lazyRepo } from '../../database/lazyRepo';
 import { sanitizeUserInput } from '../../validation/inputSanitizer';
 import { ApiError } from '../apiError';
-import { isValidSnowflake, optionalString, requireString, validateHexColor } from '../helpers';
+import { isValidSnowflake, optionalRecord, optionalString, requireString, validateHexColor } from '../helpers';
 import type { RouteHandler } from '../router';
 import { writeAuditAction } from './auditHelper';
 
@@ -43,7 +43,7 @@ export function registerAnnouncementHandlers(client: Client, routes: Map<string,
       const roleId = config?.defaultRoleId;
 
       const params: TemplatePlaceholderParams = {};
-      const bodyParams = (body.params as Record<string, unknown>) || {};
+      const bodyParams = optionalRecord(body, 'params') ?? {};
       if (bodyParams.version) params.version = String(bodyParams.version);
       if (bodyParams.duration) params.duration = String(bodyParams.duration);
       if (bodyParams.time) params.time = Number(bodyParams.time);

--- a/src/utils/api/handlers/reactionRoleHandlers.ts
+++ b/src/utils/api/handlers/reactionRoleHandlers.ts
@@ -5,7 +5,7 @@ import { lazyRepo } from '../../database/lazyRepo';
 import { buildMenuEmbed, updateMenuMessage } from '../../reactionRole/menuBuilder';
 import { invalidateGuildMenuCache } from '../../reactionRole/menuCache';
 import { ApiError } from '../apiError';
-import { getAndValidateEntity, isValidSnowflake, optionalString, requireString } from '../helpers';
+import { getAndValidateEntity, isValidSnowflake, optionalEnum, optionalString, requireString } from '../helpers';
 import type { RouteHandler } from '../router';
 import { writeAuditAction } from './auditHelper';
 
@@ -27,7 +27,9 @@ export function registerReactionRoleHandlers(client: Client, routes: Map<string,
       throw ApiError.notFound('Channel not found or not a text channel');
     }
 
-    const mode = (optionalString(body, 'mode') as ReactionRoleMode) || 'normal';
+    // Validated union — a garbage mode used to be persisted verbatim and then
+    // silently never match the 'unique'/'lock' comparisons at reaction time.
+    const mode: ReactionRoleMode = optionalEnum(body, 'mode', ['normal', 'unique', 'lock'] as const) ?? 'normal';
     const description = optionalString(body, 'description') ?? null;
 
     // Create menu entity first (need ID for options)

--- a/src/utils/api/helpers.ts
+++ b/src/utils/api/helpers.ts
@@ -147,3 +147,21 @@ export function optionalStringArray(body: Body, field: string): string[] | undef
   }
   return v as string[];
 }
+
+/** Extract an optional plain-object field. Returns undefined if absent/null. Throws 400 if not an object. */
+export function optionalRecord(body: Body, field: string): Record<string, unknown> | undefined {
+  const v = body[field];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== 'object' || Array.isArray(v)) throw ApiError.badRequest(`${field} must be an object`);
+  return v as Record<string, unknown>;
+}
+
+/** Extract an optional string field constrained to a fixed set of values. Throws 400 on anything else. */
+export function optionalEnum<T extends string>(body: Body, field: string, allowed: readonly T[]): T | undefined {
+  const v = optionalString(body, field);
+  if (v === undefined) return undefined;
+  if (!(allowed as readonly string[]).includes(v)) {
+    throw ApiError.badRequest(`${field} must be one of: ${allowed.join(', ')}`);
+  }
+  return v as T;
+}

--- a/src/utils/baitChannel/baitChannelManager.ts
+++ b/src/utils/baitChannel/baitChannelManager.ts
@@ -215,12 +215,13 @@ export class BaitChannelManager {
     }
   }
 
-  private async removePendingBanFromDb(userId: string, messageId: string, guildId?: string): Promise<void> {
+  // guildId is REQUIRED — an unscoped {userId, messageId} delete would cross
+  // guild boundaries, and guild scoping is the project's data-isolation
+  // invariant (CLAUDE.md Critical Rules), not an optional refinement.
+  private async removePendingBanFromDb(userId: string, messageId: string, guildId: string): Promise<void> {
     if (!this.pendingActionRepo) return;
     try {
-      const where: Record<string, string> = { userId, messageId };
-      if (guildId) where.guildId = guildId;
-      await this.pendingActionRepo.delete(where);
+      await this.pendingActionRepo.delete({ userId, messageId, guildId });
     } catch (error) {
       logError({
         category: ErrorCategory.DATABASE,
@@ -790,7 +791,7 @@ export class BaitChannelManager {
 
         // Message still exists - remove from pending and execute action
         this.pendingBans.delete(key);
-        await this.removePendingBanFromDb(member.id, message.id, message.guild?.id);
+        await this.removePendingBanFromDb(member.id, message.id, member.guild.id);
         await this.executeAction(member, message, config, analysis, 'Grace period expired');
 
         // Delete the bot's warning message
@@ -812,7 +813,7 @@ export class BaitChannelManager {
         // Check again in case handleMessageDelete ran between our check and here
         if (this.pendingBans.has(key)) {
           this.pendingBans.delete(key);
-          await this.removePendingBanFromDb(member.id, message.id, message.guild?.id);
+          await this.removePendingBanFromDb(member.id, message.id, member.guild.id);
           await this.logAction(message, member, 'deleted-in-time', config, analysis);
 
           // Delete the bot's warning message since the user complied

--- a/tests/unit/utils/api/helpers.test.ts
+++ b/tests/unit/utils/api/helpers.test.ts
@@ -11,6 +11,8 @@ import {
   optionalNumber,
   requireBoolean,
   optionalStringArray,
+  optionalRecord,
+  optionalEnum,
 } from "../../../../src/utils/api/helpers";
 
 // ===========================================================================
@@ -553,5 +555,56 @@ describe("optionalStringArray", () => {
       return;
     }
     throw new Error("Expected to throw");
+  });
+});
+
+// ===========================================================================
+// optionalRecord (v3.14.5)
+// ===========================================================================
+describe("optionalRecord", () => {
+  test("returns the object when present", () => {
+    expect(optionalRecord({ params: { a: 1 } }, "params")).toEqual({ a: 1 });
+  });
+
+  test("returns undefined when absent or null", () => {
+    expect(optionalRecord({}, "params")).toBeUndefined();
+    expect(optionalRecord({ params: null }, "params")).toBeUndefined();
+  });
+
+  test("throws 400 for arrays and primitives", () => {
+    for (const bad of [[], "x", 42, true]) {
+      try {
+        optionalRecord({ params: bad }, "params");
+        throw new Error("Expected to throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(ApiError);
+        expect((e as ApiError).statusCode).toBe(400);
+      }
+    }
+  });
+});
+
+// ===========================================================================
+// optionalEnum (v3.14.5)
+// ===========================================================================
+describe("optionalEnum", () => {
+  const MODES = ["normal", "unique", "lock"] as const;
+
+  test("returns an allowed value", () => {
+    expect(optionalEnum({ mode: "unique" }, "mode", MODES)).toBe("unique");
+  });
+
+  test("returns undefined when absent", () => {
+    expect(optionalEnum({}, "mode", MODES)).toBeUndefined();
+  });
+
+  test("throws 400 for a value outside the set (the old as-cast persisted garbage)", () => {
+    try {
+      optionalEnum({ mode: "chaos" }, "mode", MODES);
+      throw new Error("Expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).statusCode).toBe(400);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Patch 5 of the cleanup roadmap — the confirmed guard/validation findings.

- **Feature-scoped guards**: `/ticket-setup` + `/memory-setup` (were legacy admin-only despite being in the FEATURES catalog — webapp-granted managers couldn't run them) and the five destructive `/dev` archive-deletion handlers (now `admin`-level feature guards). Unconfigured guilds keep the admin-only fallback, so default behavior is unchanged.
- **API body validation**: announcement `params` object validated via new `optionalRecord` (400 on non-object, was a blind `as` cast); reaction-role `mode` validated via new `optionalEnum` against `normal`/`unique`/`lock` (garbage used to persist and silently never match).
- **Guild scoping**: `removePendingBanFromDb`'s guild filter was optional on a DELETE — now required, with callers passing the always-present `member.guild.id`.

## Test plan

- [x] `bun test` — 1440 pass (new optionalRecord/optionalEnum suites in helpers.test.ts)
- [x] Build, Biome, changelog gate, contract gate green
- [ ] Dev-bot spot check: run /ticket-setup as a webapp-granted tickets manager (non-admin) and confirm it's allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ