### PR TITLE
refactor: v3.14.6 — unification tail (audit findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.6] - 2026-07-06
+
+Internal cleanup: the unification helpers introduced in v3.11–v3.13 now cover
+the call sites that had been left behind. No user-facing behavior changes
+beyond two small consistency wins.
+
+### Changed
+
+- Application workflow enable/disable, the memory-setup channel picker, and
+  the AutoMod restore confirmation now use the shared toggle/select/confirm
+  helpers (the confirm helper learned to work after a deferred reply).
+- Remaining hand-rolled `<t:…>` timestamp conversions and error-log blocks
+  migrated to the shared `toUnixSeconds`/`logHandlerError` utilities; two
+  handlers dropped the deprecated `fetchReply()` roundtrip for `withResponse`.
+
+### Fixed
+
+- The ticket-type and announcement-template list dashboards now always surface
+  an error message when a button action fails mid-collector (the old guard
+  skipped feedback if the interaction had already been acknowledged), and the
+  import command no longer double-logs every failure.
+
 ## [3.14.5] - 2026-07-06
 
 Permission-guard and API-validation consistency.

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.5",
+  "botVersion": "3.14.6",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.5",
+  "version": "3.14.6",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/announcement/templateList.ts
+++ b/src/commands/handlers/announcement/templateList.ts
@@ -22,7 +22,6 @@ import { AnnouncementConfig } from '../../../typeorm/entities/announcement/Annou
 import { AnnouncementTemplate } from '../../../typeorm/entities/announcement/AnnouncementTemplate';
 import {
   awaitConfirmation,
-  buildErrorMessage,
   enhancedLogger,
   guardFeatureAccess,
   handleInteractionError,
@@ -65,13 +64,16 @@ export async function templateListHandler(interaction: ChatInputCommandInteracti
       return;
     }
 
-    await interaction.reply({
+    const response = await interaction.reply({
       embeds: [buildSummaryEmbed(templates)],
       components: buildSummaryComponents(templates),
       flags: [MessageFlags.Ephemeral],
+      withResponse: true,
     });
 
-    const message = await interaction.fetchReply();
+    // withResponse avoids the extra fetchReply REST roundtrip (repo convention).
+    const message = response.resource?.message;
+    if (!message) return;
     const collector = message.createMessageComponentCollector({
       time: COLLECTOR_TIMEOUT_MS,
       filter: (i: Interaction) => i.user.id === interaction.user.id,
@@ -195,14 +197,8 @@ export async function templateListHandler(interaction: ChatInputCommandInteracti
           guildId,
           userId: i.user.id,
         });
-        if (!i.replied && !i.deferred) {
-          await i
-            .reply({
-              content: buildErrorMessage('Something went wrong while managing templates.'),
-              flags: [MessageFlags.Ephemeral],
-            })
-            .catch(() => undefined);
-        }
+        // State-aware + swallow-safe — matches the typeList collector.
+        await replyEphemeralError(i, 'Something went wrong while managing templates.', { bugReport: true });
       }
     });
 

--- a/src/commands/handlers/application/workflow.ts
+++ b/src/commands/handlers/application/workflow.ts
@@ -19,6 +19,7 @@ import {
   type ApplicationWorkflowStatus,
 } from '../../../typeorm/entities/application/ApplicationConfig';
 import {
+  createToggleHandler,
   DEFAULT_APPLICATION_STATUSES,
   enhancedLogger,
   formatLang,
@@ -29,6 +30,7 @@ import {
   REQUIRED_APPLICATION_STATUSES,
   replyEphemeralError,
   sanitizeUserInput,
+  toUnixSeconds,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { findStatusById, appendStatusHistory as sharedAppendHistory } from '../../../utils/workflow/workflowHelpers';
@@ -320,7 +322,7 @@ export async function applicationInfoHandler(interaction: ChatInputCommandIntera
     const recentNotes = application.internalNotes.slice(-5).reverse();
     const notesText = recentNotes
       .map(n => {
-        const timestamp = Math.floor(new Date(n.addedAt).getTime() / 1000);
+        const timestamp = toUnixSeconds(new Date(n.addedAt));
         return formatLang(tlInfo.noteEntry, n.note, n.addedBy, timestamp.toString());
       })
       .join('\n');
@@ -338,7 +340,7 @@ export async function applicationInfoHandler(interaction: ChatInputCommandIntera
       .map((entry: ApplicationStatusHistoryEntry) => {
         const entryStatusDef = findStatusById(statuses, entry.status);
         const label = entryStatusDef ? `${entryStatusDef.emoji} ${entryStatusDef.label}` : entry.status;
-        const timestamp = Math.floor(new Date(entry.changedAt).getTime() / 1000);
+        const timestamp = toUnixSeconds(new Date(entry.changedAt));
         return `${label} by <@${entry.changedBy}> <t:${timestamp}:R>`;
       })
       .join('\n');
@@ -407,35 +409,31 @@ export async function applicationCheckHandler(interaction: ChatInputCommandInter
 // /application workflow-enable
 // ============================================================================
 
+const workflowToggle = createToggleHandler({
+  repo: applicationConfigRepo,
+  field: 'enableWorkflow',
+  messages: {
+    alreadyEnabled: tl.alreadyEnabled,
+    alreadyDisabled: tl.alreadyDisabled,
+    enabled: tl.enabled,
+    disabled: tl.disabled,
+  },
+  requireExisting: { notConfigured: lang.application.applicationConfigNotFound },
+  onEnable: config => {
+    if (!config.workflowStatuses || config.workflowStatuses.length === 0) {
+      config.workflowStatuses = [...DEFAULT_APPLICATION_STATUSES];
+    }
+  },
+  onToggled: (_interaction, guildId, enabled) =>
+    enhancedLogger.info(`Application workflow ${enabled ? 'enabled' : 'disabled'}`, LogCategory.COMMAND_EXECUTION, {
+      guildId,
+    }),
+});
+
 export async function applicationWorkflowEnableHandler(interaction: ChatInputCommandInteraction<CacheType>) {
   const guard = await guardFeatureAccess(interaction, 'applications', 'manage');
   if (!guard.allowed) return;
-
-  const guildId = interaction.guildId!;
-  const config = await applicationConfigRepo.findOneBy({ guildId });
-
-  if (!config) {
-    await replyEphemeralError(interaction, lang.application.applicationConfigNotFound);
-    return;
-  }
-
-  if (config.enableWorkflow) {
-    await replyEphemeralError(interaction, tl.alreadyEnabled);
-    return;
-  }
-
-  config.enableWorkflow = true;
-  if (!config.workflowStatuses || config.workflowStatuses.length === 0) {
-    config.workflowStatuses = [...DEFAULT_APPLICATION_STATUSES];
-  }
-  await applicationConfigRepo.save(config);
-
-  await interaction.reply({
-    content: tl.enabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.info('Application workflow enabled', LogCategory.COMMAND_EXECUTION, { guildId });
+  await workflowToggle.enable(interaction, interaction.guildId!);
 }
 
 // ============================================================================
@@ -445,29 +443,7 @@ export async function applicationWorkflowEnableHandler(interaction: ChatInputCom
 export async function applicationWorkflowDisableHandler(interaction: ChatInputCommandInteraction<CacheType>) {
   const guard = await guardFeatureAccess(interaction, 'applications', 'manage');
   if (!guard.allowed) return;
-
-  const guildId = interaction.guildId!;
-  const config = await applicationConfigRepo.findOneBy({ guildId });
-
-  if (!config) {
-    await replyEphemeralError(interaction, lang.application.applicationConfigNotFound);
-    return;
-  }
-
-  if (!config.enableWorkflow) {
-    await replyEphemeralError(interaction, tl.alreadyDisabled);
-    return;
-  }
-
-  config.enableWorkflow = false;
-  await applicationConfigRepo.save(config);
-
-  await interaction.reply({
-    content: tl.disabled,
-    flags: [MessageFlags.Ephemeral],
-  });
-
-  enhancedLogger.info('Application workflow disabled', LogCategory.COMMAND_EXECUTION, { guildId });
+  await workflowToggle.disable(interaction, interaction.guildId!);
 }
 
 // ============================================================================

--- a/src/commands/handlers/application/workflow.ts
+++ b/src/commands/handlers/application/workflow.ts
@@ -421,7 +421,7 @@ const workflowToggle = createToggleHandler({
   requireExisting: { notConfigured: lang.application.applicationConfigNotFound },
   onEnable: config => {
     if (!config.workflowStatuses || config.workflowStatuses.length === 0) {
-      config.workflowStatuses = [...DEFAULT_APPLICATION_STATUSES];
+      config.workflowStatuses = DEFAULT_APPLICATION_STATUSES.map(s => ({ ...s }));
     }
   },
   onToggled: (_interaction, guildId, enabled) =>

--- a/src/commands/handlers/automod/backup.ts
+++ b/src/commands/handlers/automod/backup.ts
@@ -5,20 +5,18 @@
  */
 
 import {
-  ActionRowBuilder,
   AttachmentBuilder,
   type AutoModerationActionType,
   type AutoModerationRuleEventType,
   type AutoModerationRuleTriggerType,
-  ButtonBuilder,
   ButtonStyle,
   type ChatInputCommandInteraction,
   type Client,
-  ComponentType,
   EmbedBuilder,
   MessageFlags,
 } from 'discord.js';
 import {
+  awaitConfirmation,
   enhancedLogger,
   formatLang,
   handleInteractionError,
@@ -134,93 +132,67 @@ async function handleRestore(interaction: ChatInputCommandInteraction): Promise<
       return;
     }
 
-    // Confirmation
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId('automod_restore_confirm')
-        .setLabel('Confirm Restore')
-        .setStyle(ButtonStyle.Primary),
-      new ButtonBuilder().setCustomId('automod_restore_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary),
-    );
+    // Confirmation — awaitConfirmation owns the cancel/timeout handling and
+    // works post-deferReply since v3.14.6 (this flow escaped the v3.0.4 and
+    // v3.1.34 consolidations because the helper couldn't edit a deferred reply).
+    const result = await awaitConfirmation(interaction, {
+      message: formatLang(tl.restore.confirmMessage, backup.rules.length),
+      confirmLabel: 'Confirm Restore',
+      confirmStyle: ButtonStyle.Primary,
+      idPrefix: 'automod_restore',
+    });
+    if (!result) return;
 
-    const confirmReply = await interaction.editReply({
-      content: formatLang(tl.restore.confirmMessage, backup.rules.length),
-      components: [row],
+    let created = 0;
+    for (const serializedRule of backup.rules) {
+      try {
+        const ruleConfig: AutoModRuleConfig = {
+          name: serializedRule.name,
+          eventType: serializedRule.eventType as AutoModerationRuleEventType,
+          triggerType: serializedRule.triggerType as AutoModerationRuleTriggerType,
+          triggerMetadata: {
+            keywordFilter: serializedRule.triggerMetadata?.keywordFilter,
+            regexPatterns: serializedRule.triggerMetadata?.regexPatterns,
+            mentionTotalLimit: serializedRule.triggerMetadata?.mentionTotalLimit,
+            mentionRaidProtectionEnabled: serializedRule.triggerMetadata?.mentionRaidProtectionEnabled,
+          },
+          actions: serializedRule.actions.map(a => ({
+            type: a.type as AutoModerationActionType,
+            metadata: a.metadata
+              ? {
+                  durationSeconds: a.metadata.durationSeconds,
+                  customMessage: a.metadata.customMessage,
+                }
+              : undefined,
+          })),
+          enabled: serializedRule.enabled,
+        };
+
+        await createAutoModRule(guild, ruleConfig);
+        created++;
+      } catch (error) {
+        enhancedLogger.warn(`Failed to restore rule: ${serializedRule.name}`, LogCategory.COMMAND_EXECUTION, {
+          guildId: guild.id,
+          error: String(error),
+        });
+      }
+    }
+
+    enhancedLogger.info(`AutoMod rules restored: ${created}/${backup.rules.length}`, LogCategory.COMMAND_EXECUTION, {
+      guildId: guild.id,
+      userId: interaction.user.id,
     });
 
-    try {
-      const buttonInteraction = await confirmReply.awaitMessageComponent({
-        componentType: ComponentType.Button,
-        filter: i => i.user.id === interaction.user.id,
-        time: 30_000,
-      });
+    const embed = new EmbedBuilder()
+      .setColor('#00FF00')
+      .setTitle(tl.restore.title)
+      .setDescription(formatLang(tl.restore.success, created));
 
-      if (buttonInteraction.customId === 'automod_restore_cancel') {
-        await buttonInteraction.update({
-          content: lang.errors.cancelled,
-          components: [],
-        });
-        return;
-      }
-
-      await buttonInteraction.deferUpdate();
-
-      let created = 0;
-      for (const serializedRule of backup.rules) {
-        try {
-          const ruleConfig: AutoModRuleConfig = {
-            name: serializedRule.name,
-            eventType: serializedRule.eventType as AutoModerationRuleEventType,
-            triggerType: serializedRule.triggerType as AutoModerationRuleTriggerType,
-            triggerMetadata: {
-              keywordFilter: serializedRule.triggerMetadata?.keywordFilter,
-              regexPatterns: serializedRule.triggerMetadata?.regexPatterns,
-              mentionTotalLimit: serializedRule.triggerMetadata?.mentionTotalLimit,
-              mentionRaidProtectionEnabled: serializedRule.triggerMetadata?.mentionRaidProtectionEnabled,
-            },
-            actions: serializedRule.actions.map(a => ({
-              type: a.type as AutoModerationActionType,
-              metadata: a.metadata
-                ? {
-                    durationSeconds: a.metadata.durationSeconds,
-                    customMessage: a.metadata.customMessage,
-                  }
-                : undefined,
-            })),
-            enabled: serializedRule.enabled,
-          };
-
-          await createAutoModRule(guild, ruleConfig);
-          created++;
-        } catch (error) {
-          enhancedLogger.warn(`Failed to restore rule: ${serializedRule.name}`, LogCategory.COMMAND_EXECUTION, {
-            guildId: guild.id,
-            error: String(error),
-          });
-        }
-      }
-
-      enhancedLogger.info(`AutoMod rules restored: ${created}/${backup.rules.length}`, LogCategory.COMMAND_EXECUTION, {
-        guildId: guild.id,
-        userId: interaction.user.id,
-      });
-
-      const embed = new EmbedBuilder()
-        .setColor('#00FF00')
-        .setTitle(tl.restore.title)
-        .setDescription(formatLang(tl.restore.success, created));
-
-      await interaction.editReply({
-        content: '',
-        embeds: [embed],
-        components: [],
-      });
-    } catch {
-      await interaction.editReply({
-        content: lang.errors.cancelled,
-        components: [],
-      });
-    }
+    await result.interaction.editReply({
+      content: '',
+      embeds: [embed],
+      components: [],
+    });
   } catch (error) {
     await handleInteractionError(interaction, error, tl.restore.error);
   }

--- a/src/commands/handlers/automod/backup.ts
+++ b/src/commands/handlers/automod/backup.ts
@@ -137,7 +137,7 @@ async function handleRestore(interaction: ChatInputCommandInteraction): Promise<
     // v3.1.34 consolidations because the helper couldn't edit a deferred reply).
     const result = await awaitConfirmation(interaction, {
       message: formatLang(tl.restore.confirmMessage, backup.rules.length),
-      confirmLabel: 'Confirm Restore',
+      confirmLabel: tl.restore.confirmLabel,
       confirmStyle: ButtonStyle.Primary,
       idPrefix: 'automod_restore',
     });

--- a/src/commands/handlers/import/csv.ts
+++ b/src/commands/handlers/import/csv.ts
@@ -7,7 +7,15 @@
 
 import type { ChatInputCommandInteraction } from 'discord.js';
 import { EmbedBuilder, MessageFlags } from 'discord.js';
-import { enhancedLogger, formatLang, LogCategory, lang, replyEphemeralError, toUnixSeconds } from '../../../utils';
+import {
+  enhancedLogger,
+  formatLang,
+  LogCategory,
+  lang,
+  logHandlerError,
+  replyEphemeralError,
+  toUnixSeconds,
+} from '../../../utils';
 import type { CsvImporter } from '../../../utils/import/csvImporter';
 import { importManager } from '../../../utils/import/importManager';
 
@@ -55,12 +63,7 @@ export async function csvImportHandler(interaction: ChatInputCommandInteraction)
     }
     csvContent = await response.text();
   } catch (error) {
-    enhancedLogger.error(
-      'Failed to download CSV attachment',
-      error instanceof Error ? error : undefined,
-      LogCategory.COMMAND_EXECUTION,
-      { guildId },
-    );
+    logHandlerError('CSV attachment download', error, { guildId });
     await replyEphemeralError(interaction, formatLang(tl.importFailed, 'Failed to download CSV file.'));
     return;
   }

--- a/src/commands/handlers/import/index.ts
+++ b/src/commands/handlers/import/index.ts
@@ -3,14 +3,7 @@
  */
 
 import type { ChatInputCommandInteraction } from 'discord.js';
-import {
-  enhancedLogger,
-  guardAdmin,
-  handleInteractionError,
-  LogCategory,
-  lang,
-  replyEphemeralError,
-} from '../../../utils';
+import { guardAdmin, handleInteractionError, lang, replyEphemeralError } from '../../../utils';
 import { csvImportHandler } from './csv';
 import { mee6ImportHandler } from './mee6';
 import { importStatusHandler } from './status';
@@ -38,11 +31,8 @@ export async function importHandler(interaction: ChatInputCommandInteraction): P
         await replyEphemeralError(interaction, lang.errors.unknownSubcommand);
     }
   } catch (error) {
-    enhancedLogger.error(
-      'Error in import command handler',
-      error instanceof Error ? error : undefined,
-      LogCategory.COMMAND_EXECUTION,
-    );
+    // handleInteractionError logs AND replies — the extra enhancedLogger.error
+    // here double-logged every failure.
     await handleInteractionError(interaction, error as Error, 'Import command failed');
   }
 }

--- a/src/commands/handlers/memorySetup.ts
+++ b/src/commands/handlers/memorySetup.ts
@@ -16,12 +16,14 @@ import {
 } from 'discord.js';
 import { MemoryConfig, MemoryItem, MemoryTag, type MemoryTagType } from '../../typeorm/entities/memory';
 import {
+  awaitSelectMenuChoice,
   Colors,
   E,
   enhancedLogger,
   guardFeatureRateLimit,
   LogCategory,
   lang,
+  logHandlerError,
   RateLimits,
   replyEphemeralError,
 } from '../../utils';
@@ -201,12 +203,7 @@ async function handleSetup(client: Client, interaction: ChatInputCommandInteract
       }
     });
   } catch (error) {
-    enhancedLogger.error(
-      `Memory setup error: ${error}`,
-      error instanceof Error ? error : undefined,
-      LogCategory.COMMAND_EXECUTION,
-      { guildId },
-    );
+    logHandlerError('Memory setup', error, { guildId });
     await interaction.editReply({
       content: `${E.error} ${tl.setup.error}`,
       embeds: [],
@@ -254,14 +251,7 @@ async function handleAddChannel(_client: Client, interaction: ChatInputCommandIn
       content: `${E.success} ${tl.setup.channelAdded}\n${tl.setup.forumChannel}: <#${channel.id}>`,
     });
   } catch (error) {
-    enhancedLogger.error(
-      `Memory add-channel error: ${error}`,
-      error instanceof Error ? error : undefined,
-      LogCategory.COMMAND_EXECUTION,
-      {
-        guildId,
-      },
-    );
+    logHandlerError('Memory add-channel', error, { guildId });
     await replyEphemeralError(interaction, tl.setup.error);
   }
 }
@@ -296,14 +286,14 @@ async function handleRemoveChannel(client: Client, interaction: ChatInputCommand
     flags: [MessageFlags.Ephemeral],
   });
 
+  // One-shot picker — the helper owns the filter + timeout-message handling.
+  const i = await awaitSelectMenuChoice(interaction, response, {
+    userId: interaction.user.id,
+    customId: 'memory_remove_channel_select',
+  });
+  if (!i) return;
+
   try {
-    const i = await response.awaitMessageComponent({
-      filter: i => i.user.id === interaction.user.id && i.customId === 'memory_remove_channel_select',
-      time: 30000,
-    });
-
-    if (!i.isStringSelectMenu()) return;
-
     const selectedId = Number.parseInt(i.values[0], 10);
     const config = configs.find(c => c.id === selectedId);
     if (!config) return;
@@ -355,14 +345,7 @@ async function handleRemoveChannel(client: Client, interaction: ChatInputCommand
           content: `${E.success} ${tl.setup.channelRemoved}`,
         });
       } catch (error) {
-        enhancedLogger.error(
-          `Memory remove-channel error: ${error}`,
-          error instanceof Error ? error : undefined,
-          LogCategory.COMMAND_EXECUTION,
-          {
-            guildId,
-          },
-        );
+        logHandlerError('Memory remove-channel', error, { guildId });
         await replyEphemeralError(confirmI, tl.setup.error);
       }
     }
@@ -464,11 +447,7 @@ async function postWelcomeThread(forum: ForumChannel): Promise<string | null> {
 
     return thread.id;
   } catch (error) {
-    enhancedLogger.error(
-      `Failed to create memory welcome thread: ${error}`,
-      error instanceof Error ? error : undefined,
-      LogCategory.COMMAND_EXECUTION,
-    );
+    logHandlerError('Memory welcome-thread create', error);
     return null;
   }
 }
@@ -503,12 +482,7 @@ async function setupWithChannel(
       await interaction.reply({ content, flags: [MessageFlags.Ephemeral] });
     }
   } catch (error) {
-    enhancedLogger.error(
-      `Memory setup error: ${error}`,
-      error instanceof Error ? error : undefined,
-      LogCategory.COMMAND_EXECUTION,
-      { guildId },
-    );
+    logHandlerError('Memory setup', error, { guildId });
     const content = `${E.error} ${tl.setup.error}`;
     if (componentInteraction) {
       await componentInteraction.editReply({ content });
@@ -548,14 +522,7 @@ async function createMemoryForum(
 
     return forum;
   } catch (error) {
-    enhancedLogger.error(
-      `Failed to create memory forum: ${error}`,
-      error instanceof Error ? error : undefined,
-      LogCategory.COMMAND_EXECUTION,
-      {
-        guildId,
-      },
-    );
+    logHandlerError('Memory forum create', error, { guildId });
     await replyEphemeralError(interaction, tl.setup.error);
     return null;
   }

--- a/src/commands/handlers/ticket/typeList.ts
+++ b/src/commands/handlers/ticket/typeList.ts
@@ -5,6 +5,7 @@ import {
   type ChatInputCommandInteraction,
   EmbedBuilder,
   type Interaction,
+  type InteractionCallbackResponse,
   MessageFlags,
   StringSelectMenuBuilder,
   type StringSelectMenuInteraction,
@@ -12,7 +13,6 @@ import {
 import { AppDataSource } from '../../../typeorm';
 import { CustomTicketType } from '../../../typeorm/entities/ticket/CustomTicketType';
 import {
-  buildErrorMessage,
   enhancedLogger,
   guardFeatureAccess,
   handleInteractionError,
@@ -79,26 +79,31 @@ export async function renderInteractiveTypeView(
     }
 
     // Initial render — summary or jump-to-detail.
+    let response: InteractionCallbackResponse;
     if (options.startWith === 'detail') {
       const target = types.find(t => t.typeId === options.typeId);
       if (!target) {
         await replyEphemeralError(interaction, lang.ticket.customTypes.typeEdit.notFound);
         return;
       }
-      await interaction.reply({
+      response = await interaction.reply({
         embeds: [buildDetailEmbed(target)],
         components: buildDetailComponents(target),
         flags: [MessageFlags.Ephemeral],
+        withResponse: true,
       });
     } else {
-      await interaction.reply({
+      response = await interaction.reply({
         embeds: [buildSummaryEmbed(types)],
         components: buildSummaryComponents(types),
         flags: [MessageFlags.Ephemeral],
+        withResponse: true,
       });
     }
 
-    const message = await interaction.fetchReply();
+    // withResponse avoids the extra fetchReply REST roundtrip (repo convention).
+    const message = response.resource?.message;
+    if (!message) return;
     const collector = message.createMessageComponentCollector({
       time: COLLECTOR_TIMEOUT_MS,
       filter: (i: Interaction) => i.user.id === interaction.user.id,
@@ -250,16 +255,12 @@ export async function renderInteractiveTypeView(
           guildId,
           userId: i.user.id,
         });
-        // If we threw before acknowledging the interaction, give the user
-        // visible feedback instead of letting Discord render "Interaction
-        // failed" with no clue why. The .catch swallows secondary failures
-        // (interaction expired, already replied) so the collector keeps
-        // running for the rest of the 5-min window.
-        if (!i.replied && !i.deferred) {
-          await replyEphemeralError(i, buildErrorMessage('Something went wrong while processing this action.')).catch(
-            () => undefined,
-          );
-        }
+        // Give the user visible feedback instead of letting Discord render
+        // "Interaction failed" with no clue why. replyEphemeralError is
+        // state-aware (reply/editReply/followUp) and swallows secondary
+        // delivery failures itself, and bugReport appends the report link —
+        // no need to pre-wrap with buildErrorMessage or guard on state.
+        await replyEphemeralError(i, 'Something went wrong while processing this action.', { bugReport: true });
       }
     });
 

--- a/src/commands/handlers/ticket/workflow.ts
+++ b/src/commands/handlers/ticket/workflow.ts
@@ -28,6 +28,7 @@ import {
   REQUIRED_WORKFLOW_STATUSES,
   replyEphemeralError,
   sanitizeUserInput,
+  toUnixSeconds,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { findStatusById, appendStatusHistory as sharedAppendHistory } from '../../../utils/workflow/workflowHelpers';
@@ -325,7 +326,7 @@ export async function ticketInfoHandler(interaction: ChatInputCommandInteraction
   if (ticket.lastActivityAt) {
     embed.addFields({
       name: tlInfo.lastActivity,
-      value: `<t:${Math.floor(new Date(ticket.lastActivityAt).getTime() / 1000)}:R>`,
+      value: `<t:${toUnixSeconds(new Date(ticket.lastActivityAt))}:R>`,
       inline: true,
     });
   }
@@ -337,7 +338,7 @@ export async function ticketInfoHandler(interaction: ChatInputCommandInteraction
       .map((entry: TicketStatusHistoryEntry) => {
         const entryStatusDef = findStatusById(statuses, entry.status);
         const label = entryStatusDef ? `${entryStatusDef.emoji} ${entryStatusDef.label}` : entry.status;
-        const timestamp = Math.floor(new Date(entry.changedAt).getTime() / 1000);
+        const timestamp = toUnixSeconds(new Date(entry.changedAt));
         return `${label} by <@${entry.changedBy}> <t:${timestamp}:R>`;
       })
       .join('\n');

--- a/src/commands/handlers/ticket/workflow.ts
+++ b/src/commands/handlers/ticket/workflow.ts
@@ -51,7 +51,7 @@ const workflowToggle = createToggleHandler<TicketConfig>({
   // Seed the default status set on first enable; preserved across a later disable.
   onEnable: config => {
     if (!config.workflowStatuses || config.workflowStatuses.length === 0) {
-      config.workflowStatuses = [...DEFAULT_TICKET_STATUSES];
+      config.workflowStatuses = DEFAULT_TICKET_STATUSES.map(s => ({ ...s }));
     }
   },
   onToggled: (_interaction, guildId, enabled) => {

--- a/src/commands/handlers/ticket/workflowSettings.ts
+++ b/src/commands/handlers/ticket/workflowSettings.ts
@@ -61,7 +61,7 @@ export async function workflowSettingsHandler(interaction: ChatInputCommandInter
     if (enableWorkflow !== undefined) {
       config.enableWorkflow = enableWorkflow;
       if (enableWorkflow && (!config.workflowStatuses || config.workflowStatuses.length === 0)) {
-        config.workflowStatuses = [...DEFAULT_TICKET_STATUSES];
+        config.workflowStatuses = DEFAULT_TICKET_STATUSES.map(s => ({ ...s }));
       }
     }
 

--- a/src/lang/en/automod.json
+++ b/src/lang/en/automod.json
@@ -155,7 +155,8 @@
     "invalidFormat": "The backup file format is invalid. Please use a backup file created with `/automod backup`.",
     "wouldExceedLimit": "Restoring would create {0} rule(s), but you only have {1} slot(s) available. Delete some rules first.",
     "confirmTitle": "Confirm AutoMod Restore",
-    "confirmMessage": "This will create {0} new AutoMod rule(s). Existing rules will NOT be deleted. Continue?"
+    "confirmMessage": "This will create {0} new AutoMod rule(s). Existing rules will NOT be deleted. Continue?",
+    "confirmLabel": "Confirm Restore"
   },
   "keyword": {
     "add": {

--- a/src/utils/baitChannel/baitChannelManager.ts
+++ b/src/utils/baitChannel/baitChannelManager.ts
@@ -1474,12 +1474,12 @@ export class BaitChannelManager {
           { name: '⚡ Reason', value: reason, inline: false },
           {
             name: '📅 Account Created',
-            value: `<t:${Math.floor(member.user.createdTimestamp / 1000)}:R>`,
+            value: `<t:${toUnixSeconds(new Date(member.user.createdTimestamp))}:R>`,
             inline: true,
           },
           {
             name: '📥 Joined Server',
-            value: `<t:${Math.floor(member.joinedTimestamp! / 1000)}:R>`,
+            value: `<t:${toUnixSeconds(new Date(member.joinedTimestamp!))}:R>`,
             inline: true,
           },
           {
@@ -1653,12 +1653,12 @@ export class BaitChannelManager {
           },
           {
             name: '📅 Account Created',
-            value: `<t:${Math.floor(member.user.createdTimestamp / 1000)}:R>`,
+            value: `<t:${toUnixSeconds(new Date(member.user.createdTimestamp))}:R>`,
             inline: true,
           },
           {
             name: '📥 Joined Server',
-            value: `<t:${Math.floor(member.joinedTimestamp! / 1000)}:R>`,
+            value: `<t:${toUnixSeconds(new Date(member.joinedTimestamp!))}:R>`,
             inline: true,
           },
         )

--- a/src/utils/interactions/confirmHelper.ts
+++ b/src/utils/interactions/confirmHelper.ts
@@ -50,10 +50,12 @@ export interface ConfirmationResult {
 /**
  * Show confirm/cancel buttons and await the user's response.
  * Automatically handles cancel (updates message to "Cancelled") and timeout
- * (removes components). Returns the confirmed ButtonInteraction or null.
+ * (shows the standard timeout message). Returns the confirmed
+ * ButtonInteraction or null.
  *
- * The interaction is replied to with the confirmation message.
- * Only use with interactions that haven't been replied to or deferred yet.
+ * Fresh interactions get an ephemeral reply; interactions that already
+ * deferred get the buttons via editReply (v3.14.6). Do not use after a
+ * plain reply().
  *
  * @example
  * const result = await awaitConfirmation(interaction, {
@@ -83,12 +85,14 @@ export async function awaitConfirmation(
       .setStyle(ButtonStyle.Secondary),
   );
 
-  const response = await interaction.reply({
+  const payload = {
     content: options.message,
     embeds: options.embeds ?? [],
     components: [row],
-    flags: [MessageFlags.Ephemeral],
-  });
+  };
+  const response = interaction.deferred
+    ? await interaction.editReply(payload)
+    : await interaction.reply({ ...payload, flags: [MessageFlags.Ephemeral] });
 
   try {
     const btn = await response.awaitMessageComponent({

--- a/tests/unit/utils/interactions/confirmHelper.test.ts
+++ b/tests/unit/utils/interactions/confirmHelper.test.ts
@@ -11,20 +11,27 @@ import { describe, expect, test } from 'bun:test';
 import { awaitConfirmation } from '../../../../src/utils/interactions/confirmHelper';
 import { lang } from '../../../../src/lang';
 
-function makeInteraction(behavior: { resolve?: unknown; reject?: boolean }) {
+function makeInteraction(behavior: { resolve?: unknown; reject?: boolean; deferred?: boolean }) {
   const edits: Array<{ content?: string; components?: unknown[] }> = [];
-  const interaction = {
-    reply: async () => ({
-      awaitMessageComponent: async () => {
-        if (behavior.reject) throw new Error('timeout');
-        return behavior.resolve;
-      },
-    }),
-    editReply: async (o: { content?: string; components?: unknown[] }) => {
-      edits.push(o);
+  const replies: unknown[] = [];
+  const awaitable = {
+    awaitMessageComponent: async () => {
+      if (behavior.reject) throw new Error('timeout');
+      return behavior.resolve;
     },
   };
-  return { interaction, edits };
+  const interaction = {
+    deferred: behavior.deferred ?? false,
+    reply: async (payload: unknown) => {
+      replies.push(payload);
+      return awaitable;
+    },
+    editReply: async (o: { content?: string; components?: unknown[] }) => {
+      edits.push(o);
+      return awaitable;
+    },
+  };
+  return { interaction, edits, replies };
 }
 
 function makeButton(customId: string) {
@@ -62,6 +69,18 @@ describe('awaitConfirmation', () => {
     expect(result).toBeNull();
     expect(updates).toHaveLength(1);
     expect(updates[0].content).toBe(lang.errors.cancelled);
+  });
+
+  test('deferred interactions get the buttons via editReply, not a second reply (v3.14.6)', async () => {
+    const { button } = makeButton('confirm_yes');
+    const { interaction, edits, replies } = makeInteraction({ resolve: button, deferred: true });
+
+    const result = await call(interaction);
+
+    expect(result?.interaction).toBe(button as never);
+    expect(replies).toHaveLength(0);
+    expect(edits).toHaveLength(1);
+    expect(edits[0].content).toBe('Sure?');
   });
 
   test('timeout tells the user and clears the buttons (not a silent strip)', async () => {


### PR DESCRIPTION
## Summary

Patch 6 of the cleanup roadmap — finishes the v3.11–v3.13 unification series by migrating the call sites the audit confirmed were left behind. One helper gained a capability: `awaitConfirmation` now works after `deferReply` (editReply path), which is exactly why the AutoMod restore flow had escaped the two previous consolidation passes.

- application workflow enable/disable → `createToggleHandler`
- AutoMod restore confirm/cancel → `awaitConfirmation` (+ new deferred-path test)
- memory-setup channel picker → `awaitSelectMenuChoice`
- 8 hand-rolled `Math.floor(…/1000)` → `toUnixSeconds`
- 8 long-form catch blocks → `logHandlerError`; one double-log dropped
- 2 deprecated `fetchReply()` → `withResponse`
- 2 collector catches → state-aware `replyEphemeralError` + bugReport (feedback no longer skipped post-ack)

## Test plan

- [x] `bun test` — 1441 pass
- [x] Build, Biome, changelog gate, contract gate green
- [ ] Dev-bot spot check: /automod backup restore (confirm + cancel + timeout), /memory-setup remove-channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved confirmation flows and interactive list handling for several app actions.
  * AutoMod restore now uses a clearer confirmation prompt and label.

* **Bug Fixes**
  * Error messages now appear more reliably when dashboard actions fail.
  * Several workflows now show more consistent timestamps in activity/history views.
  * Restore and selection flows handle failures more gracefully.

* **Chores**
  * Updated the app/package version to 3.14.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->