### PR TITLE
feat: v3.15.0 — i18n sweep (audit findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.0] - 2026-07-06
+
+The i18n sweep: user-facing text that bypassed the language system is now in
+it — groundwork for the es/fr/de/pt-BR translations to actually cover these
+surfaces.
+
+### Changed
+
+- **Three whole features rejoined the locale system**: the XP, onboarding, and
+  event handlers imported the English JSON directly, bypassing the per-locale
+  fallback entirely. They now read through the language module like everything
+  else.
+- **Insights finally uses its own language file**: every string in
+  `/insights` (setup, overview, growth, channels, hours) was hardcoded even
+  though `analytics.json` already contained most of them.
+- **Ticket buttons and modals localized**: Close/Admin-Only/Confirm/Cancel
+  labels, the "Oh, Mods!" staff alert, and the ticket-creation modal prompt.
+- **`/baitchannel raid` fully localized** (it was hardcoded end to end), plus
+  the onboarding DM buttons, XP config replies, import result embeds, the
+  announcement send confirmation, and assorted memory/bait validation strings.
+
 ## [3.14.8] - 2026-07-06
 
 Dead-code removal — everything the audit confirmed as having zero callers,

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.14.8",
+  "botVersion": "3.15.0",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.14.8",
+  "version": "3.15.0",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/announcement/handler.ts
+++ b/src/commands/handlers/announcement/handler.ts
@@ -274,7 +274,7 @@ async function previewAndSend(
     await announcementLogRepo.save(newLog);
 
     await result.interaction.editReply({
-      content: `Announcement sent to ${targetChannel}!`,
+      content: `${lang.announcement.success} ${targetChannel}!`,
       embeds: [],
       components: [],
     });
@@ -286,7 +286,7 @@ async function previewAndSend(
       { guildId, channelId: targetChannel.id, messageId: sentMessage.id },
     );
     await result.interaction
-      .editReply({ content: `Announcement sent to ${targetChannel}!`, embeds: [], components: [] })
+      .editReply({ content: `${lang.announcement.success} ${targetChannel}!`, embeds: [], components: [] })
       .catch(() => null);
   }
 

--- a/src/commands/handlers/baitChannel/raid.ts
+++ b/src/commands/handlers/baitChannel/raid.ts
@@ -7,9 +7,11 @@
  */
 
 import { type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
-import { guardFeatureAccess, handleInteractionError, toUnixSeconds } from '../../../utils';
+import { formatLang, guardFeatureAccess, handleInteractionError, lang, toUnixSeconds } from '../../../utils';
 import { getRaidModeManager } from '../../../utils/baitChannel/raidModeManager';
 import { Colors } from '../../../utils/colors';
+
+const tl = lang.baitChannel.raid;
 
 export async function raidHandler(_client: Client, interaction: ChatInputCommandInteraction): Promise<void> {
   const subcommand = interaction.options.getSubcommand();
@@ -23,7 +25,7 @@ export async function raidHandler(_client: Client, interaction: ChatInputCommand
   const mgr = getRaidModeManager();
   if (!mgr) {
     await interaction.reply({
-      content: '❌ Raid mode manager is not initialized (bot may still be starting up).',
+      content: tl.notInitialized,
       flags: [MessageFlags.Ephemeral],
     });
     return;
@@ -37,22 +39,22 @@ export async function raidHandler(_client: Client, interaction: ChatInputCommand
         const status = await mgr.getStatus(interaction.guildId!);
         const embed = new EmbedBuilder()
           .setColor(status.active ? Colors.status.error : Colors.status.success)
-          .setTitle(status.active ? '🚨 Raid mode is ACTIVE' : '✅ Raid mode is inactive')
+          .setTitle(status.active ? tl.statusActive : tl.statusInactive)
           .addFields(
             {
-              name: 'Recent triggers',
-              value: `${status.triggerCount} within window`,
+              name: tl.recentTriggers,
+              value: formatLang(tl.withinWindow, status.triggerCount),
               inline: true,
             },
             {
-              name: 'Distinct offenders',
+              name: tl.distinctOffenders,
               value: `${status.recentOffenderIds.length}`,
               inline: true,
             },
           );
         if (status.active && status.until) {
           embed.addFields({
-            name: 'Auto-release at',
+            name: tl.autoReleaseAt,
             value: `<t:${toUnixSeconds(status.until)}:f>`,
             inline: false,
           });
@@ -72,17 +74,15 @@ export async function raidHandler(_client: Client, interaction: ChatInputCommand
           where: { guildId: interaction.guildId! },
         });
         if (!config) {
-          await interaction.editReply(
-            '❌ Bait channel is not configured for this guild. Run `/baitchannel setup` first.',
-          );
+          await interaction.editReply(tl.notConfigured);
           return;
         }
         if (config.currentRaidModeUntil && config.currentRaidModeUntil.getTime() > Date.now()) {
-          await interaction.editReply('⚠️ Raid mode is already active. Use `/baitchannel raid release` first to reset.');
+          await interaction.editReply(tl.alreadyActive);
           return;
         }
         await mgr.enterRaidMode(interaction.guild, config);
-        await interaction.editReply(`✅ Raid mode activated. Reason: ${reason}`);
+        await interaction.editReply(formatLang(tl.activated, reason));
         return;
       }
 
@@ -93,16 +93,14 @@ export async function raidHandler(_client: Client, interaction: ChatInputCommand
           interaction.user.id,
           'manual release via slash command',
         );
-        await interaction.editReply(
-          released ? '✅ Raid mode released. Channel permissions restored.' : 'ℹ️ Raid mode was not active.',
-        );
+        await interaction.editReply(released ? tl.released : tl.notActive);
         return;
       }
 
       default:
-        await interaction.reply({ content: 'Unknown raid subcommand.', flags: [MessageFlags.Ephemeral] });
+        await interaction.reply({ content: tl.unknownSubcommand, flags: [MessageFlags.Ephemeral] });
     }
   } catch (error) {
-    await handleInteractionError(interaction, error, 'Failed to handle raid command');
+    await handleInteractionError(interaction, error, tl.error);
   }
 }

--- a/src/commands/handlers/baitChannel/setup.ts
+++ b/src/commands/handlers/baitChannel/setup.ts
@@ -163,7 +163,7 @@ export async function handleBaitChannelAddChannel(client: Client, interaction: C
 
     // Validate text channel
     if (channel.type !== ChannelType.GuildText) {
-      await replyEphemeralError(interaction, 'Please select a text channel.');
+      await replyEphemeralError(interaction, lang.baitChannel.setup.textChannelRequired);
       return;
     }
 

--- a/src/commands/handlers/event/create.ts
+++ b/src/commands/handlers/event/create.ts
@@ -13,7 +13,7 @@ import {
   GuildScheduledEventPrivacyLevel,
   MessageFlags,
 } from 'discord.js';
-import eventLang from '../../../lang/en/event.json';
+import { lang } from '../../../lang';
 import { EventConfig } from '../../../typeorm/entities/event/EventConfig';
 import { EventReminder } from '../../../typeorm/entities/event/EventReminder';
 import type { RecurringPattern } from '../../../typeorm/entities/event/EventTemplate';
@@ -29,6 +29,9 @@ import {
   toUnixSeconds,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const eventLang = lang.event;
 
 const eventConfigRepo = lazyRepo(EventConfig);
 const eventTemplateRepo = lazyRepo(EventTemplate);

--- a/src/commands/handlers/event/remind.ts
+++ b/src/commands/handlers/event/remind.ts
@@ -5,11 +5,14 @@
  */
 
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
-import eventLang from '../../../lang/en/event.json';
+import { lang } from '../../../lang';
 import { EventConfig } from '../../../typeorm/entities/event/EventConfig';
 import { EventReminder } from '../../../typeorm/entities/event/EventReminder';
 import { enhancedLogger, formatLang, guardFeatureAccess, LogCategory, replyEphemeralError } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const eventLang = lang.event;
 
 const eventConfigRepo = lazyRepo(EventConfig);
 const eventReminderRepo = lazyRepo(EventReminder);

--- a/src/commands/handlers/event/setup.ts
+++ b/src/commands/handlers/event/setup.ts
@@ -5,7 +5,6 @@
  */
 
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
-import eventLang from '../../../lang/en/event.json';
 import { EventConfig } from '../../../typeorm/entities/event/EventConfig';
 import {
   createToggleHandler,
@@ -18,6 +17,9 @@ import {
   replyEphemeralError,
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const eventLang = lang.event;
 
 const eventConfigRepo = lazyRepo(EventConfig);
 const tl = eventLang.setup;

--- a/src/commands/handlers/event/template.ts
+++ b/src/commands/handlers/event/template.ts
@@ -16,7 +16,6 @@ import {
   TextInputBuilder,
   TextInputStyle,
 } from 'discord.js';
-import eventLang from '../../../lang/en/event.json';
 import { EventTemplate } from '../../../typeorm/entities/event/EventTemplate';
 import {
   awaitConfirmation,
@@ -30,6 +29,9 @@ import {
 } from '../../../utils';
 import { MAX } from '../../../utils/constants';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const eventLang = lang.event;
 
 const templateRepo = lazyRepo(EventTemplate);
 

--- a/src/commands/handlers/import/csv.ts
+++ b/src/commands/handlers/import/csv.ts
@@ -93,13 +93,13 @@ export async function csvImportHandler(interaction: ChatInputCommandInteraction)
 
   if (dryRun) {
     const embed = new EmbedBuilder()
-      .setTitle('CSV Import — Dry Run')
+      .setTitle(lang.import.results.csvDryRunTitle)
       .setDescription(formatLang(tl.dryRunComplete, result.imported, result.skipped, result.failed))
       .setColor(0x3498db);
 
     if (result.errors.length > 0) {
       embed.addFields({
-        name: 'Errors',
+        name: lang.import.results.errorsField,
         value: result.errors.slice(0, 10).join('\n').substring(0, 1024),
       });
     }
@@ -110,25 +110,25 @@ export async function csvImportHandler(interaction: ChatInputCommandInteraction)
 
   if (result.success) {
     const embed = new EmbedBuilder()
-      .setTitle('CSV Import Complete')
+      .setTitle(lang.import.results.csvCompleteTitle)
       .setDescription(formatLang(tl.importComplete, result.imported, result.skipped, result.failed))
       .setColor(0x2ecc71)
       .addFields({
-        name: 'Duration',
+        name: lang.import.results.durationField,
         value: `${(result.durationMs / 1000).toFixed(1)}s`,
         inline: true,
       });
 
     if (result.errors.length > 0) {
       embed.addFields({
-        name: 'Warnings',
+        name: lang.import.results.warningsField,
         value: result.errors.slice(0, 10).join('\n').substring(0, 1024),
       });
     }
 
     await interaction.editReply({ content: '', embeds: [embed] });
   } else {
-    const errorMsg = result.errors.length > 0 ? result.errors[0] : 'Unknown error';
+    const errorMsg = result.errors.length > 0 ? result.errors[0] : lang.import.results.unknownError;
     await replyEphemeralError(interaction, formatLang(tl.importFailed, errorMsg));
   }
 }

--- a/src/commands/handlers/import/mee6.ts
+++ b/src/commands/handlers/import/mee6.ts
@@ -54,13 +54,13 @@ export async function mee6ImportHandler(interaction: ChatInputCommandInteraction
 
   if (dryRun) {
     const embed = new EmbedBuilder()
-      .setTitle('MEE6 Import — Dry Run')
+      .setTitle(lang.import.results.mee6DryRunTitle)
       .setDescription(formatLang(tl.dryRunComplete, result.imported, result.skipped, result.failed))
       .setColor(0x3498db);
 
     if (result.errors.length > 0) {
       embed.addFields({
-        name: 'Errors',
+        name: lang.import.results.errorsField,
         value: result.errors.slice(0, 10).join('\n').substring(0, 1024),
       });
     }
@@ -71,25 +71,25 @@ export async function mee6ImportHandler(interaction: ChatInputCommandInteraction
 
   if (result.success) {
     const embed = new EmbedBuilder()
-      .setTitle('MEE6 Import Complete')
+      .setTitle(lang.import.results.mee6CompleteTitle)
       .setDescription(formatLang(tl.importComplete, result.imported, result.skipped, result.failed))
       .setColor(0x2ecc71)
       .addFields({
-        name: 'Duration',
+        name: lang.import.results.durationField,
         value: `${(result.durationMs / 1000).toFixed(1)}s`,
         inline: true,
       });
 
     if (result.errors.length > 0) {
       embed.addFields({
-        name: 'Warnings',
+        name: lang.import.results.warningsField,
         value: result.errors.slice(0, 10).join('\n').substring(0, 1024),
       });
     }
 
     await interaction.editReply({ content: '', embeds: [embed] });
   } else {
-    const errorMsg = result.errors.length > 0 ? result.errors[0] : 'Unknown error';
+    const errorMsg = result.errors.length > 0 ? result.errors[0] : lang.import.results.unknownError;
     await replyEphemeralError(interaction, formatLang(tl.importFailed, errorMsg));
   }
 }

--- a/src/commands/handlers/insights/channels.ts
+++ b/src/commands/handlers/insights/channels.ts
@@ -1,5 +1,6 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
 import { MoreThanOrEqual } from 'typeorm';
+import { lang } from '../../../lang';
 import { AnalyticsConfig } from '../../../typeorm/entities/analytics/AnalyticsConfig';
 import { AnalyticsSnapshot } from '../../../typeorm/entities/analytics/AnalyticsSnapshot';
 import { buildChannelsEmbed } from '../../../utils/analytics/digestBuilder';
@@ -17,7 +18,7 @@ export async function channelsHandler(_client: Client, interaction: ChatInputCom
     const config = await configRepo.findOneBy({ guildId });
     if (!config?.enabled) {
       await interaction.reply({
-        content: 'Analytics are not enabled for this server. An admin can enable them with `/insights setup`.',
+        content: lang.analytics.errors.notEnabled,
         flags: [MessageFlags.Ephemeral],
       });
       return;
@@ -42,7 +43,7 @@ export async function channelsHandler(_client: Client, interaction: ChatInputCom
       guildId,
     });
     await interaction.reply({
-      content: 'Failed to fetch analytics data.',
+      content: lang.analytics.errors.fetchFailed,
       flags: [MessageFlags.Ephemeral],
     });
   }

--- a/src/commands/handlers/insights/growth.ts
+++ b/src/commands/handlers/insights/growth.ts
@@ -1,5 +1,6 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
 import { MoreThanOrEqual } from 'typeorm';
+import { lang } from '../../../lang';
 import { AnalyticsConfig } from '../../../typeorm/entities/analytics/AnalyticsConfig';
 import { AnalyticsSnapshot } from '../../../typeorm/entities/analytics/AnalyticsSnapshot';
 import { buildGrowthEmbed } from '../../../utils/analytics/digestBuilder';
@@ -17,7 +18,7 @@ export async function growthHandler(_client: Client, interaction: ChatInputComma
     const config = await configRepo.findOneBy({ guildId });
     if (!config?.enabled) {
       await interaction.reply({
-        content: 'Analytics are not enabled for this server. An admin can enable them with `/insights setup`.',
+        content: lang.analytics.errors.notEnabled,
         flags: [MessageFlags.Ephemeral],
       });
       return;
@@ -42,7 +43,7 @@ export async function growthHandler(_client: Client, interaction: ChatInputComma
       guildId,
     });
     await interaction.reply({
-      content: 'Failed to fetch analytics data.',
+      content: lang.analytics.errors.fetchFailed,
       flags: [MessageFlags.Ephemeral],
     });
   }

--- a/src/commands/handlers/insights/hours.ts
+++ b/src/commands/handlers/insights/hours.ts
@@ -1,5 +1,6 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
 import { MoreThanOrEqual } from 'typeorm';
+import { lang } from '../../../lang';
 import { AnalyticsConfig } from '../../../typeorm/entities/analytics/AnalyticsConfig';
 import { AnalyticsSnapshot } from '../../../typeorm/entities/analytics/AnalyticsSnapshot';
 import { buildHoursEmbed } from '../../../utils/analytics/digestBuilder';
@@ -17,7 +18,7 @@ export async function hoursHandler(_client: Client, interaction: ChatInputComman
     const config = await configRepo.findOneBy({ guildId });
     if (!config?.enabled) {
       await interaction.reply({
-        content: 'Analytics are not enabled for this server. An admin can enable them with `/insights setup`.',
+        content: lang.analytics.errors.notEnabled,
         flags: [MessageFlags.Ephemeral],
       });
       return;
@@ -42,7 +43,7 @@ export async function hoursHandler(_client: Client, interaction: ChatInputComman
       guildId,
     });
     await interaction.reply({
-      content: 'Failed to fetch analytics data.',
+      content: lang.analytics.errors.fetchFailed,
       flags: [MessageFlags.Ephemeral],
     });
   }

--- a/src/commands/handlers/insights/overview.ts
+++ b/src/commands/handlers/insights/overview.ts
@@ -1,4 +1,5 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
+import { lang } from '../../../lang';
 import { AnalyticsConfig } from '../../../typeorm/entities/analytics/AnalyticsConfig';
 import { AnalyticsSnapshot } from '../../../typeorm/entities/analytics/AnalyticsSnapshot';
 import { buildOverviewEmbed } from '../../../utils/analytics/digestBuilder';
@@ -17,7 +18,7 @@ export async function overviewHandler(_client: Client, interaction: ChatInputCom
     const config = await configRepo.findOneBy({ guildId });
     if (!config?.enabled) {
       await interaction.reply({
-        content: 'Analytics are not enabled for this server. An admin can enable them with `/insights setup`.',
+        content: lang.analytics.errors.notEnabled,
         flags: [MessageFlags.Ephemeral],
       });
       return;
@@ -39,7 +40,7 @@ export async function overviewHandler(_client: Client, interaction: ChatInputCom
       guildId,
     });
     await interaction.reply({
-      content: 'Failed to fetch analytics data.',
+      content: lang.analytics.errors.fetchFailed,
       flags: [MessageFlags.Ephemeral],
     });
   }

--- a/src/commands/handlers/insights/setup.ts
+++ b/src/commands/handlers/insights/setup.ts
@@ -1,5 +1,6 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
 import { AnalyticsConfig } from '../../../typeorm/entities/analytics/AnalyticsConfig';
+import { formatLang, lang } from '../../../utils';
 import { Colors } from '../../../utils/colors';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { guardFeatureAccess } from '../../../utils/interactions/guardHelper';
@@ -21,7 +22,7 @@ async function handleEnableAction(
 ) {
   if (config?.enabled) {
     await interaction.reply({
-      content: 'Analytics are already enabled.',
+      content: lang.analytics.setup.alreadyEnabled,
       flags: [MessageFlags.Ephemeral],
     });
     return;
@@ -35,7 +36,7 @@ async function handleEnableAction(
   await configRepo.save(config);
 
   await interaction.reply({
-    content: 'Analytics have been **enabled** for this server. Data collection will begin now.',
+    content: lang.analytics.setup.enabled,
     flags: [MessageFlags.Ephemeral],
   });
 
@@ -50,7 +51,7 @@ async function handleDisableAction(
 ) {
   if (!config?.enabled) {
     await interaction.reply({
-      content: 'Analytics are already disabled.',
+      content: lang.analytics.setup.alreadyDisabled,
       flags: [MessageFlags.Ephemeral],
     });
     return;
@@ -60,7 +61,7 @@ async function handleDisableAction(
   await configRepo.save(config);
 
   await interaction.reply({
-    content: 'Analytics have been **disabled**. Existing data is preserved.',
+    content: lang.analytics.setup.disabled,
     flags: [MessageFlags.Ephemeral],
   });
 
@@ -83,14 +84,14 @@ async function handleChannelAction(
     config.digestChannelId = channel.id;
     await configRepo.save(config);
     await interaction.reply({
-      content: `Digest channel set to <#${channel.id}>.`,
+      content: formatLang(lang.analytics.setup.channelSet, `<#${channel.id}>`),
       flags: [MessageFlags.Ephemeral],
     });
   } else {
     config.digestChannelId = null;
     await configRepo.save(config);
     await interaction.reply({
-      content: 'Digest channel has been cleared. No digests will be sent.',
+      content: lang.analytics.setup.channelCleared,
       flags: [MessageFlags.Ephemeral],
     });
   }
@@ -109,7 +110,7 @@ async function handleFrequencyAction(
 
   if (!frequency) {
     await interaction.reply({
-      content: 'Please specify a frequency using the `frequency` option.',
+      content: lang.analytics.setup.specifyFrequency,
       flags: [MessageFlags.Ephemeral],
     });
     return;
@@ -117,7 +118,7 @@ async function handleFrequencyAction(
 
   if (!['weekly', 'monthly', 'both'].includes(frequency)) {
     await interaction.reply({
-      content: 'Invalid frequency. Choose `weekly`, `monthly`, or `both`.',
+      content: lang.analytics.setup.invalidFrequency,
       flags: [MessageFlags.Ephemeral],
     });
     return;
@@ -126,14 +127,14 @@ async function handleFrequencyAction(
   if (day !== null) {
     if (frequency === 'weekly' && (day < 0 || day > 6)) {
       await interaction.reply({
-        content: 'Invalid day value. Use 0-6 for weekly (Sun-Sat).',
+        content: lang.analytics.setup.invalidDayWeekly,
         flags: [MessageFlags.Ephemeral],
       });
       return;
     }
     if (frequency === 'monthly' && (day < 1 || day > 28)) {
       await interaction.reply({
-        content: 'Invalid day value. Use 1-28 for monthly.',
+        content: lang.analytics.setup.invalidDayMonthly,
         flags: [MessageFlags.Ephemeral],
       });
       return;
@@ -153,7 +154,7 @@ async function handleFrequencyAction(
   const dayLabel = formatDayLabel(frequency, config.digestDay);
 
   await interaction.reply({
-    content: `Digest frequency set to **${frequency}** (day: ${dayLabel}).`,
+    content: formatLang(lang.analytics.setup.frequencySet, frequency, dayLabel),
     flags: [MessageFlags.Ephemeral],
   });
 
@@ -162,26 +163,30 @@ async function handleFrequencyAction(
 
 /** Handle the "status" action: show current analytics configuration. */
 async function handleStatusAction(interaction: ChatInputCommandInteraction<CacheType>, config: AnalyticsConfig | null) {
-  const embed = new EmbedBuilder().setTitle('Analytics Configuration').setColor(Colors.brand.primary);
+  const embed = new EmbedBuilder().setTitle(lang.analytics.setup.statusTitle).setColor(Colors.brand.primary);
   if (!config) {
-    embed.setDescription('Analytics have not been configured for this server.');
-    embed.addFields({ name: 'Status', value: 'Disabled', inline: true });
+    embed.setDescription(lang.analytics.setup.notConfigured);
+    embed.addFields({
+      name: lang.analytics.setup.statusField,
+      value: lang.analytics.setup.statusDisabled,
+      inline: true,
+    });
   } else {
     const dayLabel = formatDayLabel(config.digestFrequency, config.digestDay);
 
     embed.addFields(
       {
-        name: 'Status',
-        value: config.enabled ? 'Enabled' : 'Disabled',
+        name: lang.analytics.setup.statusField,
+        value: config.enabled ? lang.analytics.setup.statusEnabled : lang.analytics.setup.statusDisabled,
         inline: true,
       },
       {
-        name: 'Digest Channel',
-        value: config.digestChannelId ? `<#${config.digestChannelId}>` : 'Not set',
+        name: lang.analytics.setup.digestChannelField,
+        value: config.digestChannelId ? `<#${config.digestChannelId}>` : lang.analytics.setup.notSet,
         inline: true,
       },
-      { name: 'Frequency', value: config.digestFrequency, inline: true },
-      { name: 'Digest Day', value: dayLabel, inline: true },
+      { name: lang.analytics.setup.frequencyField, value: config.digestFrequency, inline: true },
+      { name: lang.analytics.setup.digestDayField, value: dayLabel, inline: true },
     );
   }
 
@@ -226,7 +231,7 @@ export async function insightsSetupHandler(_client: Client, interaction: ChatInp
       action,
     });
     await interaction.reply({
-      content: 'Failed to update analytics configuration.',
+      content: lang.analytics.setup.error,
       flags: [MessageFlags.Ephemeral],
     });
   }

--- a/src/commands/handlers/memory/channelPicker.ts
+++ b/src/commands/handlers/memory/channelPicker.ts
@@ -32,7 +32,7 @@ export async function resolveMemoryConfig(
         configs.map(c => ({
           label: c.channelName,
           value: c.id.toString(),
-          description: `Forum: <#${c.forumChannelId}>`,
+          description: `${lang.memory.channelPicker.forumPrefix} <#${c.forumChannelId}>`,
         })),
       ),
   );
@@ -51,7 +51,7 @@ export async function resolveMemoryConfig(
 
   const selectedId = Number.parseInt(choice.values[0], 10);
   const config = configs.find(c => c.id === selectedId);
-  await choice.update({ content: `${E.loading} Processing...`, components: [] });
+  await choice.update({ content: `${E.loading} ${lang.memory.channelPicker.processing}`, components: [] });
   return config || null;
 }
 

--- a/src/commands/handlers/memory/manageTags.ts
+++ b/src/commands/handlers/memory/manageTags.ts
@@ -82,7 +82,7 @@ async function handleTagAdd(interaction: ChatInputCommandInteraction, guildId: s
   // Sanitize tag name
   const name = sanitizeUserInput(rawName, { maxLength: MAX.MEMORY_TAG_NAME_LENGTH }) || '';
   if (!name) {
-    await replyEphemeralError(interaction, 'Tag name is required.');
+    await replyEphemeralError(interaction, lang.memory.tags.add.nameRequired);
     return;
   }
 

--- a/src/commands/handlers/memory/update.ts
+++ b/src/commands/handlers/memory/update.ts
@@ -61,7 +61,7 @@ async function validateUpdateContext(interaction: ChatInputCommandInteraction) {
   });
 
   if (statusTags.length === 0) {
-    await replyEphemeralError(interaction, 'No status tags configured. Run /memory-setup first.');
+    await replyEphemeralError(interaction, lang.memory.update.noStatusTags);
     return null;
   }
 
@@ -88,8 +88,14 @@ function buildStatusSelectRow(statusTags: MemoryTag[], selectedId: string) {
 /** Build the confirm/cancel button row. */
 function buildUpdateButtonRow() {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('memory_update_confirm').setLabel('Update').setStyle(ButtonStyle.Primary),
-    new ButtonBuilder().setCustomId('memory_update_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId('memory_update_confirm')
+      .setLabel(lang.memory.update.updateL)
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId('memory_update_cancel')
+      .setLabel(lang.memory.update.cancelL)
+      .setStyle(ButtonStyle.Secondary),
   );
 }
 

--- a/src/commands/handlers/onboarding/index.ts
+++ b/src/commands/handlers/onboarding/index.ts
@@ -4,7 +4,6 @@
  */
 
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
-import onboardingLang from '../../../lang/en/onboarding.json';
 import { AppDataSource } from '../../../typeorm';
 import { OnboardingConfig } from '../../../typeorm/entities/onboarding/OnboardingConfig';
 import {
@@ -20,6 +19,9 @@ import { sendOnboardingFlow } from '../../../utils/onboarding/onboardingEngine';
 import { completionRoleHandler, disableHandler, enableHandler, welcomeMessageHandler } from './setup';
 import { onboardingStatsHandler } from './stats';
 import { stepAddHandler, stepListHandler, stepRemoveHandler } from './steps';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const onboardingLang = lang.onboarding;
 
 const tl = onboardingLang;
 

--- a/src/commands/handlers/onboarding/setup.ts
+++ b/src/commands/handlers/onboarding/setup.ts
@@ -1,8 +1,11 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
-import onboardingLang from '../../../lang/en/onboarding.json';
+import { lang } from '../../../lang';
 import { OnboardingConfig } from '../../../typeorm/entities/onboarding/OnboardingConfig';
 import { createToggleHandler, enhancedLogger, formatLang } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const onboardingLang = lang.onboarding;
 
 const configRepo = lazyRepo(OnboardingConfig);
 const tl = onboardingLang;

--- a/src/commands/handlers/onboarding/stats.ts
+++ b/src/commands/handlers/onboarding/stats.ts
@@ -1,10 +1,13 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
 import { MoreThan } from 'typeorm';
-import onboardingLang from '../../../lang/en/onboarding.json';
+import { lang } from '../../../lang';
 import { OnboardingCompletion } from '../../../typeorm/entities/onboarding/OnboardingCompletion';
 import { OnboardingConfig } from '../../../typeorm/entities/onboarding/OnboardingConfig';
 import { formatLang, replyEphemeralError } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const onboardingLang = lang.onboarding;
 
 const completionRepo = lazyRepo(OnboardingCompletion);
 const configRepo = lazyRepo(OnboardingConfig);

--- a/src/commands/handlers/onboarding/steps.ts
+++ b/src/commands/handlers/onboarding/steps.ts
@@ -1,9 +1,12 @@
 import { type CacheType, type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
-import onboardingLang from '../../../lang/en/onboarding.json';
+import { lang } from '../../../lang';
 import { OnboardingConfig } from '../../../typeorm/entities/onboarding/OnboardingConfig';
 import { enhancedLogger, formatLang, replyEphemeralError } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import type { OnboardingStepDef, OnboardingStepType } from '../../../utils/onboarding/types';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const onboardingLang = lang.onboarding;
 
 const configRepo = lazyRepo(OnboardingConfig);
 const tl = onboardingLang;

--- a/src/commands/handlers/xp/admin.ts
+++ b/src/commands/handlers/xp/admin.ts
@@ -1,9 +1,12 @@
 import { type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
-import xpLang from '../../../lang/en/xp.json';
+import { lang } from '../../../lang';
 import { XPUser } from '../../../typeorm/entities/xp/XPUser';
 import { enhancedLogger, handleInteractionError, LogCategory, replyEphemeralError, TIMEOUTS } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { calculateLevel } from '../../../utils/xp/xpCalculator';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const xpLang = lang.xp;
 
 const userRepo = lazyRepo(XPUser);
 

--- a/src/commands/handlers/xp/leaderboard.ts
+++ b/src/commands/handlers/xp/leaderboard.ts
@@ -1,10 +1,13 @@
 import type { ColorResolvable } from 'discord.js';
 import { type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
-import xpLang from '../../../lang/en/xp.json';
+import { lang } from '../../../lang';
 import { XPUser } from '../../../typeorm/entities/xp/XPUser';
 import { handleInteractionError, replyEphemeralError } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { getXPConfig } from '../../../utils/xp/configCache';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const xpLang = lang.xp;
 
 const LEADERBOARD_COLOR = '#FFD700' as ColorResolvable;
 const PAGE_SIZE = 10;

--- a/src/commands/handlers/xp/rank.ts
+++ b/src/commands/handlers/xp/rank.ts
@@ -1,12 +1,15 @@
 import { type ChatInputCommandInteraction, type Client, MessageFlags } from 'discord.js';
 // Import lang directly to avoid needing lang/index.ts changes
-import xpLang from '../../../lang/en/xp.json';
+import { lang } from '../../../lang';
 import { XPRoleReward } from '../../../typeorm/entities/xp/XPRoleReward';
 import { XPUser } from '../../../typeorm/entities/xp/XPUser';
 import { handleInteractionError, replyEphemeralError } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { getXPConfig } from '../../../utils/xp/configCache';
 import { buildRankEmbed } from '../../../utils/xp/rankCard';
+
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const xpLang = lang.xp;
 
 const userRepo = lazyRepo(XPUser);
 const rewardRepo = lazyRepo(XPRoleReward);

--- a/src/commands/handlers/xp/setup.ts
+++ b/src/commands/handlers/xp/setup.ts
@@ -1,10 +1,11 @@
 import { type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
-import xpLang from '../../../lang/en/xp.json';
+import { lang } from '../../../lang';
 import { XPConfig } from '../../../typeorm/entities/xp/XPConfig';
 import { XPRoleReward } from '../../../typeorm/entities/xp/XPRoleReward';
 import {
   createToggleHandler,
   enhancedLogger,
+  formatLang,
   handleInteractionError,
   LogCategory,
   replyEphemeralError,
@@ -13,7 +14,11 @@ import { Colors } from '../../../utils/colors';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import { invalidateXPConfigCache } from '../../../utils/xp/configCache';
 
+// Locale-aware (Proxy fallback) — was a direct en JSON import that bypassed i18n.
+const xpLang = lang.xp;
+
 const configRepo = lazyRepo(XPConfig);
+const tlConfig = xpLang.config;
 const rewardRepo = lazyRepo(XPRoleReward);
 
 const xpToggle = createToggleHandler({
@@ -100,14 +105,14 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
     case 'xp-rate': {
       if (!value) {
         await interaction.reply({
-          content: `Current XP rate: **${config.xpPerMessageMin}-${config.xpPerMessageMax}** per message.`,
+          content: formatLang(tlConfig.currentRate, config.xpPerMessageMin, config.xpPerMessageMax),
           flags: [MessageFlags.Ephemeral],
         });
         return;
       }
       const parts = value.split('-').map(Number);
       if (parts.length !== 2 || Number.isNaN(parts[0]) || Number.isNaN(parts[1])) {
-        await replyEphemeralError(interaction, 'Format: `min-max` (e.g. `15-25`)');
+        await replyEphemeralError(interaction, tlConfig.rateFormat);
         return;
       }
       const [min, max] = parts;
@@ -122,7 +127,7 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
     case 'cooldown': {
       if (!value) {
         await interaction.reply({
-          content: `Current cooldown: **${config.xpCooldownSeconds}** seconds.`,
+          content: formatLang(tlConfig.currentCooldown, config.xpCooldownSeconds),
           flags: [MessageFlags.Ephemeral],
         });
         return;
@@ -138,14 +143,14 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
     case 'voice-xp': {
       if (!value) {
         await interaction.reply({
-          content: `Current voice XP: **${config.xpPerVoiceMinute}** per minute.`,
+          content: formatLang(tlConfig.currentVoiceXp, config.xpPerVoiceMinute),
           flags: [MessageFlags.Ephemeral],
         });
         return;
       }
       const voiceXp = Number(value);
       if (Number.isNaN(voiceXp) || voiceXp < 0 || voiceXp > 100) {
-        await replyEphemeralError(interaction, 'Voice XP must be between 0 and 100.');
+        await replyEphemeralError(interaction, tlConfig.voiceXpRange);
         return;
       }
       config.xpPerVoiceMinute = voiceXp;
@@ -158,7 +163,10 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
         config.levelUpChannelId = null;
       } else {
         await interaction.reply({
-          content: `Current level-up channel: ${config.levelUpChannelId ? `<#${config.levelUpChannelId}>` : 'Same channel as message'}. Use the channel option or type \`none\` to clear.`,
+          content: formatLang(
+            tlConfig.currentLevelUpChannel,
+            config.levelUpChannelId ? `<#${config.levelUpChannelId}>` : tlConfig.sameChannel,
+          ),
           flags: [MessageFlags.Ephemeral],
         });
         return;
@@ -168,7 +176,7 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
     case 'level-up-message': {
       if (!value) {
         await interaction.reply({
-          content: `Current level-up message: ${config.levelUpMessage}\nPlaceholders: \`{user}\`, \`{level}\``,
+          content: formatLang(tlConfig.currentLevelUpMessage, config.levelUpMessage),
           flags: [MessageFlags.Ephemeral],
         });
         return;
@@ -179,7 +187,10 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
     case 'voice-xp-enabled': {
       if (!value) {
         await interaction.reply({
-          content: `Voice XP is currently **${config.voiceXpEnabled ? 'enabled' : 'disabled'}**.`,
+          content: formatLang(
+            tlConfig.currentVoiceXpEnabled,
+            config.voiceXpEnabled ? tlConfig.enabled : tlConfig.disabled,
+          ),
           flags: [MessageFlags.Ephemeral],
         });
         return;
@@ -190,7 +201,10 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
     case 'stack-multipliers': {
       if (!value) {
         await interaction.reply({
-          content: `Stack multipliers is currently **${config.stackMultipliers ? 'enabled' : 'disabled'}**.`,
+          content: formatLang(
+            tlConfig.currentStackMultipliers,
+            config.stackMultipliers ? tlConfig.enabled : tlConfig.disabled,
+          ),
           flags: [MessageFlags.Ephemeral],
         });
         return;
@@ -199,7 +213,7 @@ async function handleConfig(interaction: ChatInputCommandInteraction, guildId: s
       break;
     }
     default:
-      await replyEphemeralError(interaction, 'Unknown setting.');
+      await replyEphemeralError(interaction, tlConfig.unknownSetting);
       return;
   }
 

--- a/src/events/ticket/adminOnly.ts
+++ b/src/events/ticket/adminOnly.ts
@@ -60,11 +60,11 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
     // ping a literal "undefined".
     if (gsrFlag && globalStaffRole && shouldMentionStaff) {
       await channel.send({
-        content: `${globalStaffRole}\n❗Oh, Mods!❗ ${user} ${tl.request}`,
+        content: `${globalStaffRole}\n${tl.modsAlert} ${user} ${tl.request}`,
       });
     } else {
       await channel.send({
-        content: `❗Oh, Mods!❗ ${user} ${tl.request}`,
+        content: `${tl.modsAlert} ${user} ${tl.request}`,
       });
     }
     // Resolve the "Changing to Admin Only..." ack: the creator is *requesting*
@@ -106,7 +106,10 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
   const messageId = ticket.messageId;
   if (messageId) {
     const closeButton = new ActionRowBuilder<ButtonBuilder>().setComponents(
-      new ButtonBuilder().setCustomId('close_ticket').setLabel('Close Ticket').setStyle(ButtonStyle.Danger),
+      new ButtonBuilder()
+        .setCustomId('close_ticket')
+        .setLabel(lang.ticket.buttons.closeTicket)
+        .setStyle(ButtonStyle.Danger),
     );
     const msg = await channel.messages.fetch(messageId).catch(() => null);
     await msg?.edit({ components: [closeButton] }).catch((error: unknown) => {
@@ -130,8 +133,8 @@ export const adminOnlyButton = async (_client: Client, interaction: ButtonIntera
   });
 
   const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('confirm_admin_only_ticket').setLabel('Confirm').setStyle(ButtonStyle.Danger),
-    new ButtonBuilder().setCustomId('cancel_admin_only_ticket').setLabel('Cancel').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('confirm_admin_only_ticket').setLabel(tl.confirmL).setStyle(ButtonStyle.Danger),
+    new ButtonBuilder().setCustomId('cancel_admin_only_ticket').setLabel(tl.cancelL).setStyle(ButtonStyle.Secondary),
   );
 
   await interaction.reply({

--- a/src/events/ticket/close.ts
+++ b/src/events/ticket/close.ts
@@ -163,8 +163,8 @@ export const closeButton = async (_client: Client, interaction: ButtonInteractio
   });
 
   const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder().setCustomId('confirm_close_ticket').setLabel('Confirm Close').setStyle(ButtonStyle.Danger),
-    new ButtonBuilder().setCustomId('cancel_close_ticket').setLabel('Cancel').setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('confirm_close_ticket').setLabel(tl.confirmL).setStyle(ButtonStyle.Danger),
+    new ButtonBuilder().setCustomId('cancel_close_ticket').setLabel(tl.cancelL).setStyle(ButtonStyle.Secondary),
   );
 
   await interaction.reply({

--- a/src/events/ticket/create.ts
+++ b/src/events/ticket/create.ts
@@ -104,9 +104,9 @@ function buildCustomTicketModal(ticketType: CustomTicketType): ModalBuilder {
   } else {
     const descriptionInput = new TextInputBuilder()
       .setCustomId('ticket_description')
-      .setLabel('Please describe your issue')
+      .setLabel(lang.ticket.createModal.descriptionLabel)
       .setStyle(TextInputStyle.Paragraph)
-      .setPlaceholder(ticketType.description || 'Provide details about your ticket...')
+      .setPlaceholder(ticketType.description || lang.ticket.createModal.descriptionPlaceholder)
       .setRequired(true)
       .setMaxLength(2000);
 
@@ -450,8 +450,14 @@ export const submitTicketModal = async (_client: Client, interaction: ModalSubmi
 
     const welcomeMsg = `<@${member.user.id}>\n\n${lang.ticket.welcomeMsg}`;
     const buttonOptions = new ActionRowBuilder<ButtonBuilder>().setComponents(
-      new ButtonBuilder().setCustomId('admin_only_ticket').setLabel('Admin Only').setStyle(ButtonStyle.Secondary),
-      new ButtonBuilder().setCustomId('close_ticket').setLabel('Close Ticket').setStyle(ButtonStyle.Danger),
+      new ButtonBuilder()
+        .setCustomId('admin_only_ticket')
+        .setLabel(lang.ticket.buttons.adminOnly)
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId('close_ticket')
+        .setLabel(lang.ticket.buttons.closeTicket)
+        .setStyle(ButtonStyle.Danger),
     );
     const newChannel = channel as TextChannel;
 

--- a/src/lang/en/analytics.json
+++ b/src/lang/en/analytics.json
@@ -73,7 +73,15 @@
     "digestFrequency": "Digest Frequency",
     "digestDay": "Digest Day",
     "notSet": "Not set",
-    "error": "Failed to update analytics configuration."
+    "error": "Failed to update analytics configuration.",
+    "specifyFrequency": "Please specify a frequency using the `frequency` option.",
+    "invalidDayWeekly": "Invalid day value. Use 0-6 for weekly (Sun-Sat).",
+    "invalidDayMonthly": "Invalid day value. Use 1-28 for monthly.",
+    "notConfigured": "Analytics have not been configured for this server.",
+    "statusField": "Status",
+    "digestChannelField": "Digest Channel",
+    "frequencyField": "Frequency",
+    "digestDayField": "Digest Day"
   },
   "digest": {
     "weeklyTitle": "Weekly Server Digest",

--- a/src/lang/en/baitChannel.json
+++ b/src/lang/en/baitChannel.json
@@ -121,7 +121,8 @@
   "setup": {
     "title": "Bait Channel Configured",
     "titleUpdated": "Bait Channel Updated",
-    "footer": "Use /baitchannel detection to configure smart detection"
+    "footer": "Use /baitchannel detection to configure smart detection",
+    "textChannelRequired": "Please select a text channel."
   },
   "stats": {
     "title": "Bait Channel Statistics",
@@ -268,5 +269,21 @@
     "addChannel": "Failed to add bait channel",
     "removeChannel": "Failed to remove bait channel",
     "weeklySummary": "Failed to update weekly summary settings"
+  },
+  "raid": {
+    "notInitialized": "❌ Raid mode manager is not initialized (bot may still be starting up).",
+    "statusActive": "🚨 Raid mode is ACTIVE",
+    "statusInactive": "✅ Raid mode is inactive",
+    "recentTriggers": "Recent triggers",
+    "withinWindow": "{0} within window",
+    "distinctOffenders": "Distinct offenders",
+    "autoReleaseAt": "Auto-release at",
+    "notConfigured": "❌ Bait channel is not configured for this guild. Run `/baitchannel setup` first.",
+    "alreadyActive": "⚠️ Raid mode is already active. Use `/baitchannel raid release` first to reset.",
+    "activated": "✅ Raid mode activated. Reason: {0}",
+    "released": "✅ Raid mode released. Channel permissions restored.",
+    "notActive": "ℹ️ Raid mode was not active.",
+    "unknownSubcommand": "Unknown raid subcommand.",
+    "error": "Failed to handle raid command"
   }
 }

--- a/src/lang/en/import.json
+++ b/src/lang/en/import.json
@@ -23,5 +23,15 @@
     "overwriteOption": "Overwrite existing data (default: skip existing)",
     "dryRunOption": "Preview what would be imported without writing data",
     "attachmentOption": "CSV file to import (userId,xp,level,messages)"
+  },
+  "results": {
+    "csvDryRunTitle": "CSV Import — Dry Run",
+    "csvCompleteTitle": "CSV Import Complete",
+    "mee6DryRunTitle": "MEE6 Import — Dry Run",
+    "mee6CompleteTitle": "MEE6 Import Complete",
+    "errorsField": "Errors",
+    "durationField": "Duration",
+    "warningsField": "Warnings",
+    "unknownError": "Unknown error"
   }
 }

--- a/src/lang/en/memory.json
+++ b/src/lang/en/memory.json
@@ -75,7 +75,9 @@
   "channelPicker": {
     "title": "Select Memory Channel",
     "description": "This server has multiple memory channels. Select which one to use.",
-    "placeholder": "Select a memory channel..."
+    "placeholder": "Select a memory channel...",
+    "processing": "Processing...",
+    "forumPrefix": "Forum:"
   },
   "tagSelection": {
     "categoryField": "Category",
@@ -121,7 +123,10 @@
     "notAThread": "This command must be run inside a memory thread",
     "itemNotFound": "Could not find this memory item in the database",
     "confirmTitle": "Update Status",
-    "confirmMessage": "Update status from **{0}** to **{1}**?"
+    "confirmMessage": "Update status from **{0}** to **{1}**?",
+    "noStatusTags": "No status tags configured. Run /memory-setup first.",
+    "updateL": "Update",
+    "cancelL": "Cancel"
   },
   "quickUpdate": {
     "noItems": "No memory items found in this server.",
@@ -158,7 +163,8 @@
       "typeInvalid": "Tag type must be \"category\" or \"status\"",
       "success": "Tag added!",
       "error": "Failed to add tag",
-      "duplicate": "A tag with this name already exists"
+      "duplicate": "A tag with this name already exists",
+      "nameRequired": "Tag name is required."
     },
     "edit": {
       "selectTag": "Select a tag to edit",

--- a/src/lang/en/onboarding.json
+++ b/src/lang/en/onboarding.json
@@ -91,5 +91,12 @@
     "notConfigured": "Onboarding is not configured for this server.",
     "general": "An error occurred while processing the onboarding command.",
     "dmsClosed": "Could not DM the user. They may have DMs disabled for this server."
+  },
+  "engine": {
+    "continueL": "Continue",
+    "skipL": "Skip",
+    "rolesPlaceholder": "Select your roles...",
+    "confirmSelectionL": "Confirm Selection",
+    "gotItL": "Got it!"
   }
 }

--- a/src/lang/en/onboarding.json
+++ b/src/lang/en/onboarding.json
@@ -97,6 +97,7 @@
     "skipL": "Skip",
     "rolesPlaceholder": "Select your roles...",
     "confirmSelectionL": "Confirm Selection",
-    "gotItL": "Got it!"
+    "gotItL": "Got it!",
+    "rolesSelectedHint": "Selected {0} role(s). Click **{1}** to continue."
   }
 }

--- a/src/lang/en/ticket.json
+++ b/src/lang/en/ticket.json
@@ -13,7 +13,10 @@
     "cancel": "Change to Admin Only canceled.",
     "request": "has requested to make this ticket Admin Only.",
     "requestSent": "Your request to make this ticket Admin Only has been sent to the staff team.",
-    "success": "This ticket is now Admin Only — staff roles can no longer view it."
+    "success": "This ticket is now Admin Only — staff roles can no longer view it.",
+    "confirmL": "Confirm",
+    "cancelL": "Cancel",
+    "modsAlert": "❗Oh, Mods!❗"
   },
   "close": {
     "confirm": "Are you sure you want to close this ticket?",
@@ -34,7 +37,9 @@
       "error1": "Error deleting the transcript txt file!",
       "error2": "Could not properly send transcript!",
       "attachmentError": "Error deleting transcript attachments zip file!"
-    }
+    },
+    "confirmL": "Confirm Close",
+    "cancelL": "Cancel"
   },
   "setup": {
     "cmdDescrp": "Configure the ticket system channels and category",
@@ -102,7 +107,7 @@
       "activeLabel": "Active",
       "inactiveLabel": "Inactive",
       "defaultLabel": " [DEFAULT]",
-      "fieldValue": "**ID:** `{0}`\n**Color:** {1}\n**Status:** {2}{3}\n{4}\n\u200B"
+      "fieldValue": "**ID:** `{0}`\n**Color:** {1}\n**Status:** {2}{3}\n{4}\n​"
     },
     "typeToggle": {
       "cmdDescrp": "Activate or deactivate a custom ticket type",
@@ -326,5 +331,13 @@
     "routingRoleOption": "Staff role to route tickets to",
     "routingMaxOpenOption": "Max open tickets per staff (optional, 1-50)",
     "routingStrategyOption": "The routing strategy to use"
+  },
+  "buttons": {
+    "adminOnly": "Admin Only",
+    "closeTicket": "Close Ticket"
+  },
+  "createModal": {
+    "descriptionLabel": "Please describe your issue",
+    "descriptionPlaceholder": "Provide details about your ticket..."
   }
 }

--- a/src/lang/en/xp.json
+++ b/src/lang/en/xp.json
@@ -109,5 +109,20 @@
     "invalidMultiplier": "Multiplier must be between 0.1 and 10.",
     "invalidCooldown": "Cooldown must be between 0 and 3600 seconds.",
     "maxRoleRewards": "Maximum of 25 role rewards per server."
+  },
+  "config": {
+    "currentRate": "Current XP rate: **{0}-{1}** per message.",
+    "rateFormat": "Format: `min-max` (e.g. `15-25`)",
+    "currentCooldown": "Current cooldown: **{0}** seconds.",
+    "currentVoiceXp": "Current voice XP: **{0}** per minute.",
+    "voiceXpRange": "Voice XP must be between 0 and 100.",
+    "currentLevelUpChannel": "Current level-up channel: {0}. Use the channel option or type `none` to clear.",
+    "sameChannel": "Same channel as message",
+    "currentLevelUpMessage": "Current level-up message: {0}\nPlaceholders: `{user}`, `{level}`",
+    "currentVoiceXpEnabled": "Voice XP is currently **{0}**.",
+    "currentStackMultipliers": "Stack multipliers is currently **{0}**.",
+    "enabled": "enabled",
+    "disabled": "disabled",
+    "unknownSetting": "Unknown setting."
   }
 }

--- a/src/lang/types.ts
+++ b/src/lang/types.ts
@@ -437,6 +437,14 @@ export interface LangTicket {
   archiveTicketConfigNotFound: string;
   selectTicketType: string;
   created: string;
+  buttons: {
+    adminOnly: string;
+    closeTicket: string;
+  };
+  createModal: {
+    descriptionLabel: string;
+    descriptionPlaceholder: string;
+  };
   welcomeMsg: string;
   cancelled: string;
   adminOnly: {
@@ -446,11 +454,16 @@ export interface LangTicket {
     request: string;
     requestSent: string;
     success: string;
+    confirmL: string;
+    cancelL: string;
+    modsAlert: string;
   };
   close: {
     confirm: string;
     closing: string;
     cancel: string;
+    confirmL: string;
+    cancelL: string;
     byUser: string;
     notConfigured: string;
     notFound: string;
@@ -1038,6 +1051,22 @@ export interface LangAnnouncement {
 }
 
 export interface LangBaitChannel {
+  raid: {
+    notInitialized: string;
+    statusActive: string;
+    statusInactive: string;
+    recentTriggers: string;
+    withinWindow: string;
+    distinctOffenders: string;
+    autoReleaseAt: string;
+    notConfigured: string;
+    alreadyActive: string;
+    activated: string;
+    released: string;
+    notActive: string;
+    unknownSubcommand: string;
+    error: string;
+  };
   notConfigured: string;
   setupFirst: string;
   specifyRoleOrUser: string;
@@ -1161,6 +1190,7 @@ export interface LangBaitChannel {
     title: string;
     titleUpdated: string;
     footer: string;
+    textChannelRequired: string;
   };
   stats: {
     title: string;
@@ -1416,6 +1446,8 @@ export interface LangMemory {
     title: string;
     description: string;
     placeholder: string;
+    processing: string;
+    forumPrefix: string;
   };
   tagSelection: {
     categoryField: string;
@@ -1455,6 +1487,9 @@ export interface LangMemory {
   update: {
     title: string;
     selectStatus: string;
+    noStatusTags: string;
+    updateL: string;
+    cancelL: string;
     success: string;
     error: string;
     notInForum: string;
@@ -1488,6 +1523,7 @@ export interface LangMemory {
     statusTags: string;
     noTags: string;
     add: {
+      nameRequired: string;
       modalTitle: string;
       nameLabel: string;
       namePlaceholder: string;
@@ -2034,6 +2070,16 @@ export type LangEvent = Record<string, any>;
 export type LangAnalytics = Record<string, any>;
 
 export interface LangImport {
+  results: {
+    csvDryRunTitle: string;
+    csvCompleteTitle: string;
+    mee6DryRunTitle: string;
+    mee6CompleteTitle: string;
+    errorsField: string;
+    durationField: string;
+    warningsField: string;
+    unknownError: string;
+  };
   commands: {
     importStarted: string;
     importComplete: string;

--- a/src/utils/onboarding/onboardingEngine.ts
+++ b/src/utils/onboarding/onboardingEngine.ts
@@ -28,6 +28,7 @@ import { lang } from '../../lang';
 import { AppDataSource } from '../../typeorm';
 import { OnboardingCompletion } from '../../typeorm/entities/onboarding/OnboardingCompletion';
 import { OnboardingConfig } from '../../typeorm/entities/onboarding/OnboardingConfig';
+import { formatLang } from '../../utils';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import type { OnboardingStepDef } from './types';
 
@@ -366,7 +367,7 @@ async function waitForStepInteraction(
           if (interaction.isStringSelectMenu() && customId.startsWith('onboarding_roleselect_')) {
             selectedRoles = interaction.values;
             await interaction.reply({
-              content: `Selected ${selectedRoles.length} role(s). Click **Confirm Selection** to continue.`,
+              content: formatLang(tlEngine.rolesSelectedHint, selectedRoles.length, tlEngine.confirmSelectionL),
               flags: [MessageFlags.Ephemeral],
             });
             return;

--- a/src/utils/onboarding/onboardingEngine.ts
+++ b/src/utils/onboarding/onboardingEngine.ts
@@ -13,7 +13,6 @@
  *
  * Each phase is independently testable; the orchestration just chains them.
  */
-
 import {
   ActionRowBuilder,
   ButtonBuilder,
@@ -25,11 +24,14 @@ import {
   MessageFlags,
   StringSelectMenuBuilder,
 } from 'discord.js';
+import { lang } from '../../lang';
 import { AppDataSource } from '../../typeorm';
 import { OnboardingCompletion } from '../../typeorm/entities/onboarding/OnboardingCompletion';
 import { OnboardingConfig } from '../../typeorm/entities/onboarding/OnboardingConfig';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import type { OnboardingStepDef } from './types';
+
+const tlEngine = lang.onboarding.engine;
 
 /** 24 hours in milliseconds */
 const COLLECTOR_TTL = 24 * 60 * 60 * 1000;
@@ -221,14 +223,14 @@ async function sendStep(
         const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
           new ButtonBuilder()
             .setCustomId(`onboarding_continue_${step.id}`)
-            .setLabel('Continue')
+            .setLabel(tlEngine.continueL)
             .setStyle(ButtonStyle.Primary),
         );
         if (!step.required) {
           row.addComponents(
             new ButtonBuilder()
               .setCustomId(`onboarding_skip_${step.id}`)
-              .setLabel('Skip')
+              .setLabel(tlEngine.skipL)
               .setStyle(ButtonStyle.Secondary),
           );
         }
@@ -244,7 +246,7 @@ async function sendStep(
 
         const selectMenu = new StringSelectMenuBuilder()
           .setCustomId(`onboarding_roleselect_${step.id}`)
-          .setPlaceholder('Select your roles...')
+          .setPlaceholder(tlEngine.rolesPlaceholder)
           .setMinValues(step.required ? 1 : 0)
           .setMaxValues(step.options.length)
           .addOptions(
@@ -259,14 +261,14 @@ async function sendStep(
         const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
           new ButtonBuilder()
             .setCustomId(`onboarding_confirmrole_${step.id}`)
-            .setLabel('Confirm Selection')
+            .setLabel(tlEngine.confirmSelectionL)
             .setStyle(ButtonStyle.Primary),
         );
         if (!step.required) {
           buttonRow.addComponents(
             new ButtonBuilder()
               .setCustomId(`onboarding_skip_${step.id}`)
-              .setLabel('Skip')
+              .setLabel(tlEngine.skipL)
               .setStyle(ButtonStyle.Secondary),
           );
         }
@@ -282,14 +284,14 @@ async function sendStep(
         const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
           new ButtonBuilder()
             .setCustomId(`onboarding_continue_${step.id}`)
-            .setLabel('Got it!')
+            .setLabel(tlEngine.gotItL)
             .setStyle(ButtonStyle.Primary),
         );
         if (!step.required) {
           row.addComponents(
             new ButtonBuilder()
               .setCustomId(`onboarding_skip_${step.id}`)
-              .setLabel('Skip')
+              .setLabel(tlEngine.skipL)
               .setStyle(ButtonStyle.Secondary),
           );
         }
@@ -320,7 +322,7 @@ async function sendStep(
           row.addComponents(
             new ButtonBuilder()
               .setCustomId(`onboarding_skip_${step.id}`)
-              .setLabel('Skip')
+              .setLabel(tlEngine.skipL)
               .setStyle(ButtonStyle.Secondary),
           );
         }


### PR DESCRIPTION
## Summary

Patch 9 of the cleanup roadmap — the big i18n sweep. Beyond the audit's ~17 hardcoded-string findings, the sweep surfaced something structural: **the XP, onboarding, and event handlers imported `lang/en/*.json` directly** (12 files), bypassing the locale Proxy — those features could never localize regardless of what translators did. All now read through the language module. Builders intentionally keep static English (Discord command registration uses its own localization maps, not runtime locale).

Everything else is key-adds + swaps: ticket buttons/modals/staff-alert, `/baitchannel raid` (was hardcoded end-to-end), onboarding DM buttons, XP config replies, the whole insights feature (its `analytics.json` already had most strings — unused), announcement send success, import result embeds, and assorted memory/bait validation strings. Strict lang interfaces extended in `types.ts`; es/fr/de/pt-BR inherit via the Proxy fallback until translated.

## Test plan

- [x] `bun test` — 1441 pass
- [x] Build, Biome, changelog gate, contract gate green
- [ ] Dev-bot spot check: open a ticket (buttons/modal), run /insights setup status, /baitchannel raid status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded localization across onboarding, XP, analytics, memory, imports, tickets, events, and raid management screens.
  * Added localized labels, prompts, and button text for several interactive flows and configuration views.
  * Improved localized messaging for import results and onboarding steps.

* **Bug Fixes**
  * Replaced remaining hardcoded English replies with locale-aware messages across commands and ticket actions.
  * Updated success, error, and validation messages so users see translated text consistently in their selected language.

* **Chores**
  * Bumped the app/package version to **3.15.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->