### PR TITLE
refactor: v3.14.7 — constants dedup (audit findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.7] - 2026-07-06
+
+Constants dedup — every magic number the audit confirmed as a drifted or
+duplicated copy now reads from the single catalog in `constants.ts`.
+
+### Fixed
+
+- **AutoMod keyword limit corrected**: the constants catalog said 100 keywords
+  per rule while the feature (correctly) enforced Discord's 1000 — the two
+  copies are now one, with the right value.
+- **Data-export join-event window** now matches the actual 7-day retention
+  sweep instead of a hardcoded 90 days whose comment claimed a retention that
+  didn't exist.
+- **Event templates** get their own 25-cap constant instead of borrowing the
+  announcement one.
+
+### Changed
+
+- Bait-channel idempotency TTL defined once (executor exports it), analytics
+  retention/interval and the XP config-cache TTL read the catalog, collector
+  timeouts (30s/60s/5min) use the TIMEOUTS catalog across nine handlers,
+  health-monitor intervals use INTERVALS, and bait log-embed truncation uses
+  the shared `truncateWithNotice` helper.
+
 ## [3.14.6] - 2026-07-06
 
 Internal cleanup: the unification helpers introduced in v3.11–v3.13 now cover

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.6",
+  "botVersion": "3.14.7",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.6",
+  "version": "3.14.7",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/botSetup/index.ts
+++ b/src/commands/handlers/botSetup/index.ts
@@ -20,6 +20,7 @@ import {
   RateLimits,
   replyEphemeralError,
   showAndAwaitModal,
+  TIMEOUTS,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { checkboxGroup, labelWrap, radioGroup, rawModal } from '../../../utils/modalComponents';
@@ -225,10 +226,10 @@ async function collectDashboardInteractions(
   const selectCollector = reply.createMessageComponentCollector({
     componentType: ComponentType.StringSelect,
     filter: (i: any) => i.user.id === interaction.user.id && i.customId === 'setup_system_select',
-    time: 300_000,
+    time: TIMEOUTS.DASHBOARD,
   });
 
-  const buttonCollector = createButtonCollector(reply, 300_000);
+  const buttonCollector = createButtonCollector(reply, TIMEOUTS.DASHBOARD);
 
   selectCollector.on('collect', async (selectInteraction: any) => {
     const systemId = selectInteraction.values[0];

--- a/src/commands/handlers/botSetup/systemFlows.ts
+++ b/src/commands/handlers/botSetup/systemFlows.ts
@@ -60,6 +60,7 @@ import {
   LogCategory,
   lang,
   showAndAwaitModal,
+  TIMEOUTS,
 } from '../../../utils';
 import { Colors } from '../../../utils/colors';
 import { upsertGuildEntity } from '../../../utils/database/guildQueries';
@@ -213,7 +214,7 @@ async function askChannelChoice(
     ?.awaitMessageComponent({
       filter: i => i.user.id === interaction.user.id && i.customId.startsWith('setup_ch_'),
       componentType: ComponentType.Button,
-      time: 60_000,
+      time: TIMEOUTS.COMPONENT,
     })
     .catch(() => null);
 

--- a/src/commands/handlers/dataExport.ts
+++ b/src/commands/handlers/dataExport.ts
@@ -62,6 +62,7 @@ import {
   LogCategory,
   lang,
   RateLimits,
+  RETENTION_DAYS,
   replyEphemeralError,
 } from '../../utils';
 
@@ -177,13 +178,14 @@ const EXPORT_ENTITIES: ExportEntity[] = [
   { name: 'baitKeywords', entity: BaitKeyword, buildFindOptions: guildScoped },
   { name: 'importLogs', entity: ImportLog, buildFindOptions: guildScoped },
   {
-    // 90-day retention applies to JoinEvent rows
+    // Export window matches the JoinEvent retention sweep (RETENTION_DAYS.JOIN_EVENT)
+    // — older rows are already purged, so a wider window would only mislead.
     name: 'joinEvents',
     entity: JoinEvent,
     buildFindOptions: guildId => ({
       where: {
         guildId,
-        joinedAt: MoreThanOrEqual(new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)),
+        joinedAt: MoreThanOrEqual(new Date(Date.now() - RETENTION_DAYS.JOIN_EVENT * 24 * 60 * 60 * 1000)),
       },
     }),
   },

--- a/src/commands/handlers/dev/devSuiteWorkflows.ts
+++ b/src/commands/handlers/dev/devSuiteWorkflows.ts
@@ -24,7 +24,7 @@ import { ArchivedTicketConfig } from '../../../typeorm/entities/ticket/ArchivedT
 import { Ticket } from '../../../typeorm/entities/ticket/Ticket';
 import { XPRoleReward } from '../../../typeorm/entities/xp/XPRoleReward';
 import { XPUser } from '../../../typeorm/entities/xp/XPUser';
-import { enhancedLogger, handleInteractionError, LogCategory, sleep } from '../../../utils';
+import { enhancedLogger, handleInteractionError, LogCategory, sleep, TIMEOUTS } from '../../../utils';
 import { Colors } from '../../../utils/colors';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
@@ -1203,7 +1203,7 @@ export async function handleWalkthrough(
     const collector = reply.createMessageComponentCollector({
       componentType: ComponentType.Button,
       filter: i => i.user.id === interaction.user.id,
-      time: 300_000,
+      time: TIMEOUTS.DASHBOARD,
     });
 
     collector.on('collect', async btnInteraction => {

--- a/src/commands/handlers/event/template.ts
+++ b/src/commands/handlers/event/template.ts
@@ -34,7 +34,7 @@ import { lazyRepo } from '../../../utils/database/lazyRepo';
 const templateRepo = lazyRepo(EventTemplate);
 
 const TEMPLATE_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
-const MAX_EVENT_TEMPLATES = MAX.ANNOUNCEMENT_TEMPLATES; // reuse 25 limit
+const MAX_EVENT_TEMPLATES = MAX.EVENT_TEMPLATES;
 
 const tl = eventLang.template;
 

--- a/src/commands/handlers/memory/delete.ts
+++ b/src/commands/handlers/memory/delete.ts
@@ -16,6 +16,7 @@ import {
   logHandlerError,
   RateLimits,
   replyEphemeralError,
+  TIMEOUTS,
   verifiedThreadDelete,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
@@ -119,7 +120,7 @@ export async function memoryDeleteHandler(interaction: ChatInputCommandInteracti
   });
 
   const collector = response.createMessageComponentCollector({
-    time: 60000,
+    time: TIMEOUTS.COMPONENT,
   });
 
   collector.on('collect', async i => {

--- a/src/commands/handlers/memory/tags.ts
+++ b/src/commands/handlers/memory/tags.ts
@@ -24,6 +24,7 @@ import {
   RateLimits,
   replyEphemeralError,
   showAndAwaitModal,
+  TIMEOUTS,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { resolveMemoryConfig } from './channelPicker';
@@ -210,7 +211,7 @@ async function handleEditTag(
     flags: [MessageFlags.Ephemeral],
   });
 
-  const collector = response.createMessageComponentCollector({ time: 60000 });
+  const collector = response.createMessageComponentCollector({ time: TIMEOUTS.COMPONENT });
 
   collector.on('collect', async i => {
     if (i.user.id !== interaction.user.id) {
@@ -362,7 +363,7 @@ async function handleRemoveTag(
     flags: [MessageFlags.Ephemeral],
   });
 
-  const collector = response.createMessageComponentCollector({ time: 60000 });
+  const collector = response.createMessageComponentCollector({ time: TIMEOUTS.COMPONENT });
 
   collector.on('collect', async i => {
     if (i.user.id !== interaction.user.id) {
@@ -419,7 +420,7 @@ async function confirmRemoveTag(interaction: StringSelectMenuInteraction, guildI
   });
 
   const collector = interaction.message.createMessageComponentCollector({
-    time: 30000,
+    time: TIMEOUTS.CONFIRMATION,
   });
 
   collector.on('collect', async i => {

--- a/src/commands/handlers/memorySetup.ts
+++ b/src/commands/handlers/memorySetup.ts
@@ -26,6 +26,7 @@ import {
   logHandlerError,
   RateLimits,
   replyEphemeralError,
+  TIMEOUTS,
 } from '../../utils';
 import { lazyRepo } from '../../utils/database/lazyRepo';
 
@@ -321,7 +322,7 @@ async function handleRemoveChannel(client: Client, interaction: ChatInputCommand
 
     const confirmI = await i.message.awaitMessageComponent({
       filter: ci => ci.user.id === interaction.user.id,
-      time: 30000,
+      time: TIMEOUTS.CONFIRMATION,
     });
 
     if (confirmI.customId === 'memory_remove_cancel') {

--- a/src/commands/handlers/ticket/typeRemove.ts
+++ b/src/commands/handlers/ticket/typeRemove.ts
@@ -16,6 +16,7 @@ import {
   LogCategory,
   lang,
   replyEphemeralError,
+  TIMEOUTS,
 } from '../../../utils';
 
 const tl = lang.ticket.customTypes.typeRemove;
@@ -79,7 +80,7 @@ export async function typeRemoveHandler(interaction: ChatInputCommandInteraction
     const collector = interaction.channel?.createMessageComponentCollector({
       filter,
       componentType: ComponentType.Button,
-      time: 30000,
+      time: TIMEOUTS.CONFIRMATION,
     });
 
     collector?.on('collect', async i => {

--- a/src/commands/handlers/ticket/userRestrict.ts
+++ b/src/commands/handlers/ticket/userRestrict.ts
@@ -20,6 +20,7 @@ import {
   lang,
   replyEphemeralError,
   showAndAwaitModal,
+  TIMEOUTS,
 } from '../../../utils';
 import { checkboxGroup, labelWrap, rawModal } from '../../../utils/modalComponents';
 
@@ -148,7 +149,7 @@ async function handleSingleTypeToggle(
   const collector = interaction.channel?.createMessageComponentCollector({
     filter,
     componentType: ComponentType.Button,
-    time: 30000,
+    time: TIMEOUTS.CONFIRMATION,
     max: 1,
   });
 

--- a/src/commands/handlers/xp/admin.ts
+++ b/src/commands/handlers/xp/admin.ts
@@ -1,7 +1,7 @@
 import { type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
 import xpLang from '../../../lang/en/xp.json';
 import { XPUser } from '../../../typeorm/entities/xp/XPUser';
-import { enhancedLogger, handleInteractionError, LogCategory, replyEphemeralError } from '../../../utils';
+import { enhancedLogger, handleInteractionError, LogCategory, replyEphemeralError, TIMEOUTS } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { calculateLevel } from '../../../utils/xp/xpCalculator';
 
@@ -110,7 +110,7 @@ async function handleResetAll(interaction: ChatInputCommandInteraction, guildId:
     const collected = await channel.awaitMessages({
       filter: m => m.author.id === interaction.user.id,
       max: 1,
-      time: 30_000,
+      time: TIMEOUTS.CONFIRMATION,
     });
 
     const response = collected.first();

--- a/src/events/auditLogEntryCreate.ts
+++ b/src/events/auditLogEntryCreate.ts
@@ -37,6 +37,7 @@ import { AppDataSource } from '../typeorm';
 import { BaitChannelLog } from '../typeorm/entities/bait/BaitChannelLog';
 import { IdempotencyKey } from '../typeorm/entities/bait/IdempotencyKey';
 import { PendingAction } from '../typeorm/entities/bait/PendingAction';
+import { IDEMPOTENCY_TTL_MS } from '../utils/baitChannel/banExecutor';
 import { ErrorCategory, ErrorSeverity, logError } from '../utils/errorHandler';
 import { enhancedLogger, LogCategory } from '../utils/monitoring/enhancedLogger';
 
@@ -52,7 +53,6 @@ const RECENT_LOG_WINDOW_MS = 5 * 60 * 1000;
  * Idempotency key TTL for mod-superseded rows. Matches the executor's
  * 24h TTL so duplicate detection windows align.
  */
-const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
 function todayUtc(): Date {
   const now = new Date();

--- a/src/utils/analytics/snapshotJob.ts
+++ b/src/utils/analytics/snapshotJob.ts
@@ -13,12 +13,12 @@ import { LessThan } from 'typeorm';
 import { AppDataSource } from '../../typeorm';
 import { AnalyticsConfig } from '../../typeorm/entities/analytics/AnalyticsConfig';
 import { AnalyticsSnapshot } from '../../typeorm/entities/analytics/AnalyticsSnapshot';
+import { INTERVALS, RETENTION_DAYS } from '../constants';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { activityTracker } from './activityTracker';
 import { sendDigest } from './digestBuilder';
 
 /** Retention period for analytics snapshots */
-const ANALYTICS_RETENTION_DAYS = 90;
 
 /** Interval handle for cleanup (so it can be cleared on shutdown) */
 let snapshotInterval: ReturnType<typeof setInterval> | null = null;
@@ -75,7 +75,7 @@ async function runDailySnapshot(client: Client): Promise<void> {
 
     // Clean old snapshots (90+ days)
     const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - ANALYTICS_RETENTION_DAYS);
+    cutoffDate.setDate(cutoffDate.getDate() - RETENTION_DAYS.ANALYTICS_SNAPSHOT);
 
     const deleteResult = await snapshotRepo.delete({
       date: LessThan(cutoffDate),
@@ -125,7 +125,7 @@ export function startSnapshotJob(client: Client): void {
     void runDailySnapshot(client);
 
     // Then repeat every 24 hours
-    snapshotInterval = setInterval(() => void runDailySnapshot(client), 24 * 60 * 60 * 1000);
+    snapshotInterval = setInterval(() => void runDailySnapshot(client), INTERVALS.ANALYTICS_SNAPSHOT);
   }, msToMidnight);
 
   // Store timeout reference for cleanup

--- a/src/utils/analytics/snapshotJob.ts
+++ b/src/utils/analytics/snapshotJob.ts
@@ -18,8 +18,6 @@ import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { activityTracker } from './activityTracker';
 import { sendDigest } from './digestBuilder';
 
-/** Retention period for analytics snapshots */
-
 /** Interval handle for cleanup (so it can be cleared on shutdown) */
 let snapshotInterval: ReturnType<typeof setInterval> | null = null;
 

--- a/src/utils/automod/helpers.ts
+++ b/src/utils/automod/helpers.ts
@@ -13,17 +13,16 @@ import type {
   Guild,
 } from 'discord.js';
 import { AutoModerationActionType, AutoModerationRuleTriggerType, type Collection } from 'discord.js';
+import { MAX } from '../constants';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import type { AutoModRuleConfig } from './templates';
 
-/** Discord's maximum AutoMod rules per guild */
-export const MAX_AUTOMOD_RULES = 6;
-/** Discord's maximum keywords per rule */
-export const MAX_KEYWORDS_PER_RULE = 1000;
-/** Discord's maximum regex patterns per rule */
-export const MAX_REGEX_PER_RULE = 10;
-/** Discord's maximum regex pattern length */
-export const MAX_REGEX_LENGTH = 75;
+// Discord AutoMod limits — sourced from the MAX catalog in constants.ts
+// (these aliases keep the feature-local names its seven importers use).
+export const MAX_AUTOMOD_RULES = MAX.AUTOMOD_RULES;
+export const MAX_KEYWORDS_PER_RULE = MAX.AUTOMOD_KEYWORDS_PER_RULE;
+export const MAX_REGEX_PER_RULE = MAX.AUTOMOD_REGEX_PER_RULE;
+export const MAX_REGEX_LENGTH = MAX.AUTOMOD_REGEX_MAX_LENGTH;
 
 /**
  * Fetch all AutoMod rules for a guild.

--- a/src/utils/baitChannel/baitChannelManager.ts
+++ b/src/utils/baitChannel/baitChannelManager.ts
@@ -26,6 +26,7 @@ import { createTtlCache } from '../database/configCache';
 import { ErrorCategory, ErrorSeverity, logError } from '../errorHandler';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { toUnixSeconds } from '../time';
+import { truncateWithNotice } from '../validation/inputSanitizer';
 import { buildAppealUrl } from './appealToken';
 import { buildAuditReason, flagsTriggered } from './auditReason';
 import { type BanExecutorAction, type BanExecutorResult, executeBanAction } from './banExecutor';
@@ -1501,14 +1502,14 @@ export class BaitChannelManager {
       if (actionResult === 'failed' && failureReason) {
         embed.addFields({
           name: '⚠️ Failure Reason',
-          value: failureReason.length > 1024 ? `${failureReason.substring(0, 1021)}...` : failureReason,
+          value: truncateWithNotice(failureReason, 1024),
         });
       }
 
       if (message.content) {
         embed.addFields({
           name: '💬 Message Content',
-          value: message.content.length > 1024 ? `${message.content.substring(0, 1021)}...` : message.content,
+          value: truncateWithNotice(message.content, 1024),
         });
       }
 
@@ -1667,7 +1668,7 @@ export class BaitChannelManager {
       if (message.content) {
         embed.addFields({
           name: '💬 Message Content',
-          value: message.content.length > 1024 ? `${message.content.substring(0, 1021)}...` : message.content,
+          value: truncateWithNotice(message.content, 1024),
         });
       }
 

--- a/src/utils/baitChannel/banExecutor.ts
+++ b/src/utils/baitChannel/banExecutor.ts
@@ -77,7 +77,7 @@ export interface BanExecutorResult {
 }
 
 const DEFAULT_SOFTBAN_DELAY_MS = 500;
-const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+export const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24h — auditLogEntryCreate imports this so the two can never drift
 
 /**
  * Compute today's UTC midnight as the dayBucket. Same-day retries dedup;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -128,8 +128,8 @@ export const MAX = {
   ONBOARDING_STEPS: 10,
   /** Discord AutoMod rules per guild */
   AUTOMOD_RULES: 6,
-  /** AutoMod keywords per rule */
-  AUTOMOD_KEYWORDS_PER_RULE: 100,
+  /** AutoMod keywords per rule (Discord limit) */
+  AUTOMOD_KEYWORDS_PER_RULE: 1000,
   /** AutoMod regex patterns per rule */
   AUTOMOD_REGEX_PER_RULE: 10,
   /** AutoMod regex pattern max length */
@@ -144,8 +144,6 @@ export const MAX = {
   STATUS_INCIDENTS: 100,
   /** CSV import max rows */
   IMPORT_CSV_MAX_ROWS: 10000,
-  /** Analytics snapshots retention: 90 days */
-  ANALYTICS_SNAPSHOT_DAYS: 90,
 } as const;
 
 export const JOIN_VELOCITY = {

--- a/src/utils/monitoring/healthMonitor.ts
+++ b/src/utils/monitoring/healthMonitor.ts
@@ -15,6 +15,7 @@
 import type { Client } from 'discord.js';
 import { AppDataSource } from '../../typeorm';
 import { BotConfig } from '../../typeorm/entities/BotConfig';
+import { INTERVALS } from '../constants';
 import type { StatusManager } from '../status/statusManager';
 import { enhancedLogger, LogCategory } from './enhancedLogger';
 
@@ -139,14 +140,14 @@ class HealthMonitor {
     this.periodicCheckIntervals.push(
       setInterval(() => {
         void this.checkDatabaseHealth();
-      }, 300000),
+      }, INTERVALS.HEALTH_STATUS),
     );
 
     // Clean up old errors every 5 minutes
     this.periodicCheckIntervals.push(
       setInterval(() => {
         this.cleanupOldErrors();
-      }, 300000),
+      }, INTERVALS.HEALTH_STATUS),
     );
   }
 

--- a/src/utils/xp/configCache.ts
+++ b/src/utils/xp/configCache.ts
@@ -8,13 +8,13 @@
  */
 
 import { XPConfig } from '../../typeorm/entities/xp/XPConfig';
+import { CACHE_TTL } from '../constants';
 import { createTtlCache } from '../database/configCache';
 import { lazyRepo } from '../database/lazyRepo';
 
 const configRepo = lazyRepo(XPConfig);
 
-const CONFIG_CACHE_TTL = 5 * 60 * 1000;
-const configCache = createTtlCache<string, XPConfig>(CONFIG_CACHE_TTL);
+const configCache = createTtlCache<string, XPConfig>(CACHE_TTL.XP_CONFIG);
 
 /** Get XP config for a guild with 5-minute caching. Returns null when not configured. */
 export async function getXPConfig(guildId: string): Promise<XPConfig | null> {


### PR DESCRIPTION
## Summary

Patch 7 of the cleanup roadmap — the 12 confirmed magic-number findings, all onto the `constants.ts` catalog. Two were real value bugs, not just style:

- **AutoMod keyword cap had drifted**: catalog said 100/rule, feature enforced Discord's actual 1000. Unified on the correct value (`automod/helpers.ts` now derives from the catalog).
- **Data-export join-events window** claimed "90-day retention" that doesn't exist — actual sweep is `RETENTION_DAYS.JOIN_EVENT` (7d). Window + comment now match reality.

Mechanical rest: idempotency TTL single-sourced (executor exports, audit-event imports), analytics retention/interval catalogued (3rd copy removed), XP cache TTL catalogued, `TIMEOUTS` adopted at 12 collector sites, `INTERVALS.HEALTH_STATUS` for the health monitor, event-template cap uses its own constant, bait embed truncation via `truncateWithNotice`.

## Test plan

- [x] `bun test` — 1441 pass
- [x] Build, Biome, changelog gate, contract gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ