### PR TITLE
test: v3.15.2 — test hardening (audit findings, roadmap complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.2] - 2026-07-06
+
+Test hardening — the audit's confirmed coverage holes, closing out the
+cleanup roadmap. No user-facing changes.
+
+### Added
+
+- The application close button and the ticket admin-only flow gained
+  injectable test seams and full regression suites (the v3.13.x close-hang
+  and "undefined"-ping fixes were shipping unguarded).
+- The changelog drift gate's failure branch, the close-needs-archive setup
+  warning, and the archived-but-channel-remains path are now pinned by tests;
+  the contract test compares against the live feature catalog instead of a
+  hardcoded count; the select-menu test double now actually exercises its
+  user/customId filter.
+
 ## [3.15.1] - 2026-07-06
 
 Performance pass — the audit's confirmed hot-path findings.

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.15.1",
+  "botVersion": "3.15.2",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/scripts/checkChangelog.ts
+++ b/scripts/checkChangelog.ts
@@ -50,6 +50,8 @@ function main() {
 // Only run the gate when executed directly — importing the module for tests
 // must not exit the process. (argv check instead of import.meta.main: the
 // project tsconfig targets a module mode where import.meta is unavailable.)
-if (process.argv[1]?.includes('checkChangelog')) {
+// endsWith, not includes: under `bun test` argv[1] is the test file path
+// (checkChangelog.test.ts), which a substring match would wrongly trigger on.
+if (process.argv[1]?.endsWith('/checkChangelog.ts')) {
   main();
 }

--- a/scripts/checkChangelog.ts
+++ b/scripts/checkChangelog.ts
@@ -15,16 +15,30 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { version } from '../package.json';
 
+/** Mirror deploy.yml's extraction: the first `## [x.y.z]` heading, or null. */
+export function extractTopChangelogVersion(changelog: string): string | null {
+  return changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m)?.[1] ?? null;
+}
+
+/**
+ * Pure gate: null = pass; a string = the failure message (the script prints it
+ * and exits 1). Exported so the failure branch — the script's entire purpose —
+ * is actually testable instead of only ever exercising the match branch in CI.
+ */
+export function checkChangelogDrift(changelog: string, pkgVersion: string): string | null {
+  const top = extractTopChangelogVersion(changelog);
+  if (top !== pkgVersion) {
+    return `✗ CHANGELOG drift: package.json is ${pkgVersion} but the top CHANGELOG.md entry is ${top ?? '(none found)'}.`;
+  }
+  return null;
+}
+
 function main() {
   const changelog = readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf8');
-  // Mirror deploy.yml's extraction: first `## [x.y.z]` heading.
-  const match = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m);
-  const top = match?.[1];
+  const failure = checkChangelogDrift(changelog, version);
 
-  if (top !== version) {
-    console.error(
-      `✗ CHANGELOG drift: package.json is ${version} but the top CHANGELOG.md entry is ${top ?? '(none found)'}.`,
-    );
+  if (failure) {
+    console.error(failure);
     console.error(`  Add a "## [${version}] - <date>" section to the top of CHANGELOG.md before releasing,`);
     console.error('  otherwise the deploy will announce the wrong version to Discord.');
     process.exit(1);
@@ -33,4 +47,9 @@ function main() {
   console.log(`✓ CHANGELOG top entry matches package.json version (${version}).`);
 }
 
-main();
+// Only run the gate when executed directly — importing the module for tests
+// must not exit the process. (argv check instead of import.meta.main: the
+// project tsconfig targets a module mode where import.meta is unavailable.)
+if (process.argv[1]?.includes('checkChangelog')) {
+  main();
+}

--- a/src/commands/handlers/application/applicationSetup.ts
+++ b/src/commands/handlers/application/applicationSetup.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../utils';
 import { lazyRepo } from '../../../utils/database/lazyRepo';
 import type { ConfigItem } from '../../../utils/setup/configStatusEmbed';
+import { closeNeedsArchiveWarning } from '../../../utils/setup/configStatusEmbed';
 import { buildApplicationMessage } from './applicationPosition';
 
 const tl = lang.application.setup;
@@ -205,7 +206,10 @@ export async function applicationSetupHandler(_client: Client, interaction: Chat
 
     // Closing an application requires an archive forum; warn when creation is
     // enabled but the archive is missing (mirrors ticket setup).
-    const closeNeedsArchive = !!applicationConfig?.channelId && !archivedApplicationConfig?.channelId;
+    const closeNeedsArchive = closeNeedsArchiveWarning(
+      applicationConfig?.channelId,
+      archivedApplicationConfig?.channelId,
+    );
 
     await interaction.reply({
       content: closeNeedsArchive ? tl.closeNeedsArchive : undefined,

--- a/src/commands/handlers/ticketSetup.ts
+++ b/src/commands/handlers/ticketSetup.ts
@@ -23,6 +23,7 @@ import {
 } from '../../utils';
 import { lazyRepo } from '../../utils/database/lazyRepo';
 import type { ConfigItem } from '../../utils/setup/configStatusEmbed';
+import { closeNeedsArchiveWarning } from '../../utils/setup/configStatusEmbed';
 
 const tl = lang.ticketSetup;
 const ticketConfigRepo = lazyRepo(TicketConfig);
@@ -213,7 +214,7 @@ export async function ticketSetupHandler(_client: Client, interaction: ChatInput
     // Ticket creation works with just a channel, but closing requires an archive
     // forum (the close flow has nowhere to post the transcript otherwise). Warn
     // explicitly when creation is enabled but the archive is missing.
-    const closeNeedsArchive = !!ticketConfig?.channelId && !archivedTicketConfig?.channelId;
+    const closeNeedsArchive = closeNeedsArchiveWarning(ticketConfig?.channelId, archivedTicketConfig?.channelId);
 
     await interaction.reply({
       content: closeNeedsArchive ? tl.closeNeedsArchive : undefined,

--- a/src/events/application/close.ts
+++ b/src/events/application/close.ts
@@ -17,15 +17,39 @@ const tl = lang.application.close;
 const applicationRepo = lazyRepo(Application);
 const archivedApplicationConfigRepo = lazyRepo(ArchivedApplicationConfig);
 
-export const applicationCloseEvent = async (client: Client, interaction: ButtonInteraction) => {
+/**
+ * Injectable seam for {@link applicationCloseEvent}. Production callers omit
+ * it (the defaults bind the real repos + workflow). Tests pass fakes directly
+ * rather than relying on `mock.module()` — the same deterministic-injection
+ * pattern as events/ticket/close.ts (its TicketCloseDeps twin).
+ */
+export interface ApplicationCloseDeps {
+  applicationRepo: typeof applicationRepo;
+  archivedApplicationConfigRepo: typeof archivedApplicationConfigRepo;
+  archiveAndCloseApplication: typeof archiveAndCloseApplication;
+  replyEphemeralError: typeof replyEphemeralError;
+}
+
+const defaultApplicationCloseDeps: ApplicationCloseDeps = {
+  applicationRepo,
+  archivedApplicationConfigRepo,
+  archiveAndCloseApplication,
+  replyEphemeralError,
+};
+
+export const applicationCloseEvent = async (
+  client: Client,
+  interaction: ButtonInteraction,
+  deps: ApplicationCloseDeps = defaultApplicationCloseDeps,
+) => {
   if (!interaction.guildId) return;
   const guildId = interaction.guildId;
   const channel = interaction.channel as GuildTextBasedChannel;
   const channelId = interaction.channelId || '';
-  const archivedConfig = await archivedApplicationConfigRepo.findOneBy({
+  const archivedConfig = await deps.archivedApplicationConfigRepo.findOneBy({
     guildId,
   });
-  const application = await applicationRepo.findOneBy({ guildId, channelId });
+  const application = await deps.applicationRepo.findOneBy({ guildId, channelId });
 
   // Every early return below runs AFTER confirmCloseApplication already showed
   // "Closing application..." (interaction.update). A bare return freezes that
@@ -33,13 +57,13 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
   // followUp before bailing — mirrors the ticket close flow.
   if (!archivedConfig) {
     enhancedLogger.warn(lang.application.applicationConfigNotFound, LogCategory.SYSTEM, { guildId });
-    await replyEphemeralError(interaction, tl.notConfigured);
+    await deps.replyEphemeralError(interaction, tl.notConfigured);
     return;
   }
 
   if (!application) {
     enhancedLogger.error(lang.general.fatalError, undefined, LogCategory.SYSTEM, { guildId, channelId });
-    await replyEphemeralError(interaction, tl.notFound);
+    await deps.replyEphemeralError(interaction, tl.notFound);
     return;
   }
 
@@ -49,7 +73,7 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
       guildId,
       channelId,
     });
-    await replyEphemeralError(interaction, tl.alreadyClosed);
+    await deps.replyEphemeralError(interaction, tl.alreadyClosed);
     return;
   }
 
@@ -57,31 +81,31 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
   // confirm racing the dashboard's archive (or a double-click) could pass it;
   // whoever loses the conditional UPDATE bails as a duplicate. Mirrors
   // events/ticket/close.ts.
-  if (!(await claimClose(applicationRepo, application.id, guildId))) {
+  if (!(await claimClose(deps.applicationRepo, application.id, guildId))) {
     enhancedLogger.warn(
       'Application close lost the flip race — concurrent close already in progress',
       LogCategory.SYSTEM,
       { guildId, channelId },
     );
-    await replyEphemeralError(interaction, tl.alreadyClosed);
+    await deps.replyEphemeralError(interaction, tl.alreadyClosed);
     return;
   }
 
   let result: ArchiveApplicationResult;
   try {
-    result = await archiveAndCloseApplication(client, application, guildId, channel, archivedConfig.channelId);
+    result = await deps.archiveAndCloseApplication(client, application, guildId, channel, archivedConfig.channelId);
   } catch (error) {
     // Unexpected throw escaped the workflow. Status was flipped to 'closed'
     // above but the channel still exists — revert (otherwise the dup-close guard
     // strands it) and tell the user instead of leaving "Closing application...".
-    await releaseClose(applicationRepo, application.id, guildId, application.status);
+    await releaseClose(deps.applicationRepo, application.id, guildId, application.status);
     enhancedLogger.error(
       'Application close threw unexpectedly — status reverted, channel preserved for retry',
       error instanceof Error ? error : undefined,
       LogCategory.ERROR,
       { guildId, channelId, applicationId: application.id },
     );
-    await replyEphemeralError(interaction, tl.transcriptCreate.error).catch(() => {});
+    await deps.replyEphemeralError(interaction, tl.transcriptCreate.error).catch(() => {});
     return;
   }
 
@@ -89,7 +113,7 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
     // Close did not complete (transcript fetch or forum post failed). The
     // workflow preserved the channel; revert the status so the close can be
     // retried instead of stranding a 'closed' application with a live channel.
-    await releaseClose(applicationRepo, application.id, guildId, application.status);
+    await releaseClose(deps.applicationRepo, application.id, guildId, application.status);
     enhancedLogger.warn(
       'Application close reverted — archive failed, channel + application preserved for retry',
       LogCategory.SYSTEM,
@@ -102,7 +126,7 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
     );
     // replyEphemeralError picks reply/editReply/followUp from the interaction
     // state internally, so no branch on replied/deferred is needed.
-    await replyEphemeralError(interaction, tl.transcriptCreate.error).catch((err: unknown) => {
+    await deps.replyEphemeralError(interaction, tl.transcriptCreate.error).catch((err: unknown) => {
       enhancedLogger.error(
         'Failed to deliver application-close failure notice to the user',
         err instanceof Error ? err : undefined,
@@ -118,9 +142,17 @@ export const applicationCloseEvent = async (client: Client, interaction: ButtonI
       channelId,
       applicationId: application.id,
     });
-    await replyEphemeralError(interaction, tl.archivedChannelRemains, { bugReport: true }).catch(() => {});
+    await deps.replyEphemeralError(interaction, tl.archivedChannelRemains, { bugReport: true }).catch(() => {});
   }
 };
+
+/**
+ * Untouched alias for suites that test the REAL implementation.
+ * applicationInteraction.test.ts mock.module()s this module (process-global
+ * in bun) to isolate the dispatcher; its factory spreads the real module, so
+ * this alias passes through unmocked.
+ */
+export const applicationCloseEventImpl = applicationCloseEvent;
 
 export const closeApplicationButton = async (_client: Client, interaction: ButtonInteraction) => {
   enhancedLogger.debug(`Button: close_application`, LogCategory.COMMAND_EXECUTION, {

--- a/src/events/ticket/adminOnly.ts
+++ b/src/events/ticket/adminOnly.ts
@@ -20,22 +20,52 @@ const ticketRepo = lazyRepo(Ticket);
 const staffRoleRepo = lazyRepo(StaffRole);
 const ticketConfigRepo = lazyRepo(TicketConfig);
 
-export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonInteraction) => {
+/**
+ * Injectable seam for {@link ticketAdminOnlyEvent} — the deterministic
+ * direct-injection pattern shared with the ticket/application close events.
+ * The bot-config and staff-role lookups are wrapped as functions so tests
+ * don't need AppDataSource or a query-builder fake.
+ */
+export interface AdminOnlyDeps {
+  ticketRepo: typeof ticketRepo;
+  ticketConfigRepo: typeof ticketConfigRepo;
+  getBotConfig: (guildId: string) => Promise<BotConfig | null>;
+  getStaffRoles: (guildId: string) => Promise<Array<{ role: string }>>;
+  replyEphemeralError: typeof replyEphemeralError;
+}
+
+const defaultAdminOnlyDeps: AdminOnlyDeps = {
+  ticketRepo,
+  ticketConfigRepo,
+  getBotConfig: guildId => AppDataSource.getRepository(BotConfig).findOneBy({ guildId }),
+  getStaffRoles: guildId =>
+    staffRoleRepo
+      .createQueryBuilder()
+      .select(['role'])
+      .where('guildId = :guildId', { guildId })
+      .andWhere('type = :type', { type: 'staff' })
+      .getRawMany(),
+  replyEphemeralError,
+};
+
+export const ticketAdminOnlyEvent = async (
+  _client: Client,
+  interaction: ButtonInteraction,
+  deps: AdminOnlyDeps = defaultAdminOnlyDeps,
+) => {
   const channel = interaction.channel as TextChannel;
   const channelId = interaction.channelId;
   const guildId = interaction.guildId;
   const user = interaction.user.displayName;
   const userId = interaction.user.id;
   if (!guildId) {
-    await replyEphemeralError(interaction, lang.general.cmdGuildNotFound);
+    await deps.replyEphemeralError(interaction, lang.general.cmdGuildNotFound);
     return;
   }
 
-  const ticket = await ticketRepo.findOneBy({ guildId, channelId: channelId });
+  const ticket = await deps.ticketRepo.findOneBy({ guildId, channelId: channelId });
 
-  // get the bot config repo
-  const botConfigRepo = AppDataSource.getRepository(BotConfig);
-  const botConfig = await botConfigRepo.findOneBy({ guildId });
+  const botConfig = await deps.getBotConfig(guildId);
   const gsrFlag = botConfig?.enableGlobalStaffRole;
   const globalStaffRole = botConfig?.globalStaffRole;
 
@@ -44,14 +74,14 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
     enhancedLogger.error(lang.general.fatalError, undefined, LogCategory.COMMAND_EXECUTION, { guildId, channelId });
     // confirmAdminOnly already showed "Changing to Admin Only..." — surface the
     // failure instead of leaving the user on a frozen ack.
-    await replyEphemeralError(interaction, lang.general.fatalError, { bugReport: true });
+    await deps.replyEphemeralError(interaction, lang.general.fatalError, { bugReport: true });
     return;
   }
 
   // check if the person hitting the button is the ticket creator
   if (userId === ticket.createdBy) {
     // Get ticket config to check admin-only mention setting
-    const ticketConfig = await ticketConfigRepo.findOneBy({ guildId });
+    const ticketConfig = await deps.ticketConfigRepo.findOneBy({ guildId });
     const shouldMentionStaff = ticketConfig?.adminOnlyMentionStaff ?? true;
 
     // Only mention staff if the setting is enabled AND a staff role is actually
@@ -73,12 +103,7 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
     return;
   }
 
-  const savedRoles = await staffRoleRepo
-    .createQueryBuilder()
-    .select(['role'])
-    .where('guildId = :guildId', { guildId })
-    .andWhere('type = :type', { type: 'staff' })
-    .getRawMany();
+  const savedRoles = await deps.getStaffRoles(guildId);
 
   // Remove each staff role's view access. Await sequentially (forEach does NOT
   // await async callbacks — the old fire-and-forget edits raced and could throw
@@ -120,11 +145,18 @@ export const ticketAdminOnlyEvent = async (_client: Client, interaction: ButtonI
   }
 
   // update the ticket status
-  await ticketRepo.update({ id: ticket.id, guildId }, { status: 'adminOnly' });
+  await deps.ticketRepo.update({ id: ticket.id, guildId }, { status: 'adminOnly' });
 
   // Resolve the "Changing to Admin Only..." ack so it isn't left frozen.
   await interaction.editReply({ content: tl.success }).catch(() => {});
 };
+
+/**
+ * Untouched alias for suites that test the REAL implementation (see
+ * applicationCloseEventImpl in events/application/close.ts for the pattern —
+ * ticketInteraction.test.ts mocks this module process-globally).
+ */
+export const ticketAdminOnlyEventImpl = ticketAdminOnlyEvent;
 
 export const adminOnlyButton = async (_client: Client, interaction: ButtonInteraction) => {
   enhancedLogger.debug(`Button: admin_only_ticket`, LogCategory.COMMAND_EXECUTION, {

--- a/src/utils/setup/configStatusEmbed.ts
+++ b/src/utils/setup/configStatusEmbed.ts
@@ -81,3 +81,16 @@ export function buildConfigStatusEmbed(options: ConfigStatusOptions): EmbedBuild
 
   return embed;
 }
+
+/**
+ * Creation is configured but the archive forum is missing — the close flow
+ * would have nowhere to post the transcript (the exact misconfiguration that
+ * made the Close button fail before v3.13.2). Shared by the ticket and
+ * application setup status views.
+ */
+export function closeNeedsArchiveWarning(
+  creationChannelId: string | null | undefined,
+  archiveChannelId: string | null | undefined,
+): boolean {
+  return !!creationChannelId && !archiveChannelId;
+}

--- a/tests/unit/commands/checkChangelog.test.ts
+++ b/tests/unit/commands/checkChangelog.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Changelog drift gate tests — pins the FAILURE branch, which is the script's
+ * entire purpose. Every green CI run only ever exercised the match branch, so
+ * a regex regression would have gone unnoticed until a stale release note
+ * actually shipped.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { checkChangelogDrift, extractTopChangelogVersion } from '../../../scripts/checkChangelog';
+
+const CHANGELOG = `# Changelog
+
+Some prose mentioning ## [9.9.9] inline that must NOT match (not line-start).
+
+## [3.14.2] - 2026-07-05
+
+Notes.
+
+## [3.14.1] - 2026-07-04
+`;
+
+describe('extractTopChangelogVersion', () => {
+  test('finds the FIRST line-start heading, ignoring inline mentions', () => {
+    expect(extractTopChangelogVersion(CHANGELOG)).toBe('3.14.2');
+  });
+
+  test('returns null when no heading exists', () => {
+    expect(extractTopChangelogVersion('# Changelog\n\nnothing here\n')).toBeNull();
+  });
+});
+
+describe('checkChangelogDrift', () => {
+  test('passes when the top entry matches package version', () => {
+    expect(checkChangelogDrift(CHANGELOG, '3.14.2')).toBeNull();
+  });
+
+  test('fails with both versions named when they drift', () => {
+    const failure = checkChangelogDrift(CHANGELOG, '3.14.3');
+    expect(failure).toContain('3.14.3');
+    expect(failure).toContain('3.14.2');
+  });
+
+  test('fails clearly when the changelog has no version heading at all', () => {
+    const failure = checkChangelogDrift('# Changelog\n', '1.0.0');
+    expect(failure).toContain('(none found)');
+  });
+});

--- a/tests/unit/contract/contract.test.ts
+++ b/tests/unit/contract/contract.test.ts
@@ -7,6 +7,7 @@
  * including the actionType-enum tie-in from the Phase 0 fix.
  */
 
+import { FEATURES } from '../../../src/utils/validation/featurePermission';
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -23,7 +24,10 @@ describe('cogworks-contract.json', () => {
 
   test('carries the full feature + level catalog', () => {
     expect(contract.features.keys).toContain('baitchannel');
-    expect(contract.features.keys.length).toBe(13);
+    // Compare against the live catalog, not a hardcoded count — a legitimate
+    // feature addition must not break this test (it grew as recently as
+    // v3.1.29); only real drift between generator and catalog should.
+    expect([...contract.features.keys].sort()).toEqual([...FEATURES].sort());
     expect(contract.features.levels).toEqual(['use', 'manage', 'admin']);
   });
 

--- a/tests/unit/events/application/close.test.ts
+++ b/tests/unit/events/application/close.test.ts
@@ -1,0 +1,149 @@
+/**
+ * applicationCloseEvent regression tests — the application twin of
+ * tests/unit/events/ticket/close.test.ts.
+ *
+ * The handler carries the full v3.13.x close-hang fix set (guard feedback,
+ * atomic status flip, revert-on-throw, revert-on-archived:false,
+ * channelDeleted:false notice) but had zero coverage until v3.15.2 because it
+ * lacked an injectable seam. These tests lock in that EVERY exit surfaces
+ * user feedback and that a failed close reverts the status conditionally
+ * instead of stranding the application 'closed' with a live channel.
+ */
+
+import { describe, expect, jest, test } from 'bun:test';
+import { Not } from 'typeorm';
+import applicationLang from '../../../../src/lang/en/application.json';
+import { type ApplicationCloseDeps, applicationCloseEventImpl as applicationCloseEvent } from '../../../../src/events/application/close';
+
+const tl = applicationLang.close;
+
+function makeDeps(overrides: Partial<Record<keyof ApplicationCloseDeps, unknown>> = {}) {
+  const archivedApplicationConfigRepo = { findOneBy: jest.fn().mockResolvedValue({ channelId: 'forum-1' }) };
+  const applicationRepo = {
+    findOneBy: jest.fn().mockResolvedValue({ id: 9, guildId: 'guild1', channelId: 'chan1', status: 'pending' }),
+    update: jest.fn().mockResolvedValue({ affected: 1 }),
+  };
+  const archiveAndCloseApplication = jest.fn().mockResolvedValue({ success: true, archived: true });
+  const replyEphemeralError = jest.fn().mockResolvedValue(undefined);
+  return {
+    deps: {
+      archivedApplicationConfigRepo,
+      applicationRepo,
+      archiveAndCloseApplication,
+      replyEphemeralError,
+      ...overrides,
+    } as unknown as ApplicationCloseDeps,
+    archivedApplicationConfigRepo,
+    applicationRepo,
+    archiveAndCloseApplication,
+    replyEphemeralError,
+  };
+}
+
+function makeInteraction() {
+  return {
+    guildId: 'guild1',
+    channelId: 'chan1',
+    channel: { id: 'chan1' },
+    user: { id: 'user1' },
+  } as never;
+}
+
+const client = {} as never;
+
+describe('applicationCloseEvent', () => {
+  test('no archive config → notConfigured feedback, no archive attempt', async () => {
+    const { deps, archivedApplicationConfigRepo, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+    archivedApplicationConfigRepo.findOneBy.mockResolvedValue(null);
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.notConfigured);
+    expect(archiveAndCloseApplication).not.toHaveBeenCalled();
+  });
+
+  test('no application row → notFound feedback', async () => {
+    const { deps, applicationRepo, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+    applicationRepo.findOneBy.mockResolvedValue(null);
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.notFound);
+    expect(archiveAndCloseApplication).not.toHaveBeenCalled();
+  });
+
+  test('already closed → alreadyClosed feedback, no archive attempt', async () => {
+    const { deps, applicationRepo, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+    applicationRepo.findOneBy.mockResolvedValue({ id: 9, guildId: 'guild1', channelId: 'chan1', status: 'closed' });
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.alreadyClosed);
+    expect(archiveAndCloseApplication).not.toHaveBeenCalled();
+  });
+
+  test('flip race lost (affected=0) → treated as duplicate close, no archive attempt', async () => {
+    const { deps, applicationRepo, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+    applicationRepo.update.mockResolvedValue({ affected: 0 });
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(archiveAndCloseApplication).not.toHaveBeenCalled();
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.alreadyClosed);
+  });
+
+  test('happy path → single atomic flip, archives, no error feedback', async () => {
+    const { deps, applicationRepo, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(archiveAndCloseApplication).toHaveBeenCalledTimes(1);
+    expect(applicationRepo.update).toHaveBeenCalledTimes(1);
+    expect(applicationRepo.update).toHaveBeenCalledWith(
+      { id: 9, guildId: 'guild1', status: Not('closed') },
+      { status: 'closed' },
+    );
+    expect(replyEphemeralError).not.toHaveBeenCalled();
+  });
+
+  test('workflow throws → conditional revert to original status and notifies (no stranded close)', async () => {
+    const { deps, applicationRepo, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+    archiveAndCloseApplication.mockRejectedValue(new Error('transient DB error'));
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(applicationRepo.update).toHaveBeenCalledTimes(2);
+    expect(applicationRepo.update).toHaveBeenNthCalledWith(
+      2,
+      { id: 9, guildId: 'guild1', status: 'closed' },
+      { status: 'pending' },
+    );
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.transcriptCreate.error);
+  });
+
+  test('archive returns archived:false → conditional revert and notifies', async () => {
+    const { deps, applicationRepo, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+    archiveAndCloseApplication.mockResolvedValue({ success: false, archived: false, transcriptFailed: true });
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(applicationRepo.update).toHaveBeenCalledTimes(2);
+    expect(applicationRepo.update).toHaveBeenNthCalledWith(
+      2,
+      { id: 9, guildId: 'guild1', status: 'closed' },
+      { status: 'pending' },
+    );
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.transcriptCreate.error);
+  });
+
+  test('archived but channel delete failed → notifies instead of leaving a live channel hanging', async () => {
+    const { deps, archiveAndCloseApplication, replyEphemeralError } = makeDeps();
+    archiveAndCloseApplication.mockResolvedValue({ success: true, archived: true, channelDeleted: false });
+
+    await applicationCloseEvent(client, makeInteraction(), deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), tl.archivedChannelRemains, {
+      bugReport: true,
+    });
+  });
+});

--- a/tests/unit/events/applicationInteraction.test.ts
+++ b/tests/unit/events/applicationInteraction.test.ts
@@ -25,6 +25,7 @@
  * (applicationCloseEvent) are replaced via Bun's mock.module().
  */
 
+import * as realApplicationCloseModule from "../../../src/events/application/close";
 import {
   afterEach,
   beforeEach,
@@ -44,7 +45,11 @@ import { rateLimiter } from "../../../src/utils/security/rateLimiter";
 
 const mockApplicationCloseEvent = jest.fn().mockResolvedValue(undefined);
 
+// Spread the REAL module so sibling exports (buttons, the *Impl alias used by
+// events/application/close.test.ts) pass through — mock.module is process-
+// global in bun, and a stub-only factory clobbers them for every other suite.
 mock.module("../../../src/events/application/close", () => ({
+  ...realApplicationCloseModule,
   applicationCloseEvent: (...args: unknown[]) =>
     mockApplicationCloseEvent(...args),
 }));

--- a/tests/unit/events/ticket/adminOnly.test.ts
+++ b/tests/unit/events/ticket/adminOnly.test.ts
@@ -104,13 +104,16 @@ describe('ticketAdminOnlyEvent', () => {
 
   test('creator request with NO configured staff role never pings a literal "undefined"', async () => {
     const { deps, getBotConfig } = makeDeps();
-    getBotConfig.mockResolvedValue({ enableGlobalStaffRole: true, globalStaffRole: null });
+    // No globalStaffRole key at all — the historical bug interpolated the
+    // missing value, so the regression renders the literal string "undefined".
+    getBotConfig.mockResolvedValue({ enableGlobalStaffRole: true });
     const { interaction, sent } = makeInteraction('creator-1');
 
     await ticketAdminOnlyEvent(client, interaction, deps);
 
     expect(sent).toHaveLength(1);
     expect(sent[0].content).not.toContain('undefined');
+    expect(sent[0].content).not.toContain('null');
     expect(sent[0].content.startsWith(tl.modsAlert)).toBe(true);
   });
 

--- a/tests/unit/events/ticket/adminOnly.test.ts
+++ b/tests/unit/events/ticket/adminOnly.test.ts
@@ -1,0 +1,155 @@
+/**
+ * ticketAdminOnlyEvent regression tests — pins the v3.13.2 rewrite that had
+ * shipped untested: the creator-request branch (requestSent ack, staff act on
+ * it), the null-globalStaffRole guard (used to ping a literal "undefined"),
+ * per-role permission-failure tolerance, and the frozen-ack fix for a missing
+ * ticket.
+ */
+
+import { describe, expect, jest, test } from 'bun:test';
+import ticketLang from '../../../../src/lang/en/ticket.json';
+import generalLang from '../../../../src/lang/en/general.json';
+import { type AdminOnlyDeps, ticketAdminOnlyEventImpl as ticketAdminOnlyEvent } from '../../../../src/events/ticket/adminOnly';
+
+const tl = ticketLang.adminOnly;
+
+function makeDeps(overrides: Partial<Record<keyof AdminOnlyDeps, unknown>> = {}) {
+  const ticketRepo = {
+    findOneBy: jest
+      .fn()
+      .mockResolvedValue({ id: 3, guildId: 'guild1', channelId: 'chan1', createdBy: 'creator-1', messageId: 'welcome-1' }),
+    update: jest.fn().mockResolvedValue({ affected: 1 }),
+  };
+  const ticketConfigRepo = { findOneBy: jest.fn().mockResolvedValue({ adminOnlyMentionStaff: true }) };
+  const getBotConfig = jest.fn().mockResolvedValue({ enableGlobalStaffRole: true, globalStaffRole: '<@&staff-role>' });
+  const getStaffRoles = jest.fn().mockResolvedValue([{ role: '<@&staff-role>' }]);
+  const replyEphemeralError = jest.fn().mockResolvedValue(undefined);
+  return {
+    deps: {
+      ticketRepo,
+      ticketConfigRepo,
+      getBotConfig,
+      getStaffRoles,
+      replyEphemeralError,
+      ...overrides,
+    } as unknown as AdminOnlyDeps,
+    ticketRepo,
+    ticketConfigRepo,
+    getBotConfig,
+    getStaffRoles,
+    replyEphemeralError,
+  };
+}
+
+function makeInteraction(userId = 'staff-9') {
+  const sent: Array<{ content: string }> = [];
+  const edits: Array<{ content?: string }> = [];
+  const permEdits: Array<{ roleId: string; perms: unknown }> = [];
+  const welcomeEdits: unknown[] = [];
+  const permissionOverwrites = {
+    edit: jest.fn(async (roleId: string, perms: unknown) => {
+      permEdits.push({ roleId, perms });
+    }),
+  };
+  const interaction = {
+    guildId: 'guild1',
+    channelId: 'chan1',
+    user: { id: userId, displayName: 'Somebody' },
+    channel: {
+      send: async (payload: { content: string }) => {
+        sent.push(payload);
+      },
+      permissionOverwrites,
+      messages: {
+        fetch: async () => ({
+          edit: async (payload: unknown) => {
+            welcomeEdits.push(payload);
+          },
+        }),
+      },
+    },
+    editReply: async (payload: { content?: string }) => {
+      edits.push(payload);
+    },
+  } as never;
+  return { interaction, sent, edits, permEdits, welcomeEdits, permissionOverwrites };
+}
+
+const client = {} as never;
+
+describe('ticketAdminOnlyEvent', () => {
+  test('missing ticket → visible error instead of a frozen "Changing..." ack', async () => {
+    const { deps, ticketRepo, replyEphemeralError } = makeDeps();
+    ticketRepo.findOneBy.mockResolvedValue(null);
+    const { interaction } = makeInteraction();
+
+    await ticketAdminOnlyEvent(client, interaction, deps);
+
+    expect(replyEphemeralError).toHaveBeenCalledWith(expect.anything(), generalLang.fatalError, { bugReport: true });
+  });
+
+  test('creator click = a REQUEST: staff pinged, requestSent ack, status untouched', async () => {
+    const { deps, ticketRepo } = makeDeps();
+    const { interaction, sent, edits, permEdits } = makeInteraction('creator-1');
+
+    await ticketAdminOnlyEvent(client, interaction, deps);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].content.startsWith('<@&staff-role>')).toBe(true);
+    expect(edits).toEqual([{ content: tl.requestSent }]);
+    // The creator requests — staff perform. Nothing changes yet.
+    expect(ticketRepo.update).not.toHaveBeenCalled();
+    expect(permEdits).toHaveLength(0);
+  });
+
+  test('creator request with NO configured staff role never pings a literal "undefined"', async () => {
+    const { deps, getBotConfig } = makeDeps();
+    getBotConfig.mockResolvedValue({ enableGlobalStaffRole: true, globalStaffRole: null });
+    const { interaction, sent } = makeInteraction('creator-1');
+
+    await ticketAdminOnlyEvent(client, interaction, deps);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].content).not.toContain('undefined');
+    expect(sent[0].content.startsWith(tl.modsAlert)).toBe(true);
+  });
+
+  test('creator request honors adminOnlyMentionStaff=false (no role ping)', async () => {
+    const { deps, ticketConfigRepo } = makeDeps();
+    ticketConfigRepo.findOneBy.mockResolvedValue({ adminOnlyMentionStaff: false });
+    const { interaction, sent } = makeInteraction('creator-1');
+
+    await ticketAdminOnlyEvent(client, interaction, deps);
+
+    expect(sent[0].content).not.toContain('<@&staff-role>');
+  });
+
+  test('staff click: hides valid staff roles, skips malformed ones, flips status, success ack', async () => {
+    const { deps, getStaffRoles, ticketRepo } = makeDeps();
+    getStaffRoles.mockResolvedValue([{ role: '<@&111>' }, { role: 'not-a-mention' }, { role: '<@&222>' }]);
+    const { interaction, edits, permEdits, welcomeEdits } = makeInteraction('staff-9');
+
+    await ticketAdminOnlyEvent(client, interaction, deps);
+
+    expect(permEdits.map(p => p.roleId)).toEqual(['111', '222']);
+    expect(welcomeEdits).toHaveLength(1); // Admin Only button stripped
+    expect(ticketRepo.update).toHaveBeenCalledWith({ id: 3, guildId: 'guild1' }, { status: 'adminOnly' });
+    expect(edits).toEqual([{ content: tl.success }]);
+  });
+
+  test('one role failing to hide does not abort the rest or strand the interaction', async () => {
+    const { deps, getStaffRoles, ticketRepo } = makeDeps();
+    getStaffRoles.mockResolvedValue([{ role: '<@&111>' }, { role: '<@&222>' }]);
+    const { interaction, edits, permEdits, permissionOverwrites } = makeInteraction('staff-9');
+    permissionOverwrites.edit.mockImplementationOnce(async () => {
+      throw new Error('Missing Permissions');
+    });
+
+    await ticketAdminOnlyEvent(client, interaction, deps);
+
+    // role 111 threw, role 222 still processed; status + ack still happen.
+    expect(permEdits.map(p => p.roleId)).toEqual(['222']);
+    expect(ticketRepo.update).toHaveBeenCalledTimes(1);
+    expect(edits).toEqual([{ content: tl.success }]);
+  });
+});

--- a/tests/unit/events/ticketInteraction.test.ts
+++ b/tests/unit/events/ticketInteraction.test.ts
@@ -22,6 +22,7 @@
  * are replaced via Bun's mock.module() before the handler is imported.
  */
 
+import * as realAdminOnlyModule from "../../../src/events/ticket/adminOnly";
 import {
   afterEach,
   beforeEach,
@@ -48,7 +49,11 @@ const mockEmailImportModalHandler = jest.fn().mockResolvedValue(undefined);
 // deps seam) and broke it. confirmClose/closeButton/cancelClose run for real
 // here; routing into ticketCloseEvent is verified via the DB lookup it performs
 // (findOneBySpy) rather than a spy on the function itself.
+// Spread the REAL module so sibling exports (buttons, the *Impl alias used by
+// events/ticket/adminOnly.test.ts) pass through — see the close-module NOTE
+// above for why stub-only factories are hazardous.
 mock.module("../../../src/events/ticket/adminOnly", () => ({
+  ...realAdminOnlyModule,
   ticketAdminOnlyEvent: (...args: unknown[]) =>
     mockTicketAdminOnlyEvent(...args),
 }));

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -164,6 +164,23 @@ describe("archiveAndCloseApplication", () => {
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
+  test("channel delete refused → archived:true but channelDeleted:false (caller must tell the user)", async () => {
+    fakeVerifiedChannelDelete.mockResolvedValue({ success: false, alreadyGone: false, error: "Missing Permissions" });
+    const client = makeFakeClient(forumChannel);
+
+    const result = await archiveAndCloseApplication(
+      client,
+      makeApplication(),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    // The transcript is safe, but the caller must NOT report a clean close.
+    expect(result).toEqual({ success: true, archived: true, channelDeleted: false });
+  });
+
   test("re-close append: posts header embed into the existing thread, no new thread", async () => {
     fakeRepoState.findOneByResult = { messageId: "existing-app-thread" };
     const client = makeFakeClient(forumChannel);

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -165,7 +165,7 @@ describe("archiveAndCloseApplication", () => {
   });
 
   test("channel delete refused → archived:true but channelDeleted:false (caller must tell the user)", async () => {
-    fakeVerifiedChannelDelete.mockResolvedValue({ success: false, alreadyGone: false, error: "Missing Permissions" });
+    fakeVerifiedChannelDelete.mockResolvedValueOnce({ success: false, alreadyGone: false, error: "Missing Permissions" });
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(

--- a/tests/unit/utils/interactions/selectMenuHelper.test.ts
+++ b/tests/unit/utils/interactions/selectMenuHelper.test.ts
@@ -11,8 +11,13 @@ import { awaitSelectMenuChoice } from '../../../../src/utils/interactions/select
 
 function makeResponse(behavior: { resolve?: unknown; reject?: boolean }) {
   return {
-    awaitMessageComponent: async () => {
+    // Honest double: applies the caller's filter like discord.js does — a
+    // candidate the filter rejects never resolves (simulated as timeout), so
+    // the userId/customId predicate is actually exercised (v3.15.2 fix: the
+    // old fake ignored its options entirely).
+    awaitMessageComponent: async (options?: { filter?: (i: unknown) => boolean }) => {
       if (behavior.reject) throw new Error('timeout');
+      if (options?.filter && !options.filter(behavior.resolve)) throw new Error('timeout (filtered)');
       return behavior.resolve;
     },
   };
@@ -36,7 +41,7 @@ const call = (interaction: unknown, response: unknown) => awaitSelectMenuChoice(
 
 describe('awaitSelectMenuChoice', () => {
   test('returns the select interaction when the user makes a choice', async () => {
-    const picked = { isStringSelectMenu: () => true, values: ['5'] };
+    const picked = { isStringSelectMenu: () => true, values: ['5'], user: { id: 'u1' }, customId: 'pick' };
     const { interaction, edits } = makeInteraction();
 
     const result = await call(interaction, makeResponse({ resolve: picked }));
@@ -56,10 +61,29 @@ describe('awaitSelectMenuChoice', () => {
     expect(edits[0].components).toEqual([]);
   });
 
+  test('a pick from the WRONG USER never resolves — treated as timeout', async () => {
+    const stranger = { isStringSelectMenu: () => true, values: ['5'], user: { id: 'intruder' }, customId: 'pick' };
+    const { interaction, edits } = makeInteraction();
+
+    const result = await call(interaction, makeResponse({ resolve: stranger }));
+
+    expect(result).toBeNull();
+    expect(edits).toHaveLength(1);
+  });
+
+  test('a pick with the WRONG customId never resolves — treated as timeout', async () => {
+    const other = { isStringSelectMenu: () => true, values: ['5'], user: { id: 'u1' }, customId: 'other-menu' };
+    const { interaction } = makeInteraction();
+
+    const result = await call(interaction, makeResponse({ resolve: other }));
+
+    expect(result).toBeNull();
+  });
+
   test('returns null for a non-select component', async () => {
     const { interaction } = makeInteraction();
 
-    const result = await call(interaction, makeResponse({ resolve: { isStringSelectMenu: () => false } }));
+    const result = await call(interaction, makeResponse({ resolve: { isStringSelectMenu: () => false, user: { id: 'u1' }, customId: 'pick' } }));
 
     expect(result).toBeNull();
   });

--- a/tests/unit/utils/setup/configStatusEmbed.test.ts
+++ b/tests/unit/utils/setup/configStatusEmbed.test.ts
@@ -1,0 +1,25 @@
+/**
+ * closeNeedsArchiveWarning — pins the v3.13.2 misconfiguration warning shared
+ * by the ticket and application setup views: creation configured without an
+ * archive forum is exactly the state that makes the Close button fail.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { closeNeedsArchiveWarning } from '../../../../src/utils/setup/configStatusEmbed';
+
+describe('closeNeedsArchiveWarning', () => {
+  test('warns when creation is configured but the archive is missing', () => {
+    expect(closeNeedsArchiveWarning('chan-1', undefined)).toBe(true);
+    expect(closeNeedsArchiveWarning('chan-1', null)).toBe(true);
+    expect(closeNeedsArchiveWarning('chan-1', '')).toBe(true);
+  });
+
+  test('quiet when both are configured', () => {
+    expect(closeNeedsArchiveWarning('chan-1', 'forum-1')).toBe(false);
+  });
+
+  test('quiet when creation itself is not configured (nothing to close)', () => {
+    expect(closeNeedsArchiveWarning(undefined, undefined)).toBe(false);
+    expect(closeNeedsArchiveWarning(null, 'forum-1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Patch 11 of 11 — the final cleanup-roadmap patch. The two headline items give the application close button and the ticket admin-only flow the injectable seams + regression suites their ticket-close twin has had since v3.13.x (both were carrying multi-version fix sets with zero coverage).

Also structural: bun's process-global `mock.module` was silently clobbering sibling exports of the mocked modules for every other suite. The dispatcher tests' factories now spread the real modules, and real-implementation suites import untouched `*Impl` aliases — the documented v3.1.35 gotcha is now handled by construction for these modules.

Smaller pins: the changelog gate's failure branch (extracted + tested — green CI had never exercised the script's entire purpose), the close-needs-archive setup warning (extracted to a shared predicate), the `channelDeleted:false` application path, an honest select-menu test double that exercises its filter, and a contract test that tracks the live feature catalog instead of a hardcoded count.

## Test plan

- [x] `bun test` — 1466 pass (was 1441)
- [x] Build, Biome, changelog gate, contract gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ