### PR TITLE
perf: v3.15.1 — hot-path performance pass (audit findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.1] - 2026-07-06
+
+Performance pass — the audit's confirmed hot-path findings.
+
+### Changed
+
+- **Message-heavy paths lightened**: XP cooldown hits (the common case for
+  every message in an XP-enabled guild) now issue a single-column counter
+  update instead of a full row save; starboard skips its reaction-members
+  fetch entirely when the raw count can't reach the threshold; bait-channel
+  activity flushes batch-load and bulk-save instead of two queries per user.
+- **Join raids no longer hammer the database**: the per-join bait-channel
+  config lookup now uses the manager's cache — the uncached query spiked
+  exactly when joins spiked.
+- **Ticket closes** run their three metadata lookups concurrently and reuse
+  the creator fetch for the archive thread name.
+- **Faster startup on many guilds**: default ticket-type seeding runs
+  concurrently instead of guild-by-guild.
+- New database index for bait-channel audit-log correlation lookups
+  (`guildId, userId, createdAt`), plus batched restriction removals and a
+  batched memory-setup overview.
+
 ## [3.15.0] - 2026-07-06
 
 The i18n sweep: user-facing text that bypassed the language system is now in

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.15.0",
+  "botVersion": "3.15.1",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/contextMenus/manageRestrictions.ts
+++ b/src/commands/handlers/contextMenus/manageRestrictions.ts
@@ -5,6 +5,7 @@
  */
 
 import { EmbedBuilder, MessageFlags, type UserContextMenuCommandInteraction } from 'discord.js';
+import { In } from 'typeorm';
 import { CustomTicketType } from '../../../typeorm/entities/ticket/CustomTicketType';
 import { TicketConfig } from '../../../typeorm/entities/ticket/TicketConfig';
 import { UserTicketRestriction } from '../../../typeorm/entities/ticket/UserTicketRestriction';
@@ -91,9 +92,9 @@ export async function manageRestrictionsHandler(interaction: UserContextMenuComm
     const toAdd = [...newRestrictedSet].filter(id => !restrictedTypeIds.has(id));
     const toRemove = [...restrictedTypeIds].filter(id => !newRestrictedSet.has(id));
 
-    // Apply changes
-    for (const typeId of toRemove) {
-      await restrictionRepo.delete({ guildId, userId: targetUser.id, typeId });
+    // Apply changes — removals in one query, mirroring the batched adds
+    if (toRemove.length > 0) {
+      await restrictionRepo.delete({ guildId, userId: targetUser.id, typeId: In(toRemove) });
     }
     if (toAdd.length > 0) {
       const newRestrictions = toAdd.map(typeId =>

--- a/src/commands/handlers/memorySetup.ts
+++ b/src/commands/handlers/memorySetup.ts
@@ -376,13 +376,22 @@ async function handleView(interaction: ChatInputCommandInteraction, guildId: str
 
   const embed = new EmbedBuilder().setTitle(`${E.memory} ${tl.setup.viewTitle}`).setColor(Colors.brand.primary);
 
+  // Two grouped queries instead of two COUNTs per configured channel.
+  const countsByConfig = async (repo: typeof memoryTagRepo | typeof memoryItemRepo) => {
+    const rows: Array<{ cid: string | number; n: string }> = await repo
+      .createQueryBuilder('r')
+      .select('r.memoryConfigId', 'cid')
+      .addSelect('COUNT(*)', 'n')
+      .where('r.guildId = :guildId', { guildId })
+      .groupBy('r.memoryConfigId')
+      .getRawMany();
+    return new Map(rows.map(r => [Number(r.cid), Number(r.n)]));
+  };
+  const [tagCounts, itemCounts] = await Promise.all([countsByConfig(memoryTagRepo), countsByConfig(memoryItemRepo)]);
+
   for (const config of configs) {
-    const tagCount = await memoryTagRepo.count({
-      where: { guildId, memoryConfigId: config.id },
-    });
-    const itemCount = await memoryItemRepo.count({
-      where: { guildId, memoryConfigId: config.id },
-    });
+    const tagCount = tagCounts.get(config.id) ?? 0;
+    const itemCount = itemCounts.get(config.id) ?? 0;
 
     embed.addFields({
       name: config.channelName,

--- a/src/commands/handlers/ticket/userRestrict.ts
+++ b/src/commands/handlers/ticket/userRestrict.ts
@@ -9,6 +9,7 @@ import {
   MessageFlags,
   type User,
 } from 'discord.js';
+import { In } from 'typeorm';
 import { AppDataSource } from '../../../typeorm';
 import { CustomTicketType } from '../../../typeorm/entities/ticket/CustomTicketType';
 import { UserTicketRestriction } from '../../../typeorm/entities/ticket/UserTicketRestriction';
@@ -270,9 +271,10 @@ async function showRestrictionsModal(
   const toAdd = [...newRestrictedSet].filter(id => !restrictedTypeIds.has(id));
   const toRemove = [...restrictedTypeIds].filter(id => !newRestrictedSet.has(id));
 
-  // Batch: remove lifted restrictions
-  for (const typeId of toRemove) {
-    await restrictionRepo.delete({ guildId, userId: targetUser.id, typeId });
+  // Batch: remove lifted restrictions in one query (the additions below were
+  // already batched via save(array))
+  if (toRemove.length > 0) {
+    await restrictionRepo.delete({ guildId, userId: targetUser.id, typeId: In(toRemove) });
   }
 
   // Batch: add new restrictions

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -19,16 +19,22 @@ export default {
 
       const extClient = client;
 
-      // Only track joins for guilds with bait channel enabled
-      const configRepo = AppDataSource.getRepository(BaitChannelConfig);
+      // Only track joins for guilds with bait channel enabled. Use the
+      // manager's TTL cache — an uncached DB query per member join was a raid
+      // amplifier (hammering the DB exactly when joins spike). Falls back to a
+      // direct query only if the manager isn't attached yet (startup window).
       let config: BaitChannelConfig | null;
-      try {
-        config = await configRepo.findOne({
-          where: { guildId: member.guild.id },
-        });
-      } catch (error) {
-        enhancedLogger.error('guildMemberAdd handler failed', error as Error, LogCategory.ERROR);
-        return;
+      if (extClient.baitChannelManager) {
+        config = await extClient.baitChannelManager.getCachedConfig(member.guild.id);
+      } else {
+        try {
+          config = await AppDataSource.getRepository(BaitChannelConfig).findOne({
+            where: { guildId: member.guild.id },
+          });
+        } catch (error) {
+          enhancedLogger.error('guildMemberAdd handler failed', error as Error, LogCategory.ERROR);
+          return;
+        }
       }
 
       if (!config?.enabled) return;

--- a/src/events/starboardReaction.ts
+++ b/src/events/starboardReaction.ts
@@ -104,6 +104,9 @@ export async function handleStarboardReactionAdd(
 
     // Count reactions (excluding self-star if disabled)
     let reactionCount = reaction.count ?? 0;
+    // A raw count below the threshold can never pass — skip the users.fetch
+    // REST call (this fired on EVERY matching reaction before the check).
+    if (reactionCount < config.threshold) return;
     if (!config.selfStar && message.author) {
       // Check if the author reacted — if so, subtract 1
       const users = await reaction.users.fetch();

--- a/src/events/xpMessageHandler.ts
+++ b/src/events/xpMessageHandler.ts
@@ -67,8 +67,10 @@ export default {
         const cooldownMs = config.xpCooldownSeconds * 1000;
         const elapsed = now.getTime() - xpUser.lastXpAt.getTime();
         if (elapsed < cooldownMs) {
-          // Still on cooldown — save message count but no XP
-          await userRepo.save(xpUser);
+          // Still on cooldown — bump the message counter with a single-column
+          // UPDATE instead of a full-entity save (this is the common path for
+          // every message in an XP-enabled guild).
+          await userRepo.increment({ guildId, userId: message.author.id }, 'messages', 1);
           return;
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -534,21 +534,23 @@ async function main() {
     const botConfigRepo = AppDataSource.getRepository(BotConfig);
     const botConfigs = await botConfigRepo.find();
 
-    // ensure default ticket types for all guilds (migration)
-    for (const config of botConfigs) {
-      try {
-        await ensureDefaultTicketTypes(config.guildId);
-      } catch (error) {
-        enhancedLogger.error(
-          `Failed to ensure default ticket types for guild ${config.guildId}`,
-          error as Error,
-          LogCategory.DATABASE,
-          {
-            guildId: config.guildId,
-          },
-        );
-      }
-    }
+    // ensure default ticket types for all guilds (migration) — concurrent so
+    // startup cost doesn't grow linearly with guild count; one guild failing
+    // still doesn't block the others.
+    await Promise.allSettled(
+      botConfigs.map(config =>
+        ensureDefaultTicketTypes(config.guildId).catch(error => {
+          enhancedLogger.error(
+            `Failed to ensure default ticket types for guild ${config.guildId}`,
+            error as Error,
+            LogCategory.DATABASE,
+            {
+              guildId: config.guildId,
+            },
+          );
+        }),
+      ),
+    );
 
     // Run legacy data migrations (after TypeORM sync, before command registration)
     const guildIds = botConfigs.map(c => c.guildId);

--- a/src/typeorm/entities/bait/BaitChannelLog.ts
+++ b/src/typeorm/entities/bait/BaitChannelLog.ts
@@ -7,7 +7,7 @@ export type DmFailureReason = 'closed' | 'no_shared_guild' | 'timeout' | 'unknow
 // Audit-log correlation queries (confirmSelfAction / handleModSupersedes /
 // handleUnban) filter by guildId + userId + createdAt on every relevant
 // audit-log event — without this index they scan the guild's whole log.
-@Index(['guildId', 'userId', 'createdAt'])
+@Index('IDX_bait_logs_guild_user_created', ['guildId', 'userId', 'createdAt'])
 export class BaitChannelLog {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/typeorm/entities/bait/BaitChannelLog.ts
+++ b/src/typeorm/entities/bait/BaitChannelLog.ts
@@ -4,6 +4,10 @@ export type DmFailureReason = 'closed' | 'no_shared_guild' | 'timeout' | 'unknow
 
 @Entity('bait_channel_logs')
 @Index(['guildId', 'createdAt'])
+// Audit-log correlation queries (confirmSelfAction / handleModSupersedes /
+// handleUnban) filter by guildId + userId + createdAt on every relevant
+// audit-log event — without this index they scan the guild's whole log.
+@Index(['guildId', 'userId', 'createdAt'])
 export class BaitChannelLog {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/typeorm/migrations/1774000012000-AddBaitLogCorrelationIndex.ts
+++ b/src/typeorm/migrations/1774000012000-AddBaitLogCorrelationIndex.ts
@@ -1,0 +1,23 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the `(guildId, userId, createdAt)` index on `bait_channel_logs`.
+ *
+ * The audit-log correlation handlers (`confirmSelfAction`,
+ * `handleModSupersedes`, `handleUnban` in `events/auditLogEntryCreate.ts`)
+ * all filter by exactly this triple on every relevant audit-log event; the
+ * existing `(guildId, createdAt)` index leaves them scanning every row for
+ * the guild. Additive and non-breaking — dev (`synchronize: true`) picks the
+ * decorator up automatically; this migration covers prod.
+ */
+export class AddBaitLogCorrelationIndex1774000012000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE INDEX `IDX_bait_logs_guild_user_created` ON `bait_channel_logs` (`guildId`, `userId`, `createdAt`)',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX `IDX_bait_logs_guild_user_created` ON `bait_channel_logs`');
+  }
+}

--- a/src/utils/baitChannel/baitChannelManager.ts
+++ b/src/utils/baitChannel/baitChannelManager.ts
@@ -1737,6 +1737,15 @@ export class BaitChannelManager {
     this.configCache.invalidate(guildId);
   }
 
+  /**
+   * Cached config lookup for event handlers outside the manager (e.g.
+   * guildMemberAdd) — the raw repo query per member join was a raid
+   * amplifier, hammering the DB exactly when joins spike.
+   */
+  public getCachedConfig(guildId: string): Promise<BaitChannelConfig | null> {
+    return this.getConfig(guildId);
+  }
+
   // Track user activity in-memory, flushed to DB periodically
   async trackMessage(message: Message): Promise<void> {
     if (!message.guild || message.author.bot) return;
@@ -1770,37 +1779,49 @@ export class BaitChannelManager {
     const toFlush = this.activityBuffer;
     this.activityBuffer = new Map();
 
-    for (const [key, buffered] of toFlush) {
-      try {
+    try {
+      // Batch-load every buffered row in ONE query (this used to be a findOne
+      // + save pair per user — 2N sequential queries per flush across all
+      // bait-enabled guilds), then bulk-save the merged results.
+      const wherePairs = [...toFlush.keys()].map(key => {
         const [guildId, userId] = key.split(':');
-        let activity = await this.activityRepo.findOne({
-          where: { guildId, userId },
-        });
+        return { guildId, userId };
+      });
+      const existing = await this.activityRepo.find({ where: wherePairs });
+      const byKey = new Map(existing.map(a => [`${a.guildId}:${a.userId}`, a]));
 
+      const toSave = [];
+      for (const [key, buffered] of toFlush) {
+        const [guildId, userId] = key.split(':');
+        const activity = byKey.get(key);
         if (!activity) {
-          activity = this.activityRepo.create({
-            guildId,
-            userId,
-            messageCount: buffered.messageCount,
-            firstMessageAt: buffered.firstMessageAt,
-            lastMessageAt: buffered.lastMessageAt,
-            joinedAt: buffered.joinedAt,
-          });
+          toSave.push(
+            this.activityRepo.create({
+              guildId,
+              userId,
+              messageCount: buffered.messageCount,
+              firstMessageAt: buffered.firstMessageAt,
+              lastMessageAt: buffered.lastMessageAt,
+              joinedAt: buffered.joinedAt,
+            }),
+          );
         } else {
           activity.messageCount += buffered.messageCount;
           activity.lastMessageAt = buffered.lastMessageAt;
+          toSave.push(activity);
         }
-
-        await this.activityRepo.save(activity);
-      } catch (error) {
-        logError({
-          category: ErrorCategory.DATABASE,
-          severity: ErrorSeverity.LOW,
-          message: 'Failed to flush user activity buffer',
-          error,
-          context: { key },
-        });
       }
+      await this.activityRepo.save(toSave);
+    } catch (error) {
+      // Activity stats are advisory — losing one flush is acceptable, matching
+      // the old per-key LOW-severity swallow.
+      logError({
+        category: ErrorCategory.DATABASE,
+        severity: ErrorSeverity.LOW,
+        message: 'Failed to flush user activity buffer',
+        error,
+        context: { bufferedUsers: toFlush.size },
+      });
     }
   }
 

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -135,14 +135,14 @@ async function findExistingArchive(
   });
 }
 
-async function resolveArchiveThreadName(client: Client, ticket: Ticket): Promise<string> {
+function resolveArchiveThreadName(ticket: Ticket, creatorUser: { username: string } | null): string {
   // Clamped to Discord's 100-char thread-name limit — emailSenderName is free
-  // text and an over-limit name fails the whole threads.create call.
+  // text and an over-limit name fails the whole threads.create call. The
+  // creator was already fetched for the header metadata — no second REST call.
   if (ticket.isEmailTicket && ticket.emailSender) {
     return (ticket.emailSenderName || ticket.emailSender.split('@')[0]).slice(0, 100);
   }
-  const user = await client.users.fetch(ticket.createdBy).catch(() => null);
-  return user?.username || 'Unknown';
+  return creatorUser?.username || 'Unknown';
 }
 
 /** Union of existing + incoming forum tag ids, order-preserving, deduped. */
@@ -189,9 +189,13 @@ export async function archiveAndCloseTicket(
 
   // Build header + chunks. Ticket metadata is resolved locally — type info
   // falls back to the ticket's stored type name when the custom row is gone.
-  const typeInfo = await resolveTicketTypeInfo(ticket, guildId, deps);
-  const creatorUser = await client.users.fetch(ticket.createdBy).catch(() => null);
-  const assignedUser = ticket.assignedTo ? await client.users.fetch(ticket.assignedTo).catch(() => null) : null;
+  // Independent lookups — run them concurrently instead of three sequential
+  // round-trips on every close.
+  const [typeInfo, creatorUser, assignedUser] = await Promise.all([
+    resolveTicketTypeInfo(ticket, guildId, deps),
+    client.users.fetch(ticket.createdBy).catch(() => null),
+    ticket.assignedTo ? client.users.fetch(ticket.assignedTo).catch(() => null) : Promise.resolve(null),
+  ]);
 
   const metadata: TicketMetadata = {
     title: ticket.isEmailTicket && ticket.emailSubject ? ticket.emailSubject : typeInfo?.displayName || 'Ticket',
@@ -230,7 +234,7 @@ export async function archiveAndCloseTicket(
     if (!existingArchive) {
       // First-time close: create a new forum thread with the header as
       // the initial message, then post chunks as follow-ups.
-      const threadName = await resolveArchiveThreadName(client, ticket);
+      const threadName = resolveArchiveThreadName(ticket, creatorUser);
       const newPost = await forumChannel.threads.create({
         name: threadName,
         // allowedMentions parse:[] — the transcript is historical content; it
@@ -288,7 +292,7 @@ export async function archiveAndCloseTicket(
       if (!post) {
         // Thread gone: recreate it (header as the initial message), re-apply
         // the accumulated tags, repoint the archive row, and post the chunks.
-        const threadName = await resolveArchiveThreadName(client, ticket);
+        const threadName = resolveArchiveThreadName(ticket, creatorUser);
         const newPost = await forumChannel.threads.create({
           name: threadName,
           message: {


### PR DESCRIPTION
## Summary

Patch 10 of the cleanup roadmap — the nine confirmed performance findings, all behavior-preserving. The three that matter most at scale:

- **Bait activity flush**: 2N sequential queries per 30s flush → 1 batched read + 1 bulk save
- **XP cooldown path** (every message in an XP guild): full-entity save → single-column `increment`
- **Join-raid amplifier**: per-join uncached config query → the manager's TTL cache

Plus: starboard skips its REST members-fetch when the raw count can't pass the threshold, ticket-close metadata lookups run concurrently (and stop double-fetching the creator), restriction removals and the memory-setup overview are batched, startup seeding is concurrent, and `bait_channel_logs` gains the `(guildId, userId, createdAt)` index its three audit-correlation queries filter on (migration `1774000012000`, additive).

## Test plan

- [x] `bun test` — 1441 pass
- [x] Build, Biome, changelog gate, contract gate green
- [ ] Prod deploy note: migration adds one index — additive, no data change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ