### PR TITLE
fix: v3.15.3 — bait channel dual-write bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.3] - 2026-07-06
+
+Bait channel configuration fixes — the `channelId → channelIds` migration
+left setup writing only the legacy column while detection reads the new one.
+
+### Fixed
+
+- **`/baitchannel setup` changes take effect again**: setup wrote only the
+  legacy `channelId` column, but detection prefers `channelIds` — once the
+  startup backfill had populated `channelIds`, changing the bait channel via
+  setup silently had no effect. Both columns are now written through a single
+  helper (`getBaitChannelIds`/`setBaitChannels`), which every reader and
+  writer of the pair now goes through. Re-running setup also repairs rows the
+  old bug left divergent. (The dashboard's PUT route in ninsys-api has the
+  same bug and is tracked separately; the bot now tolerates its legacy-only
+  writes via the uniform fallback.)
+- **Deleting one of several bait channels no longer disables the system**:
+  the channel-delete cleanup disabled detection whenever the legacy primary
+  channel was deleted, even with other bait channels still configured. It now
+  re-points the primary at a surviving channel and only disables when none
+  remain.
+- **Raid-mode lockdown exempts legacy-configured bait channels**: the
+  lockdown sweep read only `channelIds`, so a legacy-only config would lock
+  its own bait channel during a raid.
+- Setup-dashboard completion state for the bait system now recognizes
+  multi-channel configs instead of only the legacy column.
+
 ## [3.15.2] - 2026-07-06
 
 Test hardening — the audit's confirmed coverage holes, closing out the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,6 +467,7 @@ GuildAuditLogEntryCreate event (separate)
 
 Module map (`src/utils/baitChannel/`):
 - `baitChannelManager.ts` — orchestrator; per-guild config cache; grace timers
+- `channelList.ts` — `getBaitChannelIds`/`setBaitChannels`: single owner of the `channelIds`/legacy `channelId` column pair (v3.15.3) — never read or write either column directly
 - `banExecutor.ts` — REST executor + idempotency claim (use this, never `member.ban()` directly)
 - `auditReason.ts` — structured `cogworks:bait score=N ch=#X flags=[…]` reason
 - `retryQueue.ts` — 5s/30s/5min backoff + dead-letter; orphaned grace row sweep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,7 +467,7 @@ GuildAuditLogEntryCreate event (separate)
 
 Module map (`src/utils/baitChannel/`):
 - `baitChannelManager.ts` — orchestrator; per-guild config cache; grace timers
-- `channelList.ts` — `getBaitChannelIds`/`setBaitChannels`: single owner of the `channelIds`/legacy `channelId` column pair (v3.15.3) — never read or write either column directly
+- `channelList.ts` — `getBaitChannelIds`/`setBaitChannels`: single owner of the `channelIds`/legacy `channelId` column pair (v3.15.3) — all list reads/writes go through these; the raw legacy column is read directly only as the warning-banner home
 - `banExecutor.ts` — REST executor + idempotency claim (use this, never `member.ban()` directly)
 - `auditReason.ts` — structured `cogworks:bait score=N ch=#X flags=[…]` reason
 - `retryQueue.ts` — 5s/30s/5min backoff + dead-letter; orphaned grace row sweep

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.15.2",
+  "botVersion": "3.15.3",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.15.2",
+  "version": "3.15.3",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/commands/handlers/baitChannel/setup.ts
+++ b/src/commands/handlers/baitChannel/setup.ts
@@ -51,14 +51,20 @@ export async function setupHandler(client: Client, interaction: ChatInputCommand
       });
       setBaitChannels(config, [channel.id]);
     } else {
-      // Check if channel is changing - if so, delete old message
       const currentChannels = getBaitChannelIds(config);
       const oldPrimary = currentChannels[0];
-      isChannelChange = oldPrimary !== channel.id;
+      // The warning banner lives in the channel the LEGACY channelId column
+      // points at — every writer posts it there, including the pre-v3.15.3
+      // setup whose legacy-only writes created divergent rows. Key the
+      // banner's delete/keep decision off that column, not the effective-list
+      // primary: on a divergent row they differ, and using the list primary
+      // would orphan the old banner and post a duplicate.
+      const bannerHome = config.channelId || oldPrimary;
+      isChannelChange = bannerHome !== channel.id;
 
-      if (isChannelChange && oldPrimary && config.channelMessageId) {
+      if (isChannelChange && bannerHome && config.channelMessageId) {
         try {
-          const oldChannel = await interaction.guild!.channels.fetch(oldPrimary);
+          const oldChannel = await interaction.guild!.channels.fetch(bannerHome);
           if (oldChannel?.isTextBased()) {
             const oldMessage = await (oldChannel as TextChannel).messages.fetch(config.channelMessageId);
             await oldMessage.delete();

--- a/src/commands/handlers/baitChannel/setup.ts
+++ b/src/commands/handlers/baitChannel/setup.ts
@@ -12,11 +12,13 @@ import type { ExtendedClient } from '../../../types/ExtendedClient';
 import {
   enhancedLogger,
   formatLang,
+  getBaitChannelIds,
   handleInteractionError,
   LogCategory,
   lang,
   replyEphemeralError,
   safeDbOperation,
+  setBaitChannels,
 } from '../../../utils';
 import { Colors } from '../../../utils/colors';
 
@@ -43,18 +45,20 @@ export async function setupHandler(client: Client, interaction: ChatInputCommand
     if (!config) {
       config = configRepo.create({
         guildId: interaction.guildId!,
-        channelId: channel.id,
         gracePeriodSeconds: gracePeriod,
         actionType: action as BaitActionType,
         logChannelId: logChannel?.id ?? null,
       });
+      setBaitChannels(config, [channel.id]);
     } else {
       // Check if channel is changing - if so, delete old message
-      isChannelChange = config.channelId !== channel.id;
+      const currentChannels = getBaitChannelIds(config);
+      const oldPrimary = currentChannels[0];
+      isChannelChange = oldPrimary !== channel.id;
 
-      if (isChannelChange && config.channelId && config.channelMessageId) {
+      if (isChannelChange && oldPrimary && config.channelMessageId) {
         try {
-          const oldChannel = await interaction.guild!.channels.fetch(config.channelId);
+          const oldChannel = await interaction.guild!.channels.fetch(oldPrimary);
           if (oldChannel?.isTextBased()) {
             const oldMessage = await (oldChannel as TextChannel).messages.fetch(config.channelMessageId);
             await oldMessage.delete();
@@ -66,7 +70,9 @@ export async function setupHandler(client: Client, interaction: ChatInputCommand
         config.channelMessageId = null;
       }
 
-      config.channelId = channel.id;
+      // Replace the primary but preserve any extra channels added via
+      // `/baitchannel channels add` (dedupe, max 3 enforced by add handler)
+      setBaitChannels(config, [channel.id, ...currentChannels.filter(id => id !== oldPrimary)].slice(0, 3));
       config.gracePeriodSeconds = gracePeriod;
       config.actionType = action as BaitActionType;
       if (logChannel) config.logChannelId = logChannel.id;
@@ -178,12 +184,7 @@ export async function handleBaitChannelAddChannel(client: Client, interaction: C
       return;
     }
 
-    // Build current channel list from channelIds or legacy channelId
-    const currentChannels: string[] = config.channelIds?.length
-      ? [...config.channelIds]
-      : config.channelId
-        ? [config.channelId]
-        : [];
+    const currentChannels = getBaitChannelIds(config);
 
     // Validate max 3 channels
     if (currentChannels.length >= 3) {
@@ -199,9 +200,7 @@ export async function handleBaitChannelAddChannel(client: Client, interaction: C
 
     // Add channel
     currentChannels.push(channel.id);
-    config.channelIds = currentChannels;
-    // Keep legacy channelId in sync with first channel
-    config.channelId = currentChannels[0];
+    setBaitChannels(config, currentChannels);
 
     await safeDbOperation(() => configRepo.save(config), 'Save bait channel config');
 
@@ -245,12 +244,7 @@ export async function handleBaitChannelRemoveChannel(client: Client, interaction
       return;
     }
 
-    // Build current channel list
-    const currentChannels: string[] = config.channelIds?.length
-      ? [...config.channelIds]
-      : config.channelId
-        ? [config.channelId]
-        : [];
+    const currentChannels = getBaitChannelIds(config);
 
     // Must keep at least 1 channel
     if (currentChannels.length <= 1) {
@@ -266,9 +260,7 @@ export async function handleBaitChannelRemoveChannel(client: Client, interaction
 
     // Remove channel
     const updatedChannels = currentChannels.filter(id => id !== channel.id);
-    config.channelIds = updatedChannels;
-    // Keep legacy channelId in sync with first channel
-    config.channelId = updatedChannels[0];
+    setBaitChannels(config, updatedChannels);
 
     await safeDbOperation(() => configRepo.save(config), 'Save bait channel config');
 

--- a/src/commands/handlers/baitChannel/status.ts
+++ b/src/commands/handlers/baitChannel/status.ts
@@ -1,7 +1,7 @@
 import { type ChatInputCommandInteraction, type Client, EmbedBuilder, MessageFlags } from 'discord.js';
 import { AppDataSource } from '../../../typeorm';
 import { BaitChannelConfig } from '../../../typeorm/entities/bait/BaitChannelConfig';
-import { handleInteractionError, lang, replyEphemeralError, safeDbOperation } from '../../../utils';
+import { getBaitChannelIds, handleInteractionError, lang, replyEphemeralError, safeDbOperation } from '../../../utils';
 
 const tl = lang.baitChannel;
 
@@ -18,8 +18,7 @@ export async function statusHandler(_client: Client, interaction: ChatInputComma
       return;
     }
 
-    // Build channel list from channelIds or legacy channelId
-    const baitChannelIds = config.channelIds?.length ? config.channelIds : config.channelId ? [config.channelId] : [];
+    const baitChannelIds = getBaitChannelIds(config);
     const channelMentions = baitChannelIds.map(id => `<#${id}>`).join(', ') || tl.status.channelNotFound;
 
     const logChannel = config.logChannelId

--- a/src/commands/handlers/botSetup/systemFlows.ts
+++ b/src/commands/handlers/botSetup/systemFlows.ts
@@ -59,6 +59,7 @@ import {
   extractModalField,
   LogCategory,
   lang,
+  setBaitChannels,
   showAndAwaitModal,
   TIMEOUTS,
 } from '../../../utils';
@@ -768,15 +769,14 @@ const baitConfig: SimpleSystemConfig<BaitData, 'baitchannel'> = {
   apply: async (guildId, data, { guild, client }) => {
     const repo = AppDataSource.getRepository(BaitChannelConfig);
     let config = await repo.findOneBy({ guildId });
-    if (!config) config = repo.create({ guildId, channelId: data.channelId });
+    if (!config) config = repo.create({ guildId });
     // Re-running setup via the always-visible /bot-setup dashboard must yield a
     // functional (enabled) config. An existing row may carry enabled=false from
     // /baitchannel toggle or a deleted bait channel (channelDelete auto-disables);
     // without this, command-gating would keep /baitchannel hidden with no
     // in-Discord way back. This makes the dashboard the guaranteed re-enable path.
     config.enabled = true;
-    config.channelId = data.channelId;
-    config.channelIds = [data.channelId];
+    setBaitChannels(config, [data.channelId]);
     config.actionType = data.actionType;
     // Only set testMode when the auto-create path explicitly opts in. Manual
     // path leaves the column at whatever it was (default false on create).

--- a/src/events/channelDelete.ts
+++ b/src/events/channelDelete.ts
@@ -126,11 +126,19 @@ const CHANNEL_REF_CLEANERS: ChannelRefCleaner[] = [
       if (!config) return;
 
       let changed = false;
+      // Union of the effective list and the legacy channelId column: on rows
+      // the pre-v3.15.3 dual-write bug left divergent, the legacy column is
+      // the admin's most recent explicit choice — deleting the stale
+      // channelIds entry must fall back to it, not disable the system.
       const currentChannels = getBaitChannelIds(config);
-      if (currentChannels.includes(channelId) || config.channelId === channelId) {
-        // The warning message lives in the legacy-primary channel — gone with it
+      const allChannels =
+        config.channelId && !currentChannels.includes(config.channelId)
+          ? [...currentChannels, config.channelId]
+          : currentChannels;
+      if (allChannels.includes(channelId)) {
+        // The warning banner lives in the legacy-column channel — gone with it
         if (config.channelId === channelId) config.channelMessageId = null;
-        const remaining = currentChannels.filter(id => id !== channelId);
+        const remaining = allChannels.filter(id => id !== channelId);
         setBaitChannels(config, remaining);
         // Only disable when NO bait channels remain — deleting one of several
         // must not silently kill detection on the survivors

--- a/src/events/channelDelete.ts
+++ b/src/events/channelDelete.ts
@@ -15,6 +15,7 @@ import { TicketConfig } from '../typeorm/entities/ticket/TicketConfig';
 import { XPConfig } from '../typeorm/entities/xp/XPConfig';
 import type { ExtendedClient } from '../types/ExtendedClient';
 import { enhancedLogger, LogCategory } from '../utils';
+import { getBaitChannelIds, setBaitChannels } from '../utils/baitChannel/channelList';
 import { invalidateGuildMenuCache } from '../utils/reactionRole/menuCache';
 import { invalidateRulesCache } from '../utils/rules/rulesCache';
 import { requestGuildCommandRefresh } from '../utils/setup/commandGating';
@@ -125,14 +126,15 @@ const CHANNEL_REF_CLEANERS: ChannelRefCleaner[] = [
       if (!config) return;
 
       let changed = false;
-      if (config.channelId === channelId) {
-        config.enabled = false;
-        config.channelId = '';
-        config.channelMessageId = null;
-        changed = true;
-      }
-      if (config.channelIds?.includes(channelId)) {
-        config.channelIds = config.channelIds.filter(id => id !== channelId);
+      const currentChannels = getBaitChannelIds(config);
+      if (currentChannels.includes(channelId) || config.channelId === channelId) {
+        // The warning message lives in the legacy-primary channel — gone with it
+        if (config.channelId === channelId) config.channelMessageId = null;
+        const remaining = currentChannels.filter(id => id !== channelId);
+        setBaitChannels(config, remaining);
+        // Only disable when NO bait channels remain — deleting one of several
+        // must not silently kill detection on the survivors
+        if (remaining.length === 0) config.enabled = false;
         changed = true;
       }
       if (config.logChannelId === channelId) {

--- a/src/utils/baitChannel/baitChannelManager.ts
+++ b/src/utils/baitChannel/baitChannelManager.ts
@@ -30,6 +30,7 @@ import { truncateWithNotice } from '../validation/inputSanitizer';
 import { buildAppealUrl } from './appealToken';
 import { buildAuditReason, flagsTriggered } from './auditReason';
 import { type BanExecutorAction, type BanExecutorResult, executeBanAction } from './banExecutor';
+import { getBaitChannelIds } from './channelList';
 import { getContentBurstDetector } from './contentBurstDetector';
 import type { JoinVelocityTracker } from './joinVelocityTracker';
 import { getRaidModeManager } from './raidModeManager';
@@ -272,7 +273,7 @@ export class BaitChannelManager {
       }
 
       // Multi-channel support: check channelIds array with legacy channelId fallback
-      const baitChannels = config.channelIds?.length ? config.channelIds : config.channelId ? [config.channelId] : [];
+      const baitChannels = getBaitChannelIds(config);
       if (!baitChannels.includes(message.channelId)) {
         enhancedLogger.debug(
           `Message in ${message.channelId}, bait channels are [${baitChannels.join(', ')}]`,

--- a/src/utils/baitChannel/channelList.ts
+++ b/src/utils/baitChannel/channelList.ts
@@ -4,10 +4,13 @@
  *
  * The v3.1.35 multi-channel migration left both columns live: detection
  * prefers `channelIds` while older rows may only carry `channelId`. Every
- * reader must use `getBaitChannelIds` (uniform fallback) and every writer
- * must use `setBaitChannels` (dual-write) so the two columns can never
- * diverge again. Stage B (column retirement) is deferred until ninsys-api
- * gains `channelIds`.
+ * list reader must use `getBaitChannelIds` (uniform fallback) and every
+ * writer must use `setBaitChannels` (dual-write) so the two columns can
+ * never diverge again. Deliberate exception: the warning banner's home is
+ * the raw legacy `channelId` column (every writer posts the banner to the
+ * channel it assigns there), so banner-lifecycle code reads that column
+ * directly. Stage B (column retirement) is deferred until ninsys-api gains
+ * `channelIds`.
  */
 
 import type { BaitChannelConfig } from '../../typeorm/entities/bait/BaitChannelConfig';
@@ -27,9 +30,10 @@ export function getBaitChannelIds(config: BaitChannelColumns): string[] {
 /**
  * Write the bait channel list to BOTH columns (the caller still saves).
  * Dedupes while preserving order; `ids[0]` becomes the legacy primary.
- * An empty list normalizes to `channelIds = null` (not `[]`) — simple-array
- * hydrates '' back as `['']` otherwise — and `channelId = ''` to match the
- * non-nullable column's "unset" convention used across the codebase.
+ * An empty list normalizes to `channelIds = null` (not `[]`) — null is the
+ * canonical "unset" this codebase uses everywhere for the column (backfill,
+ * entity default), so readers never need to distinguish null from `[]` —
+ * and `channelId = ''` to match the non-nullable column's unset convention.
  */
 export function setBaitChannels(config: BaitChannelColumns, ids: string[]): void {
   const deduped = [...new Set(ids)].filter(Boolean);

--- a/src/utils/baitChannel/channelList.ts
+++ b/src/utils/baitChannel/channelList.ts
@@ -1,0 +1,38 @@
+/**
+ * Bait channel list helpers — single source of truth for the
+ * `channelIds` (multi-channel) / `channelId` (legacy) column pair.
+ *
+ * The v3.1.35 multi-channel migration left both columns live: detection
+ * prefers `channelIds` while older rows may only carry `channelId`. Every
+ * reader must use `getBaitChannelIds` (uniform fallback) and every writer
+ * must use `setBaitChannels` (dual-write) so the two columns can never
+ * diverge again. Stage B (column retirement) is deferred until ninsys-api
+ * gains `channelIds`.
+ */
+
+import type { BaitChannelConfig } from '../../typeorm/entities/bait/BaitChannelConfig';
+
+type BaitChannelColumns = Pick<BaitChannelConfig, 'channelId' | 'channelIds'>;
+
+/**
+ * Effective bait channel list: `channelIds` when non-empty, else the legacy
+ * `channelId` as a one-element list, else empty. Returns a fresh array —
+ * callers may mutate it freely.
+ */
+export function getBaitChannelIds(config: BaitChannelColumns): string[] {
+  if (config.channelIds?.length) return [...config.channelIds];
+  return config.channelId ? [config.channelId] : [];
+}
+
+/**
+ * Write the bait channel list to BOTH columns (the caller still saves).
+ * Dedupes while preserving order; `ids[0]` becomes the legacy primary.
+ * An empty list normalizes to `channelIds = null` (not `[]`) — simple-array
+ * hydrates '' back as `['']` otherwise — and `channelId = ''` to match the
+ * non-nullable column's "unset" convention used across the codebase.
+ */
+export function setBaitChannels(config: BaitChannelColumns, ids: string[]): void {
+  const deduped = [...new Set(ids)].filter(Boolean);
+  config.channelIds = deduped.length > 0 ? deduped : null;
+  config.channelId = deduped[0] ?? '';
+}

--- a/src/utils/baitChannel/raidModeManager.ts
+++ b/src/utils/baitChannel/raidModeManager.ts
@@ -34,6 +34,7 @@ import { Colors } from '../colors';
 import { ErrorCategory, ErrorSeverity, logError } from '../errorHandler';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import { toUnixSeconds } from '../time';
+import { getBaitChannelIds } from './channelList';
 
 /** Maximum duration of an auto-entered raid lockdown — admin must release earlier or wait. */
 const RAID_MODE_MAX_DURATION_MS = 4 * 60 * 60 * 1000; // 4 hours
@@ -285,7 +286,7 @@ export class RaidModeManager {
   private async applyChannelLockdown(guild: Guild, config: BaitChannelConfig, lockdown: boolean): Promise<void> {
     const everyone = guild.roles.everyone;
     const exemptChannelIds = new Set<string>(
-      [config.logChannelId, config.summaryChannelId, ...(config.channelIds ?? [])].filter(
+      [config.logChannelId, config.summaryChannelId, ...getBaitChannelIds(config)].filter(
         (v): v is string => typeof v === 'string',
       ),
     );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,6 +16,7 @@ export {
 // Core utilities
 export * from './apiConnector';
 export * from './baitChannel/baitChannelManager';
+export * from './baitChannel/channelList';
 export * from './collectors';
 export * from './colors';
 // Constants

--- a/src/utils/setup/systemStates.ts
+++ b/src/utils/setup/systemStates.ts
@@ -20,6 +20,7 @@ import { RulesConfig } from '../../typeorm/entities/rules';
 import { DEFAULT_SYSTEM_STATES, type SystemStates } from '../../typeorm/entities/SetupState';
 import { ArchivedTicketConfig } from '../../typeorm/entities/ticket/ArchivedTicketConfig';
 import { TicketConfig } from '../../typeorm/entities/ticket/TicketConfig';
+import { getBaitChannelIds } from '../baitChannel/channelList';
 
 /**
  * Inspect the DB and return per-system status (`not_started` / `partial` /
@@ -60,7 +61,7 @@ export async function detectSystemStates(guildId: string): Promise<SystemStates>
     if (appConfig && archivedApp) states.application = 'complete';
     else if (appConfig) states.application = 'partial';
     if (annConfig?.defaultRoleId && annConfig.defaultChannelId) states.announcement = 'complete';
-    if (baitConfig?.channelId) states.baitchannel = 'complete';
+    if (baitConfig && getBaitChannelIds(baitConfig).length > 0) states.baitchannel = 'complete';
     if (memoryConfig) states.memory = 'complete';
     if (rulesConfig?.channelId && rulesConfig.roleId) states.rules = 'complete';
     if (reactionMenuCount > 0) states.reactionRole = 'complete';

--- a/tests/unit/events/channelDelete.test.ts
+++ b/tests/unit/events/channelDelete.test.ts
@@ -408,6 +408,55 @@ describe('channelDelete event handler', () => {
     expect(saved.channelMessageId).toBe('warn-msg');
   });
 
+  test('BaitChannelConfig divergent row: deleting the stale channelIds entry falls back to the legacy channel', async () => {
+    // Pre-v3.15.3 dual-write bug signature: legacy channelId=B (admin's last
+    // explicit choice, banner lives there), channelIds=[A] stale. Deleting A
+    // must fall back to B — not wipe it and disable the system.
+    const channel = makeFakeChannel('stale-A', 'guild-1');
+    fakeRepos.BaitChannelConfig.rows.set('1', {
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'chan-B',
+      channelMessageId: 'banner-msg',
+      channelIds: ['stale-A'],
+      logChannelId: null,
+      summaryChannelId: null,
+      enabled: true,
+    });
+
+    await channelDeleteHandler.execute(channel, mockClient);
+
+    expect(fakeRepos.BaitChannelConfig.saveCalls.length).toBe(1);
+    const saved = fakeRepos.BaitChannelConfig.saveCalls[0];
+    expect(saved.enabled).toBe(true);
+    expect(saved.channelId).toBe('chan-B');
+    expect(saved.channelIds).toEqual(['chan-B']); // divergence repaired
+    expect(saved.channelMessageId).toBe('banner-msg'); // banner in B untouched
+  });
+
+  test('BaitChannelConfig divergent row: deleting the legacy channel keeps detection on the channelIds entry', async () => {
+    const channel = makeFakeChannel('chan-B', 'guild-1');
+    fakeRepos.BaitChannelConfig.rows.set('1', {
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'chan-B',
+      channelMessageId: 'banner-msg',
+      channelIds: ['live-A'],
+      logChannelId: null,
+      summaryChannelId: null,
+      enabled: true,
+    });
+
+    await channelDeleteHandler.execute(channel, mockClient);
+
+    expect(fakeRepos.BaitChannelConfig.saveCalls.length).toBe(1);
+    const saved = fakeRepos.BaitChannelConfig.saveCalls[0];
+    expect(saved.enabled).toBe(true);
+    expect(saved.channelId).toBe('live-A');
+    expect(saved.channelIds).toEqual(['live-A']);
+    expect(saved.channelMessageId).toBe(null); // banner died with chan-B
+  });
+
   test('BaitChannelConfig: deleting the LAST bait channel disables the system', async () => {
     const channel = makeFakeChannel('bait-only', 'guild-1');
     fakeRepos.BaitChannelConfig.rows.set('1', {

--- a/tests/unit/events/channelDelete.test.ts
+++ b/tests/unit/events/channelDelete.test.ts
@@ -362,6 +362,75 @@ describe('channelDelete event handler', () => {
     expect(mockClient.baitChannelManager.clearConfigCache).toHaveBeenCalledWith('guild-1');
   });
 
+  test('BaitChannelConfig: deleting the PRIMARY of several bait channels keeps detection enabled', async () => {
+    const channel = makeFakeChannel('bait-1', 'guild-1');
+    fakeRepos.BaitChannelConfig.rows.set('1', {
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'bait-1',
+      channelMessageId: 'warn-msg',
+      channelIds: ['bait-1', 'bait-2'],
+      logChannelId: null,
+      summaryChannelId: null,
+      enabled: true,
+    });
+
+    await channelDeleteHandler.execute(channel, mockClient);
+
+    expect(fakeRepos.BaitChannelConfig.saveCalls.length).toBe(1);
+    const saved = fakeRepos.BaitChannelConfig.saveCalls[0];
+    expect(saved.enabled).toBe(true); // survivors keep working
+    expect(saved.channelIds).toEqual(['bait-2']);
+    expect(saved.channelId).toBe('bait-2'); // legacy column re-pointed at new primary
+    expect(saved.channelMessageId).toBe(null); // warning message died with the channel
+  });
+
+  test('BaitChannelConfig: deleting a NON-primary bait channel keeps primary and warning message', async () => {
+    const channel = makeFakeChannel('bait-2', 'guild-1');
+    fakeRepos.BaitChannelConfig.rows.set('1', {
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'bait-1',
+      channelMessageId: 'warn-msg',
+      channelIds: ['bait-1', 'bait-2'],
+      logChannelId: null,
+      summaryChannelId: null,
+      enabled: true,
+    });
+
+    await channelDeleteHandler.execute(channel, mockClient);
+
+    expect(fakeRepos.BaitChannelConfig.saveCalls.length).toBe(1);
+    const saved = fakeRepos.BaitChannelConfig.saveCalls[0];
+    expect(saved.enabled).toBe(true);
+    expect(saved.channelIds).toEqual(['bait-1']);
+    expect(saved.channelId).toBe('bait-1');
+    expect(saved.channelMessageId).toBe('warn-msg');
+  });
+
+  test('BaitChannelConfig: deleting the LAST bait channel disables the system', async () => {
+    const channel = makeFakeChannel('bait-only', 'guild-1');
+    fakeRepos.BaitChannelConfig.rows.set('1', {
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'bait-only',
+      channelMessageId: 'warn-msg',
+      channelIds: ['bait-only'],
+      logChannelId: null,
+      summaryChannelId: null,
+      enabled: true,
+    });
+
+    await channelDeleteHandler.execute(channel, mockClient);
+
+    expect(fakeRepos.BaitChannelConfig.saveCalls.length).toBe(1);
+    const saved = fakeRepos.BaitChannelConfig.saveCalls[0];
+    expect(saved.enabled).toBe(false);
+    expect(saved.channelIds).toBe(null); // normalized, not []
+    expect(saved.channelId).toBe('');
+    expect(saved.channelMessageId).toBe(null);
+  });
+
   test('XPConfig: removes channel from ignoredChannels array', async () => {
     const channel = makeFakeChannel('chan-skip', 'guild-1');
     fakeRepos.XPConfig.rows.set('1', {

--- a/tests/unit/handlers/baitChannel/setup.test.ts
+++ b/tests/unit/handlers/baitChannel/setup.test.ts
@@ -1,0 +1,210 @@
+/**
+ * /baitchannel setup Handler Unit Tests (v3.15.3 regression)
+ *
+ * THE live bug: setup wrote only the legacy `channelId` column while
+ * detection reads `channelIds` — once the startup backfill had populated
+ * `channelIds`, changing the bait channel via setup had no effect on
+ * detection. These tests pin the dual-write on both the create and update
+ * paths, including the divergent-row repair case.
+ *
+ * Strategy: patch AppDataSource.getRepository (same seam as
+ * channelDelete.test.ts) and drive the handler with a fake interaction.
+ * The warning-message block is skipped because the fake channel is not an
+ * `instanceof TextChannel`; keyword seeding is short-circuited by a
+ * BaitKeyword fake whose count() > 0.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from 'bun:test';
+
+interface FakeConfigRepo {
+  row: any;
+  findOneCalls: any[];
+  createCalls: any[];
+  saveCalls: any[];
+  findOne: (opts: any) => Promise<any>;
+  create: (obj: any) => any;
+  save: (entity: any) => Promise<any>;
+}
+
+function makeFakeConfigRepo(row: any = null): FakeConfigRepo {
+  const repo: FakeConfigRepo = {
+    row,
+    findOneCalls: [],
+    createCalls: [],
+    saveCalls: [],
+    async findOne(opts: any) {
+      repo.findOneCalls.push(opts);
+      return repo.row;
+    },
+    create(obj: any) {
+      repo.createCalls.push({ ...obj });
+      return obj;
+    },
+    async save(entity: any) {
+      repo.saveCalls.push({ ...entity });
+      repo.row = entity;
+      return entity;
+    },
+  };
+  return repo;
+}
+
+// Benign catch-all for entities the handler touches indirectly (BaitKeyword
+// seeding): count() > 0 makes seedDefaultKeywords return without inserting.
+const benignRepo = {
+  count: async () => 1,
+  find: async () => [],
+  findOne: async () => null,
+  findOneBy: async () => null,
+  save: async (e: any) => e,
+  create: (e: any) => e,
+} as any;
+
+let configRepo: FakeConfigRepo;
+let setupHandler: typeof import('../../../../src/commands/handlers/baitChannel/setup').setupHandler;
+let originalGetRepository: ((entity: any) => unknown) | undefined;
+
+beforeAll(async () => {
+  const { AppDataSource } = await import('../../../../src/typeorm');
+  originalGetRepository = (AppDataSource as unknown as { getRepository: (e: any) => unknown }).getRepository;
+  (AppDataSource as unknown as { getRepository: (e: any) => unknown }).getRepository = (entity: any) =>
+    entity?.name === 'BaitChannelConfig' ? configRepo : benignRepo;
+  setupHandler = (await import('../../../../src/commands/handlers/baitChannel/setup')).setupHandler;
+});
+
+afterAll(async () => {
+  if (originalGetRepository) {
+    const { AppDataSource } = await import('../../../../src/typeorm');
+    (AppDataSource as unknown as { getRepository: (e: any) => unknown }).getRepository = originalGetRepository;
+  }
+});
+
+const clearConfigCache = jest.fn();
+const mockClient = { baitChannelManager: { clearConfigCache } } as any;
+
+function makeInteraction(channelId: string) {
+  return {
+    guildId: 'guild-1',
+    guild: {
+      channels: {
+        // Update path may fetch the old primary to delete the warning message;
+        // "channel gone" is an accepted outcome there.
+        fetch: jest.fn(async () => {
+          throw new Error('channel gone');
+        }),
+      },
+    },
+    options: {
+      getChannel: (name: string) => (name === 'channel' ? { id: channelId, isTextBased: () => true } : null),
+      getInteger: () => 20,
+      getString: () => 'ban',
+    },
+    reply: jest.fn(async () => {}),
+    replied: false,
+    deferred: false,
+  } as any;
+}
+
+describe('/baitchannel setup dual-write (v3.15.3)', () => {
+  beforeEach(() => {
+    clearConfigCache.mockClear();
+  });
+
+  test('create path: writes BOTH channelIds and legacy channelId', async () => {
+    configRepo = makeFakeConfigRepo(null);
+    const interaction = makeInteraction('new-chan');
+
+    await setupHandler(mockClient, interaction);
+
+    expect(configRepo.saveCalls.length).toBe(1);
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelIds).toEqual(['new-chan']);
+    expect(saved.channelId).toBe('new-chan');
+    expect(interaction.reply).toHaveBeenCalledTimes(1);
+    expect(clearConfigCache).toHaveBeenCalledWith('guild-1');
+  });
+
+  test('update path: changing the channel updates channelIds (THE live bug)', async () => {
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'old-chan',
+      channelIds: ['old-chan'],
+      channelMessageId: null,
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('new-chan');
+
+    await setupHandler(mockClient, interaction);
+
+    expect(configRepo.saveCalls.length).toBe(1);
+    const saved = configRepo.saveCalls[0];
+    // Pre-fix behavior: channelId='new-chan' but channelIds stayed ['old-chan']
+    // → detection kept watching the old channel forever.
+    expect(saved.channelIds).toEqual(['new-chan']);
+    expect(saved.channelId).toBe('new-chan');
+  });
+
+  test('update path: preserves extra channels added via /baitchannel channels add', async () => {
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'old-primary',
+      channelIds: ['old-primary', 'extra-1', 'extra-2'],
+      channelMessageId: null,
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('new-primary');
+
+    await setupHandler(mockClient, interaction);
+
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelIds).toEqual(['new-primary', 'extra-1', 'extra-2']);
+    expect(saved.channelId).toBe('new-primary');
+  });
+
+  test('update path: repairs a divergent row left behind by the pre-fix bug', async () => {
+    // The bug's signature state: legacy column updated, channelIds stale.
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'written-by-bug',
+      channelIds: ['stale-detected'],
+      channelMessageId: null,
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('final-chan');
+
+    await setupHandler(mockClient, interaction);
+
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelIds).toEqual(['final-chan']);
+    expect(saved.channelId).toBe('final-chan');
+  });
+
+  test('legacy-only row (channelIds null): update populates channelIds', async () => {
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'old-chan',
+      channelIds: null,
+      channelMessageId: null,
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('new-chan');
+
+    await setupHandler(mockClient, interaction);
+
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelIds).toEqual(['new-chan']);
+    expect(saved.channelId).toBe('new-chan');
+  });
+});

--- a/tests/unit/handlers/baitChannel/setup.test.ts
+++ b/tests/unit/handlers/baitChannel/setup.test.ts
@@ -87,8 +87,8 @@ function makeInteraction(channelId: string) {
     guildId: 'guild-1',
     guild: {
       channels: {
-        // Update path may fetch the old primary to delete the warning message;
-        // "channel gone" is an accepted outcome there.
+        // Update path fetches the old banner's channel to delete the warning
+        // message; "channel gone" is an accepted outcome there.
         fetch: jest.fn(async () => {
           throw new Error('channel gone');
         }),
@@ -206,5 +206,102 @@ describe('/baitchannel setup dual-write (v3.15.3)', () => {
     const saved = configRepo.saveCalls[0];
     expect(saved.channelIds).toEqual(['new-chan']);
     expect(saved.channelId).toBe('new-chan');
+  });
+});
+
+describe('/baitchannel setup warning-banner lifecycle (v3.15.3)', () => {
+  beforeEach(() => {
+    clearConfigCache.mockClear();
+  });
+
+  test('channel change: old banner fetched from the LEGACY column channel, then id cleared', async () => {
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'banner-home',
+      channelIds: ['banner-home'],
+      channelMessageId: 'banner-msg',
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('new-chan');
+
+    await setupHandler(mockClient, interaction);
+
+    // Deletion attempted where the banner actually lives
+    expect(interaction.guild.channels.fetch).toHaveBeenCalledWith('banner-home');
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelMessageId).toBe(null);
+    expect(saved.channelIds).toEqual(['new-chan']);
+  });
+
+  test('divergent row + setup with the legacy channel: banner kept, NOT re-fetched from stale channelIds', async () => {
+    // The likely first admin action after the fix ships: re-running setup
+    // with the channel they already chose (legacy=B, stale channelIds=[A]).
+    // Keying off channelIds[0] would try to delete the banner in A (missing),
+    // null the id, and post a duplicate banner in B.
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'chan-B',
+      channelIds: ['stale-A'],
+      channelMessageId: 'banner-msg',
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('chan-B');
+
+    await setupHandler(mockClient, interaction);
+
+    expect(interaction.guild.channels.fetch).not.toHaveBeenCalled();
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelMessageId).toBe('banner-msg'); // banner untouched
+    expect(saved.channelIds).toEqual(['chan-B']); // list repaired
+    expect(saved.channelId).toBe('chan-B');
+  });
+
+  test('divergent row + setup with a third channel: banner deleted from the legacy channel', async () => {
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'chan-B',
+      channelIds: ['stale-A'],
+      channelMessageId: 'banner-msg',
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('chan-C');
+
+    await setupHandler(mockClient, interaction);
+
+    expect(interaction.guild.channels.fetch).toHaveBeenCalledWith('chan-B'); // not stale-A
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelMessageId).toBe(null);
+    expect(saved.channelIds).toEqual(['chan-C']);
+  });
+
+  test('same-channel re-run on a normal row is idempotent: no banner churn', async () => {
+    configRepo = makeFakeConfigRepo({
+      id: 1,
+      guildId: 'guild-1',
+      channelId: 'chan-X',
+      channelIds: ['chan-X', 'extra-1'],
+      channelMessageId: 'banner-msg',
+      gracePeriodSeconds: 15,
+      actionType: 'ban',
+      logChannelId: null,
+    });
+    const interaction = makeInteraction('chan-X');
+
+    await setupHandler(mockClient, interaction);
+
+    expect(interaction.guild.channels.fetch).not.toHaveBeenCalled();
+    const saved = configRepo.saveCalls[0];
+    expect(saved.channelMessageId).toBe('banner-msg');
+    expect(saved.channelIds).toEqual(['chan-X', 'extra-1']);
+    expect(saved.channelId).toBe('chan-X');
   });
 });

--- a/tests/unit/utils/baitChannel/baitChannelManager.test.ts
+++ b/tests/unit/utils/baitChannel/baitChannelManager.test.ts
@@ -466,3 +466,100 @@ describe("logAction (null-safety)", () => {
     expect(saved.actionTaken).toBe("whitelisted");
   });
 });
+
+// ---------------------------------------------------------------------------
+// handleMessage channel matching (v3.15.3 — getBaitChannelIds fallback)
+//
+// Detection prefers `channelIds` and falls back to legacy `channelId`. The
+// dual-write bug meant setup could leave the two columns divergent; these
+// tests pin the read-side precedence either way.
+// ---------------------------------------------------------------------------
+
+function makeDetectionMember(id = "owner-1") {
+  return {
+    id,
+    guild: { ownerId: id }, // server owner → whitelisted, cheap terminal path
+    user: {
+      tag: `${id}#0001`,
+      createdTimestamp: Date.now() - 24 * 60 * 60 * 1000,
+    },
+    joinedTimestamp: Date.now() - 60_000,
+    roles: {
+      cache: {
+        find: (_p: (r: any) => boolean) => undefined,
+        some: (_p: (r: any) => boolean) => false,
+        size: 1,
+      },
+    },
+    permissions: { has: () => false },
+  } as any;
+}
+
+function makeDetectionMessage(channelId: string, member: any) {
+  return {
+    id: "msg-1",
+    content: "bait post",
+    channelId,
+    guild: { id: "guild-1" },
+    guildId: "guild-1",
+    author: { id: member.id, bot: false },
+    system: false,
+    member,
+    delete: jest.fn(async () => {}),
+  } as any;
+}
+
+function makeDetectionConfig(overrides: Partial<any> = {}) {
+  return {
+    guildId: "guild-1",
+    enabled: true,
+    channelId: "",
+    channelIds: null,
+    logChannelId: null, // whitelisted log-to-channel becomes a no-op
+    whitelistedRoles: null,
+    whitelistedUsers: null,
+    disableAdminWhitelist: false,
+    ...overrides,
+  };
+}
+
+describe("handleMessage channel matching", () => {
+  test("legacy-only config (channelIds null) still routes messages into detection", async () => {
+    const { manager } = makeManager({
+      configState: {
+        findOneResult: makeDetectionConfig({ channelId: "bait-legacy" }),
+        findResults: [],
+      },
+    });
+    const member = makeDetectionMember();
+    const message = makeDetectionMessage("bait-legacy", member);
+
+    await manager.handleMessage(message);
+
+    // Owner is whitelisted → message deleted + whitelisted action logged
+    expect(message.delete).toHaveBeenCalledTimes(1);
+    const logRepo = (manager as any).logRepo;
+    expect(logRepo.create.mock.calls[0][0].actionTaken).toBe("whitelisted");
+  });
+
+  test("channelIds takes precedence over a stale legacy channelId (divergent row)", async () => {
+    const config = makeDetectionConfig({
+      channelId: "stale-old",
+      channelIds: ["bait-new"],
+    });
+    const { manager } = makeManager({
+      configState: { findOneResult: config, findResults: [] },
+    });
+    const member = makeDetectionMember();
+
+    // Message in the stale legacy channel: NOT a bait channel anymore
+    const staleMessage = makeDetectionMessage("stale-old", member);
+    await manager.handleMessage(staleMessage);
+    expect(staleMessage.delete).not.toHaveBeenCalled();
+
+    // Message in the channelIds channel: detected
+    const liveMessage = makeDetectionMessage("bait-new", member);
+    await manager.handleMessage(liveMessage);
+    expect(liveMessage.delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/utils/baitChannel/channelList.test.ts
+++ b/tests/unit/utils/baitChannel/channelList.test.ts
@@ -1,0 +1,76 @@
+/**
+ * channelList Unit Tests
+ *
+ * `getBaitChannelIds` / `setBaitChannels` are the single owner of the
+ * `channelIds` (multi-channel) / `channelId` (legacy) column pair. The
+ * v3.15.3 live bug was `/baitchannel setup` writing ONLY the legacy column
+ * while detection preferred `channelIds` — these helpers exist so readers
+ * and writers can never diverge again.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { getBaitChannelIds, setBaitChannels } from '../../../../src/utils/baitChannel/channelList';
+
+describe('getBaitChannelIds', () => {
+  test('prefers channelIds when non-empty (stale legacy column is ignored)', () => {
+    const config = { channelId: 'stale-legacy', channelIds: ['a', 'b'] };
+    expect(getBaitChannelIds(config)).toEqual(['a', 'b']);
+  });
+
+  test('falls back to legacy channelId when channelIds is null', () => {
+    const config = { channelId: 'legacy-1', channelIds: null };
+    expect(getBaitChannelIds(config)).toEqual(['legacy-1']);
+  });
+
+  test('falls back to legacy channelId when channelIds is empty', () => {
+    const config = { channelId: 'legacy-1', channelIds: [] };
+    expect(getBaitChannelIds(config)).toEqual(['legacy-1']);
+  });
+
+  test('returns empty list when both columns are unset', () => {
+    expect(getBaitChannelIds({ channelId: '', channelIds: null })).toEqual([]);
+  });
+
+  test('returns a fresh array — mutating the result must not touch the config', () => {
+    const config = { channelId: 'a', channelIds: ['a', 'b'] };
+    const ids = getBaitChannelIds(config);
+    ids.push('c');
+    expect(config.channelIds).toEqual(['a', 'b']);
+  });
+});
+
+describe('setBaitChannels', () => {
+  test('dual-writes: channelIds gets the list, legacy channelId gets the primary', () => {
+    const config = { channelId: '', channelIds: null as string[] | null };
+    setBaitChannels(config, ['a', 'b']);
+    expect(config.channelIds).toEqual(['a', 'b']);
+    expect(config.channelId).toBe('a');
+  });
+
+  test('dedupes while preserving order', () => {
+    const config = { channelId: '', channelIds: null as string[] | null };
+    setBaitChannels(config, ['a', 'b', 'a']);
+    expect(config.channelIds).toEqual(['a', 'b']);
+    expect(config.channelId).toBe('a');
+  });
+
+  test('empty list normalizes to channelIds=null and channelId=""', () => {
+    const config = { channelId: 'old', channelIds: ['old'] as string[] | null };
+    setBaitChannels(config, []);
+    expect(config.channelIds).toBeNull();
+    expect(config.channelId).toBe('');
+  });
+
+  test('drops empty-string ids (simple-array hydration quirk)', () => {
+    const config = { channelId: 'old', channelIds: ['old'] as string[] | null };
+    setBaitChannels(config, ['']);
+    expect(config.channelIds).toBeNull();
+    expect(config.channelId).toBe('');
+  });
+
+  test('round-trips through getBaitChannelIds', () => {
+    const config = { channelId: '', channelIds: null as string[] | null };
+    setBaitChannels(config, ['x', 'y', 'z']);
+    expect(getBaitChannelIds(config)).toEqual(['x', 'y', 'z']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the **live bug** where `/baitchannel setup` changes were silently ineffective: the `channelId → channelIds` migration (v3.1.35) left setup writing only the legacy `channelId` column while the detection engine prefers `channelIds`. Once the startup backfill populated `channelIds` (i.e. for essentially every configured guild), changing the bait channel via setup had no effect on detection.

## Changes

- **New `src/utils/baitChannel/channelList.ts`** — single owner of the column pair:
  - `getBaitChannelIds(config)`: uniform read fallback (`channelIds` if non-empty, else legacy `channelId`, else `[]`)
  - `setBaitChannels(config, ids)`: dual-write with dedupe; empty list normalizes to `channelIds = null` / `channelId = ''`
- **`/baitchannel setup`** dual-writes on create AND update; update replaces the primary while preserving extras added via `/baitchannel channels add` (dedupe, cap 3), and repairs rows left divergent by the old bug
- **Readers unified** on `getBaitChannelIds`: detection (`baitChannelManager`), `/baitchannel status`, raid-mode lockdown exemptions (gains the previously missing legacy fallback), add/remove channel handlers, setup-dashboard completion state
- **`channelDelete`**: deleting one of several bait channels re-points the primary at a survivor and keeps detection enabled; only disables when no bait channels remain (previously deleting the legacy primary always disabled the whole system)
- **bot-setup dashboard flow** routed through `setBaitChannels` (behavior unchanged; centralizes the dual-write)

## Not in scope

- ninsys-api's PUT route writes only legacy `channelId` (same bug class, separate repo/work). Bot-side tolerates it via the uniform fallback, but dashboard bait-channel changes stay broken until ninsys-api gains `channelIds`.
- Stage B column retirement (deferred — hard cross-repo deploy ordering).

## Testing

- New `channelList.test.ts` (10 tests): fallback precedence, dedupe, empty→null normalization, copy semantics
- New `handlers/baitChannel/setup.test.ts` (5 tests): dual-write on create/update, extras preserved, divergent-row repair — the live-bug regression tests
- `channelDelete.test.ts` +3: primary-of-several deleted keeps enabled, non-primary deleted keeps warning message, last channel deleted disables
- `baitChannelManager.test.ts` +2: legacy-only fallback routes into detection; `channelIds` precedence over stale legacy column
- All gates green: `build`, `test` (1486 pass), `check`, `check:changelog`, `check:contract`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bait channel setup now supports multiple channels more reliably, including preserving extra channels when updating the primary one.
  * Status and setup completion now reflect the full configured channel list.

* **Bug Fixes**
  * Fixed cases where deleting one bait channel could disable the system even when other bait channels remained.
  * Fixed legacy setups so raid-mode lockdown and bait detection use the correct active channel list.
  * Repaired inconsistent bait channel settings during setup re-runs and when upgrading older configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->