### PR TITLE
feat: v3.16.0 — archival enrichment Phase A+B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.0] - 2026-07-06
+
+Archival enrichment — ticket and application archive headers now carry the
+context that was already in the database but never rendered, and the SLA
+subsystem finally has a data source.
+
+### Added
+
+- **Richer archive headers** (tickets and applications): "Ticket #"/
+  "Application #", "Closed by" (who clicked the button or triggered the
+  dashboard close, with raw id), and a "Participants" row tallying each
+  human's messages (bots excluded, capped to Discord's field limit). Every
+  new row renders only when its data exists — old archives are unchanged.
+- **Application archives identify the position**: the header title and Type
+  row now show the position's emoji and title (guild-scoped lookup with a
+  safe fallback when the position row was deleted), plus an "Outcome" row
+  (Accepted/Rejected — resolved from either the API's accepted/rejected
+  status or the workflow's approved/denied history) and a "Reviewed by" row.
+- **Tickets render SLA data**: "First response" timestamp with an
+  "⚠️ SLA breached" badge when applicable.
+
+### Fixed
+
+- **The SLA checker finally has real data**: `Ticket.firstResponseAt` had no
+  production write path (dev seeding only), so `/ticket sla` stats and
+  breach alerts ran on an always-null column. The message handler now
+  records the first response from anyone other than the opener via a
+  lightweight conditional update — the same silent-fail pattern as the
+  activity bump.
+
 ## [3.15.3] - 2026-07-06
 
 Bait channel configuration fixes — the `channelId → channelIds` migration

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.15.3",
+  "botVersion": "3.16.0",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.15.3",
+  "version": "3.16.0",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/events/application/close.ts
+++ b/src/events/application/close.ts
@@ -93,7 +93,15 @@ export const applicationCloseEvent = async (
 
   let result: ArchiveApplicationResult;
   try {
-    result = await deps.archiveAndCloseApplication(client, application, guildId, channel, archivedConfig.channelId);
+    result = await deps.archiveAndCloseApplication(
+      client,
+      application,
+      guildId,
+      channel,
+      archivedConfig.channelId,
+      undefined,
+      { id: interaction.user.id, username: interaction.user.username },
+    );
   } catch (error) {
     // Unexpected throw escaped the workflow. Status was flipped to 'closed'
     // above but the channel still exists — revert (otherwise the dup-close guard

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -38,35 +38,30 @@ export default {
     // Handle bait channel
     await baitChannelManager.handleMessage(message);
 
-    // Update lastActivityAt for ticket channels (lightweight update)
+    // One UPDATE for the ticket channel: bump lastActivityAt always, and in
+    // the SAME statement capture the first response from someone other than
+    // the opener — the SLA subsystem's data source (slaChecker queries
+    // firstResponseAt IS NULL; before v3.16.0 nothing in production ever wrote
+    // it). For email-import tickets `createdBy` is the importing admin, NOT
+    // the sender the ticket represents, so every Discord message there is a
+    // staff response and the opener-exclusion is skipped. Merged into one
+    // statement to keep the per-message hot path at a single round-trip; the
+    // conditional CASE makes firstResponseAt a no-op for every message but the
+    // genuine first response. Silent-fail like any non-critical hot-path write.
     try {
+      const now = new Date();
       await ticketRepo
         .createQueryBuilder()
         .update(Ticket)
-        .set({ lastActivityAt: new Date() })
+        .set({
+          lastActivityAt: now,
+          firstResponseAt: () =>
+            'CASE WHEN firstResponseAt IS NULL AND (isEmailTicket = TRUE OR createdBy != :author) THEN :firstResponseNow ELSE firstResponseAt END',
+        })
         .where('guildId = :guildId', { guildId: message.guild.id })
         .andWhere('channelId = :channelId', { channelId: message.channelId })
         .andWhere('status != :closed', { closed: 'closed' })
-        .execute();
-    } catch {
-      // Silently fail — this is a non-critical update
-    }
-
-    // Capture the FIRST response from someone other than the opener — the
-    // SLA subsystem's data source (slaChecker queries firstResponseAt IS
-    // NULL; before v3.16.0 nothing in production ever wrote it). Bot authors
-    // never reach here (early return above). Conditional WHERE means this is
-    // a 0-row no-op for everything but the one first-response message.
-    try {
-      await ticketRepo
-        .createQueryBuilder()
-        .update(Ticket)
-        .set({ firstResponseAt: new Date() })
-        .where('guildId = :guildId', { guildId: message.guild.id })
-        .andWhere('channelId = :channelId', { channelId: message.channelId })
-        .andWhere('status != :closed', { closed: 'closed' })
-        .andWhere('firstResponseAt IS NULL')
-        .andWhere('createdBy != :author', { author: message.author.id })
+        .setParameters({ author: message.author.id, firstResponseNow: now })
         .execute();
     } catch {
       // Silently fail — this is a non-critical update

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -51,5 +51,25 @@ export default {
     } catch {
       // Silently fail — this is a non-critical update
     }
+
+    // Capture the FIRST response from someone other than the opener — the
+    // SLA subsystem's data source (slaChecker queries firstResponseAt IS
+    // NULL; before v3.16.0 nothing in production ever wrote it). Bot authors
+    // never reach here (early return above). Conditional WHERE means this is
+    // a 0-row no-op for everything but the one first-response message.
+    try {
+      await ticketRepo
+        .createQueryBuilder()
+        .update(Ticket)
+        .set({ firstResponseAt: new Date() })
+        .where('guildId = :guildId', { guildId: message.guild.id })
+        .andWhere('channelId = :channelId', { channelId: message.channelId })
+        .andWhere('status != :closed', { closed: 'closed' })
+        .andWhere('firstResponseAt IS NULL')
+        .andWhere('createdBy != :author', { author: message.author.id })
+        .execute();
+    } catch {
+      // Silently fail — this is a non-critical update
+    }
   },
 };

--- a/src/events/ticket/close.ts
+++ b/src/events/ticket/close.ts
@@ -91,7 +91,10 @@ export const ticketCloseEvent = async (
 
   let result: ArchiveTicketResult;
   try {
-    result = await deps.archiveAndCloseTicket(client, ticket, guildId, channel, archivedConfig.channelId);
+    result = await deps.archiveAndCloseTicket(client, ticket, guildId, channel, archivedConfig.channelId, undefined, {
+      id: interaction.user.id,
+      username: interaction.user.username,
+    });
   } catch (error) {
     // An unexpected throw escaped the workflow (e.g. a transient DB error while
     // resolving a custom ticket type — closeWorkflow's metadata region isn't

--- a/src/utils/api/handlers/applicationHandlers.ts
+++ b/src/utils/api/handlers/applicationHandlers.ts
@@ -111,6 +111,10 @@ export function registerApplicationHandlers(
       return { success: true, archived: false };
     }
 
+    // ninsys-api sends the dashboard actor's id as `triggeredBy` — the
+    // workflow resolves the username for the "Closed by" archive row.
+    const triggeredBy = optionalString(body, 'triggeredBy');
+
     let result: Awaited<ReturnType<typeof archiveAndCloseApplication>>;
     try {
       result = await archiveAndCloseApplication(
@@ -119,6 +123,8 @@ export function registerApplicationHandlers(
         guildId,
         channel as GuildTextBasedChannel,
         archivedConfig.channelId,
+        undefined,
+        triggeredBy ? { id: triggeredBy } : undefined,
       );
     } catch (error) {
       // Unexpected throw — the channel still exists; revert so the archive can

--- a/src/utils/api/handlers/ticketHandlers.ts
+++ b/src/utils/api/handlers/ticketHandlers.ts
@@ -5,7 +5,7 @@ import { lazyRepo } from '../../database/lazyRepo';
 import { claimClose, releaseClose } from '../../database/statusFlip';
 import { archiveAndCloseTicket as defaultArchiveAndCloseTicket } from '../../ticket/closeWorkflow';
 import { ApiError } from '../apiError';
-import { getAndValidateEntity, isValidSnowflake, requireString } from '../helpers';
+import { getAndValidateEntity, isValidSnowflake, optionalString, requireString } from '../helpers';
 import type { RouteHandler } from '../router';
 import { writeAuditAction } from './auditHelper';
 
@@ -62,6 +62,10 @@ export function registerTicketHandlers(
       return { success: true, ticketId: ticket.id, archived: false };
     }
 
+    // ninsys-api sends the dashboard actor's id as `triggeredBy` — the
+    // workflow resolves the username for the "Closed by" archive row.
+    const triggeredBy = optionalString(body, 'triggeredBy');
+
     let result: Awaited<ReturnType<typeof archiveAndCloseTicket>>;
     try {
       result = await archiveAndCloseTicket(
@@ -70,6 +74,8 @@ export function registerTicketHandlers(
         guildId,
         channel as GuildTextBasedChannel,
         archivedConfig.channelId,
+        undefined,
+        triggeredBy ? { id: triggeredBy } : undefined,
       );
     } catch (error) {
       // An unexpected throw escaped the workflow (its metadata region isn't

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -13,15 +13,18 @@
 import type { Client, ForumChannel, ForumThreadChannel, GuildTextBasedChannel } from 'discord.js';
 import type { Application } from '../../typeorm/entities/application/Application';
 import { ArchivedApplication } from '../../typeorm/entities/application/ArchivedApplication';
+import { Position } from '../../typeorm/entities/application/Position';
 import { Colors } from '../colors';
 import { lazyRepo } from '../database/lazyRepo';
 import { verifiedChannelDelete } from '../discord/verifiedDelete';
 import { fetchMessagesAsTranscript } from '../fetchAllMessages';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
+import type { CloseActor } from '../ticket/closeWorkflow';
 import { buildTranscript, type TicketMetadata, type TranscriptMessage } from '../ticket/transcriptBuilder';
 import { buildHeaderEmbed, postTranscriptToThread } from '../ticket/transcriptPoster';
 
 const archivedAppRepo = lazyRepo(ArchivedApplication);
+const positionRepo = lazyRepo(Position);
 
 export interface ArchiveApplicationResult {
   success: boolean;
@@ -47,13 +50,58 @@ export interface CloseApplicationWorkflowDeps {
   fetchMessagesAsTranscript: typeof fetchMessagesAsTranscript;
   verifiedChannelDelete: typeof verifiedChannelDelete;
   archivedAppRepo: typeof archivedAppRepo;
+  positionRepo: typeof positionRepo;
 }
 
 const defaultDeps: CloseApplicationWorkflowDeps = {
   fetchMessagesAsTranscript,
   verifiedChannelDelete,
   archivedAppRepo,
+  positionRepo,
 };
+
+/**
+ * Resolve the Position row an application was submitted for. `type` carries
+ * `position_<id>` (see events/application/apply.ts); the row may have been
+ * deleted since — return null and let the header fall back to the generic
+ * "Application" label rather than throwing in the un-try'd metadata region
+ * (the v3.14.2 bug class).
+ */
+async function resolveApplicationPosition(
+  application: Application,
+  guildId: string,
+  deps: CloseApplicationWorkflowDeps,
+): Promise<Position | null> {
+  const raw = application.type?.startsWith('position_') ? Number(application.type.slice('position_'.length)) : NaN;
+  if (!Number.isInteger(raw)) return null;
+  return deps.positionRepo.findOneBy({ id: raw, guildId }).catch(() => null);
+}
+
+/**
+ * Outcome label from the application's terminal state. Two vocabularies
+ * exist: the API approve/deny routes set `status` to 'accepted'/'rejected',
+ * while the Discord workflow writes 'approved'/'denied' status-history
+ * entries. `claimClose` flips only the DB row, so the in-memory entity still
+ * carries the pre-close status; fall back to the newest decisive history
+ * entry when the current status isn't itself an outcome.
+ */
+const OUTCOME_LABELS: Record<string, string> = {
+  accepted: 'Accepted',
+  approved: 'Accepted',
+  rejected: 'Rejected',
+  denied: 'Rejected',
+};
+
+function resolveApplicationOutcome(application: Application): string | null {
+  const current = OUTCOME_LABELS[application.status];
+  if (current) return current;
+  const history = application.statusHistory ?? [];
+  for (let i = history.length - 1; i >= 0; i--) {
+    const label = OUTCOME_LABELS[history[i].status];
+    if (label) return label;
+  }
+  return null;
+}
 
 /**
  * Archive an application to the forum channel and clean up.
@@ -69,6 +117,7 @@ export async function archiveAndCloseApplication(
   channel: GuildTextBasedChannel,
   archiveForumChannelId: string,
   deps: CloseApplicationWorkflowDeps = defaultDeps,
+  closedBy?: CloseActor,
 ): Promise<ArchiveApplicationResult> {
   const channelId = application.channelId || channel.id;
 
@@ -83,17 +132,32 @@ export async function archiveAndCloseApplication(
     return { success: false, archived: false, transcriptFailed: true };
   }
 
-  const creatorUser = await client.users.fetch(application.createdBy).catch(() => null);
+  // Independent lookups — run concurrently (mirrors ticket closeWorkflow).
+  const [creatorUser, position, reviewedByUser, closedByUser] = await Promise.all([
+    client.users.fetch(application.createdBy).catch(() => null),
+    resolveApplicationPosition(application, guildId, deps),
+    application.reviewedBy ? client.users.fetch(application.reviewedBy).catch(() => null) : Promise.resolve(null),
+    // API closes only carry the actor's id — resolve the username here.
+    closedBy?.id && !closedBy.username ? client.users.fetch(closedBy.id).catch(() => null) : Promise.resolve(null),
+  ]);
+
   const threadName = creatorUser?.username || 'Unknown';
+  const positionLabel = position ? `${position.emoji ? `${position.emoji} ` : ''}${position.title}` : null;
   const metadata: TicketMetadata = {
-    title: `Application — ${threadName}`,
-    type: 'Application',
+    title: positionLabel ? `${positionLabel} — ${threadName}` : `Application — ${threadName}`,
+    type: position?.title ?? 'Application',
     createdByUsername: threadName,
     openedAt: 'createdAt' in channel && channel.createdAt instanceof Date ? channel.createdAt : new Date(),
     closedAt: new Date(),
     assignedToUsername: null,
     kind: 'application',
     createdById: application.createdBy,
+    entityId: application.id,
+    closedByUsername: closedBy?.username ?? closedByUser?.username ?? null,
+    closedById: closedBy?.id ?? null,
+    outcome: resolveApplicationOutcome(application),
+    reviewedByUsername: reviewedByUser?.username ?? null,
+    reviewedById: application.reviewedBy ?? null,
   };
 
   const transcript = buildTranscript(transcriptMessages, metadata);

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -85,20 +85,35 @@ async function resolveApplicationPosition(
  * carries the pre-close status; fall back to the newest decisive history
  * entry when the current status isn't itself an outcome.
  */
-const OUTCOME_LABELS: Record<string, string> = {
-  accepted: 'Accepted',
-  approved: 'Accepted',
-  rejected: 'Rejected',
-  denied: 'Rejected',
-};
+// A Map, not an object literal: application.status is admin-extensible
+// (/application workflow-add-status accepts any /^[a-z0-9-]{1,20}$/ id, which
+// admits 'constructor'), and an object-literal lookup on such a key would
+// return an inherited Object.prototype member (a function) that then throws
+// when the embed builder rejects the non-string field value.
+const OUTCOME_LABELS = new Map<string, string>([
+  ['accepted', 'Accepted'],
+  ['approved', 'Accepted'],
+  ['rejected', 'Rejected'],
+  ['denied', 'Rejected'],
+]);
+
+function outcomeLabel(status: string): string | null {
+  return OUTCOME_LABELS.get(status) ?? null;
+}
 
 function resolveApplicationOutcome(application: Application): string | null {
-  const current = OUTCOME_LABELS[application.status];
+  const current = outcomeLabel(application.status);
   if (current) return current;
+  // Current status isn't itself a decision (usually 'closed' after the flip).
+  // Scan history newest-first, skipping the terminal 'closed' entry (the close
+  // action, not a decision). The FIRST substantive entry decides: if it's
+  // decisive that's the outcome; if it's anything else, an earlier decision
+  // was retracted (e.g. approved → moved back to under-review) and we report
+  // no outcome rather than resurrecting the withdrawn one.
   const history = application.statusHistory ?? [];
   for (let i = history.length - 1; i >= 0; i--) {
-    const label = OUTCOME_LABELS[history[i].status];
-    if (label) return label;
+    if (history[i].status === 'closed') continue;
+    return outcomeLabel(history[i].status);
   }
   return null;
 }

--- a/src/utils/ticket/closeWorkflow.ts
+++ b/src/utils/ticket/closeWorkflow.ts
@@ -155,6 +155,16 @@ function mergeForumTags(existing: string[] | null | undefined, incoming: string[
 }
 
 /**
+ * Who performed a close. The Discord button path knows both fields; the
+ * internal API path only has the actor's id (`triggeredBy`) — the workflow
+ * resolves the username itself when it's missing.
+ */
+export interface CloseActor {
+  id?: string;
+  username?: string;
+}
+
+/**
  * Archive a ticket to the forum channel and clean up.
  *
  * This is the shared core that both the event handler and API handler call.
@@ -167,6 +177,7 @@ export async function archiveAndCloseTicket(
   channel: GuildTextBasedChannel,
   archiveForumChannelId: string,
   deps: CloseWorkflowDeps = defaultDeps,
+  closedBy?: CloseActor,
 ): Promise<ArchiveTicketResult> {
   const channelId = ticket.channelId || '';
 
@@ -189,12 +200,14 @@ export async function archiveAndCloseTicket(
 
   // Build header + chunks. Ticket metadata is resolved locally — type info
   // falls back to the ticket's stored type name when the custom row is gone.
-  // Independent lookups — run them concurrently instead of three sequential
+  // Independent lookups — run them concurrently instead of sequential
   // round-trips on every close.
-  const [typeInfo, creatorUser, assignedUser] = await Promise.all([
+  const [typeInfo, creatorUser, assignedUser, closedByUser] = await Promise.all([
     resolveTicketTypeInfo(ticket, guildId, deps),
     client.users.fetch(ticket.createdBy).catch(() => null),
     ticket.assignedTo ? client.users.fetch(ticket.assignedTo).catch(() => null) : Promise.resolve(null),
+    // API closes only carry the actor's id — resolve the username here.
+    closedBy?.id && !closedBy.username ? client.users.fetch(closedBy.id).catch(() => null) : Promise.resolve(null),
   ]);
 
   const metadata: TicketMetadata = {
@@ -210,6 +223,11 @@ export async function archiveAndCloseTicket(
     assignedToUsername: assignedUser?.username ?? null,
     createdById: ticket.createdBy,
     assignedToId: ticket.assignedTo ?? undefined,
+    entityId: ticket.id,
+    closedByUsername: closedBy?.username ?? closedByUser?.username ?? null,
+    closedById: closedBy?.id ?? null,
+    firstResponseAt: ticket.firstResponseAt ?? null,
+    slaBreached: ticket.slaBreached === true,
   };
   // Prefer the channel's createdAt as a more accurate open time when available.
   if ('createdAt' in channel && channel.createdAt instanceof Date) {

--- a/src/utils/ticket/slaChecker.ts
+++ b/src/utils/ticket/slaChecker.ts
@@ -82,8 +82,6 @@ async function processGuildSla(client: Client, config: TicketConfig): Promise<vo
       // SLA breached
       const elapsedMinutes = Math.floor(elapsed / 60_000);
 
-      ticket.slaBreached = true;
-
       // Only mark the breach as notified once an alert is actually delivered.
       // Otherwise an unconfigured/unreachable breach channel would permanently
       // flag the ticket notified with nothing sent — and the query filters on
@@ -116,8 +114,14 @@ async function processGuildSla(client: Client, config: TicketConfig): Promise<vo
         }
       }
 
-      ticket.slaBreachNotified = notified;
-      await ticketRepo.save(ticket);
+      // Targeted UPDATE, not save(): a full-entity save would write back the
+      // firstResponseAt we loaded as NULL, clobbering a value captured
+      // concurrently by messageCreate between this find and the write (v3.16.0
+      // made firstResponseAt a live column). Touch only the two breach columns.
+      await ticketRepo.update(
+        { id: ticket.id, guildId: config.guildId },
+        { slaBreached: true, slaBreachNotified: notified },
+      );
 
       enhancedLogger.info('SLA breach detected', LogCategory.SYSTEM, {
         guildId: config.guildId,

--- a/src/utils/ticket/transcriptBuilder.ts
+++ b/src/utils/ticket/transcriptBuilder.ts
@@ -84,6 +84,27 @@ export interface TicketMetadata {
   createdById?: string;
   /** Discord user id of the assignee — badges their author lines with 🛡️. */
   assignedToId?: string;
+  // v3.16.0 archival enrichment — every field below is optional and its
+  // header row renders ONLY when the data exists (absent data shows nothing).
+  /** DB row id — renders as "Ticket #N" / "Application #N". */
+  entityId?: number;
+  /** Who performed the close (button clicker or dashboard actor). */
+  closedByUsername?: string | null;
+  closedById?: string | null;
+  /** First non-opener human response (SLA source). Tickets only. */
+  firstResponseAt?: Date | null;
+  slaBreached?: boolean;
+  /** Application outcome label — 'Accepted' / 'Rejected'. */
+  outcome?: string | null;
+  /** Reviewer who claimed the application. */
+  reviewedByUsername?: string | null;
+  reviewedById?: string | null;
+}
+
+/** Per-author message tally for the header's Participants row. */
+export interface TranscriptParticipant {
+  username: string;
+  count: number;
 }
 
 /** Author-line badge context, derived from {@link TicketMetadata}. */
@@ -153,30 +174,96 @@ function blockquote(body: string): string {
     .join('\n');
 }
 
+/** `username (`id`)` when both are known — the id makes archives greppable. */
+function formatUserWithId(username: string | null | undefined, id: string | null | undefined): string | null {
+  if (username && id) return `${username} (\`${id}\`)`;
+  if (username) return username;
+  if (id) return `\`${id}\``;
+  return null;
+}
+
+/** Discord's per-field value limit. */
+const FIELD_VALUE_LIMIT = 1024;
+
+/**
+ * `alice (12), bob (5), …` — capped under the 1024-char field limit; when
+ * the tail doesn't fit it collapses into `+N more`.
+ */
+function formatParticipants(participants: TranscriptParticipant[]): string {
+  const parts: string[] = [];
+  let length = 0;
+  for (let i = 0; i < participants.length; i++) {
+    const piece = `${participants[i].username} (${participants[i].count})`;
+    // Reserve room for a ", +NN more" tail so the cap can never be blown.
+    const reserve = i < participants.length - 1 ? 12 : 0;
+    const addLen = (parts.length > 0 ? 2 : 0) + piece.length;
+    if (length + addLen + reserve > FIELD_VALUE_LIMIT) {
+      parts.push(`+${participants.length - i} more`);
+      break;
+    }
+    parts.push(piece);
+    length += addLen;
+  }
+  return parts.join(', ');
+}
+
 /**
  * Header data for the archive post's embed card. Applications omit the
  * "Assigned to" row when there's no assignee (tickets show "Unassigned" —
  * unassigned tickets are signal, unassigned applications are the norm).
+ * Enrichment rows (id, closed-by, first-response, outcome, reviewer,
+ * participants — v3.16.0) render only when their data exists.
  */
 export function buildHeaderData(
   metadata: TicketMetadata,
   messageCount: number,
   attachmentCount: number,
+  participants?: TranscriptParticipant[],
 ): TranscriptHeaderData {
   const kind = metadata.kind ?? 'ticket';
   const duration = formatDurationShort(metadata.closedAt.getTime() - metadata.openedAt.getTime());
-  const fields: TranscriptHeaderData['fields'] = [
+  const fields: TranscriptHeaderData['fields'] = [];
+  if (metadata.entityId !== undefined) {
+    fields.push({
+      name: kind === 'application' ? 'Application #' : 'Ticket #',
+      value: `${metadata.entityId}`,
+      inline: true,
+    });
+  }
+  fields.push(
     { name: 'Opened', value: formatFullStamp(metadata.openedAt), inline: true },
     { name: 'Closed', value: formatFullStamp(metadata.closedAt), inline: true },
     { name: 'Duration', value: duration, inline: true },
     { name: 'Type', value: metadata.type, inline: true },
     { name: 'Created by', value: metadata.createdByUsername, inline: true },
-  ];
+  );
   if (metadata.assignedToUsername !== null || kind === 'ticket') {
     fields.push({ name: 'Assigned to', value: metadata.assignedToUsername ?? 'Unassigned', inline: true });
   }
+  const closedBy = formatUserWithId(metadata.closedByUsername, metadata.closedById);
+  if (closedBy) {
+    fields.push({ name: 'Closed by', value: closedBy, inline: true });
+  }
+  if (metadata.firstResponseAt || metadata.slaBreached) {
+    const stamp = metadata.firstResponseAt ? formatFullStamp(metadata.firstResponseAt) : 'None';
+    fields.push({
+      name: 'First response',
+      value: metadata.slaBreached ? `${stamp}\n⚠️ SLA breached` : stamp,
+      inline: true,
+    });
+  }
+  if (metadata.outcome) {
+    fields.push({ name: 'Outcome', value: metadata.outcome, inline: true });
+  }
+  const reviewedBy = formatUserWithId(metadata.reviewedByUsername, metadata.reviewedById);
+  if (reviewedBy) {
+    fields.push({ name: 'Reviewed by', value: reviewedBy, inline: true });
+  }
   const counts = attachmentCount > 0 ? `${messageCount} · ${attachmentCount} 📎` : `${messageCount}`;
   fields.push({ name: 'Messages', value: counts, inline: true });
+  if (participants && participants.length > 0) {
+    fields.push({ name: 'Participants', value: formatParticipants(participants), inline: false });
+  }
   // Discord caps embed titles at 256 chars — an email-ticket subject can
   // exceed that, and an over-limit title fails the whole archive post.
   const title = `${kind === 'application' ? '📋' : '🎫'} ${metadata.title}`;
@@ -557,6 +644,18 @@ function shouldIncludeMessage(msg: TranscriptMessage): boolean {
   return hasText || hasAttachments || hasStickers || hasPoll || hasMeaningfulEmbeds;
 }
 
+/** Per-author message tallies from kept messages, bots excluded, most active first. */
+function buildParticipants(kept: TranscriptMessage[]): TranscriptParticipant[] {
+  const byAuthor = new Map<string, TranscriptParticipant>();
+  for (const msg of kept) {
+    if (msg.author.bot) continue;
+    const entry = byAuthor.get(msg.author.id);
+    if (entry) entry.count++;
+    else byAuthor.set(msg.author.id, { username: msg.author.username, count: 1 });
+  }
+  return [...byAuthor.values()].sort((a, b) => b.count - a.count);
+}
+
 /**
  * End-to-end builder. Filters out system/UI noise, formats survivors
  * chat-style, and chunks them (text + attachment payloads) to fit Discord's
@@ -565,7 +664,7 @@ function shouldIncludeMessage(msg: TranscriptMessage): boolean {
 export function buildTranscript(messages: TranscriptMessage[], metadata: TicketMetadata): TranscriptResult {
   const kept = messages.filter(shouldIncludeMessage);
   const attachmentCount = kept.reduce((sum, m) => sum + m.attachments.length, 0);
-  const headerData = buildHeaderData(metadata, kept.length, attachmentCount);
+  const headerData = buildHeaderData(metadata, kept.length, attachmentCount, buildParticipants(kept));
 
   if (kept.length === 0) {
     const hadAny = messages.length > 0;

--- a/tests/unit/events/application/close.test.ts
+++ b/tests/unit/events/application/close.test.ts
@@ -12,8 +12,11 @@
 
 import { describe, expect, jest, test } from 'bun:test';
 import { Not } from 'typeorm';
+import {
+  type ApplicationCloseDeps,
+  applicationCloseEventImpl as applicationCloseEvent,
+} from '../../../../src/events/application/close';
 import applicationLang from '../../../../src/lang/en/application.json';
-import { type ApplicationCloseDeps, applicationCloseEventImpl as applicationCloseEvent } from '../../../../src/events/application/close';
 
 const tl = applicationLang.close;
 
@@ -45,7 +48,7 @@ function makeInteraction() {
     guildId: 'guild1',
     channelId: 'chan1',
     channel: { id: 'chan1' },
-    user: { id: 'user1' },
+    user: { id: 'user1', username: 'closer-user' },
   } as never;
 }
 
@@ -98,6 +101,9 @@ describe('applicationCloseEvent', () => {
     await applicationCloseEvent(client, makeInteraction(), deps);
 
     expect(archiveAndCloseApplication).toHaveBeenCalledTimes(1);
+    // The clicking user is threaded as the CloseActor (7th arg) so the
+    // archive header renders "Closed by" — v3.16.0
+    expect(archiveAndCloseApplication.mock.calls[0][6]).toEqual({ id: 'user1', username: 'closer-user' });
     expect(applicationRepo.update).toHaveBeenCalledTimes(1);
     expect(applicationRepo.update).toHaveBeenCalledWith(
       { id: 9, guildId: 'guild1', status: Not('closed') },

--- a/tests/unit/events/messageCreate.test.ts
+++ b/tests/unit/events/messageCreate.test.ts
@@ -1,0 +1,124 @@
+/**
+ * messageCreate Event Handler Unit Tests (v3.16.0)
+ *
+ * Pins the SLA first-response capture: before v3.16.0 NOTHING in production
+ * wrote Ticket.firstResponseAt (dev seeding only), so slaChecker's
+ * `firstResponseAt IS NULL` query matched every ticket forever. The handler
+ * now issues a second conditional UPDATE per guild message; these tests
+ * assert its WHERE clause carries the guard trio (open ticket, first
+ * response still null, author is not the opener) and that bot/DM messages
+ * never reach it.
+ *
+ * Strategy: patch AppDataSource.getRepository (same seam as
+ * channelDelete.test.ts) with a fake exposing a recording query-builder.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from 'bun:test';
+
+interface RecordedUpdate {
+  set: Record<string, unknown>;
+  wheres: { clause: string; params?: Record<string, unknown> }[];
+}
+
+const executedUpdates: RecordedUpdate[] = [];
+
+function makeQueryBuilder() {
+  const record: RecordedUpdate = { set: {}, wheres: [] };
+  const qb: any = {
+    update: () => qb,
+    set: (values: Record<string, unknown>) => {
+      record.set = values;
+      return qb;
+    },
+    where: (clause: string, params?: Record<string, unknown>) => {
+      record.wheres.push({ clause, params });
+      return qb;
+    },
+    andWhere: (clause: string, params?: Record<string, unknown>) => {
+      record.wheres.push({ clause, params });
+      return qb;
+    },
+    execute: async () => {
+      executedUpdates.push(record);
+      return { affected: 0 };
+    },
+  };
+  return qb;
+}
+
+const fakeTicketRepo = { createQueryBuilder: () => makeQueryBuilder() };
+
+let messageCreateHandler: typeof import('../../../src/events/messageCreate').default;
+let originalGetRepository: ((entity: any) => unknown) | undefined;
+
+beforeAll(async () => {
+  const { AppDataSource } = await import('../../../src/typeorm');
+  originalGetRepository = (AppDataSource as unknown as { getRepository: (e: any) => unknown }).getRepository;
+  (AppDataSource as unknown as { getRepository: (e: any) => unknown }).getRepository = () => fakeTicketRepo;
+  messageCreateHandler = (await import('../../../src/events/messageCreate')).default;
+});
+
+afterAll(async () => {
+  if (originalGetRepository) {
+    const { AppDataSource } = await import('../../../src/typeorm');
+    (AppDataSource as unknown as { getRepository: (e: any) => unknown }).getRepository = originalGetRepository;
+  }
+});
+
+const mockClient = {
+  baitChannelManager: {
+    trackMessage: jest.fn(async () => {}),
+    handleMessage: jest.fn(async () => {}),
+  },
+} as any;
+
+function makeMessage(overrides: Partial<any> = {}) {
+  return {
+    guild: { id: 'guild-1' },
+    channelId: 'chan-1',
+    channel: { name: 'general' },
+    author: { id: 'author-1', bot: false },
+    ...overrides,
+  } as any;
+}
+
+describe('messageCreate ticket updates', () => {
+  beforeEach(() => {
+    executedUpdates.length = 0;
+    mockClient.baitChannelManager.trackMessage.mockClear();
+    mockClient.baitChannelManager.handleMessage.mockClear();
+  });
+
+  test('guild message fires BOTH updates: lastActivityAt bump + firstResponseAt capture', async () => {
+    await messageCreateHandler.execute(makeMessage(), mockClient);
+
+    expect(executedUpdates).toHaveLength(2);
+    expect(Object.keys(executedUpdates[0].set)).toEqual(['lastActivityAt']);
+    expect(Object.keys(executedUpdates[1].set)).toEqual(['firstResponseAt']);
+  });
+
+  test('firstResponseAt update carries the guard trio: open, still-null, not-the-opener', async () => {
+    await messageCreateHandler.execute(makeMessage(), mockClient);
+
+    const clauses = executedUpdates[1].wheres.map(w => w.clause);
+    expect(clauses).toContain('firstResponseAt IS NULL');
+    expect(clauses.some(c => c.includes('createdBy != :author'))).toBe(true);
+    expect(clauses.some(c => c.includes('status != :closed'))).toBe(true);
+    // Guild-scoped (multi-server isolation)
+    const guildWhere = executedUpdates[1].wheres.find(w => w.clause.includes('guildId'));
+    expect(guildWhere?.params).toEqual({ guildId: 'guild-1' });
+    // The author param is the message author — the DB comparison excludes the opener
+    const authorWhere = executedUpdates[1].wheres.find(w => w.clause.includes(':author'));
+    expect(authorWhere?.params).toEqual({ author: 'author-1' });
+  });
+
+  test('bot messages never reach the ticket updates', async () => {
+    await messageCreateHandler.execute(makeMessage({ author: { id: 'bot-1', bot: true } }), mockClient);
+    expect(executedUpdates).toHaveLength(0);
+  });
+
+  test('DM messages (no guild) never reach the ticket updates', async () => {
+    await messageCreateHandler.execute(makeMessage({ guild: null }), mockClient);
+    expect(executedUpdates).toHaveLength(0);
+  });
+});

--- a/tests/unit/events/messageCreate.test.ts
+++ b/tests/unit/events/messageCreate.test.ts
@@ -4,10 +4,11 @@
  * Pins the SLA first-response capture: before v3.16.0 NOTHING in production
  * wrote Ticket.firstResponseAt (dev seeding only), so slaChecker's
  * `firstResponseAt IS NULL` query matched every ticket forever. The handler
- * now issues a second conditional UPDATE per guild message; these tests
- * assert its WHERE clause carries the guard trio (open ticket, first
- * response still null, author is not the opener) and that bot/DM messages
- * never reach it.
+ * now issues ONE UPDATE per guild message that bumps lastActivityAt and — via
+ * a conditional CASE — captures firstResponseAt for the first non-opener
+ * response. These tests assert the merged statement's SET/WHERE shape, the
+ * email-import exemption (createdBy is the importing admin there, so the
+ * opener-exclusion is skipped), and that bot/DM messages never reach it.
  *
  * Strategy: patch AppDataSource.getRepository (same seam as
  * channelDelete.test.ts) with a fake exposing a recording query-builder.
@@ -18,12 +19,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from 'b
 interface RecordedUpdate {
   set: Record<string, unknown>;
   wheres: { clause: string; params?: Record<string, unknown> }[];
+  params: Record<string, unknown>;
 }
 
 const executedUpdates: RecordedUpdate[] = [];
 
 function makeQueryBuilder() {
-  const record: RecordedUpdate = { set: {}, wheres: [] };
+  const record: RecordedUpdate = { set: {}, wheres: [], params: {} };
   const qb: any = {
     update: () => qb,
     set: (values: Record<string, unknown>) => {
@@ -32,10 +34,20 @@ function makeQueryBuilder() {
     },
     where: (clause: string, params?: Record<string, unknown>) => {
       record.wheres.push({ clause, params });
+      if (params) Object.assign(record.params, params);
       return qb;
     },
     andWhere: (clause: string, params?: Record<string, unknown>) => {
       record.wheres.push({ clause, params });
+      if (params) Object.assign(record.params, params);
+      return qb;
+    },
+    setParameters: (params: Record<string, unknown>) => {
+      Object.assign(record.params, params);
+      return qb;
+    },
+    setParameter: (key: string, value: unknown) => {
+      record.params[key] = value;
       return qb;
     },
     execute: async () => {
@@ -82,6 +94,12 @@ function makeMessage(overrides: Partial<any> = {}) {
   } as any;
 }
 
+/** The raw SQL of the firstResponseAt CASE expression (set() takes a fn). */
+function firstResponseSql(update: RecordedUpdate): string {
+  const fn = update.set.firstResponseAt as () => string;
+  return fn();
+}
+
 describe('messageCreate ticket updates', () => {
   beforeEach(() => {
     executedUpdates.length = 0;
@@ -89,35 +107,48 @@ describe('messageCreate ticket updates', () => {
     mockClient.baitChannelManager.handleMessage.mockClear();
   });
 
-  test('guild message fires BOTH updates: lastActivityAt bump + firstResponseAt capture', async () => {
+  test('guild message fires ONE merged UPDATE setting both lastActivityAt and firstResponseAt', async () => {
     await messageCreateHandler.execute(makeMessage(), mockClient);
 
-    expect(executedUpdates).toHaveLength(2);
-    expect(Object.keys(executedUpdates[0].set)).toEqual(['lastActivityAt']);
-    expect(Object.keys(executedUpdates[1].set)).toEqual(['firstResponseAt']);
+    expect(executedUpdates).toHaveLength(1);
+    expect(Object.keys(executedUpdates[0].set).sort()).toEqual(['firstResponseAt', 'lastActivityAt']);
+    // lastActivityAt is an unconditional Date; firstResponseAt is a CASE fn.
+    expect(executedUpdates[0].set.lastActivityAt).toBeInstanceOf(Date);
+    expect(typeof executedUpdates[0].set.firstResponseAt).toBe('function');
   });
 
-  test('firstResponseAt update carries the guard trio: open, still-null, not-the-opener', async () => {
+  test('firstResponseAt CASE carries the guard trio and the email-import exemption', async () => {
     await messageCreateHandler.execute(makeMessage(), mockClient);
 
-    const clauses = executedUpdates[1].wheres.map(w => w.clause);
-    expect(clauses).toContain('firstResponseAt IS NULL');
-    expect(clauses.some(c => c.includes('createdBy != :author'))).toBe(true);
+    const sql = firstResponseSql(executedUpdates[0]);
+    expect(sql).toContain('firstResponseAt IS NULL');
+    expect(sql).toContain('createdBy != :author');
+    // Email-import tickets: createdBy is the importing admin, so every Discord
+    // message is a staff response — the opener-exclusion must be OR-skipped.
+    expect(sql).toContain('isEmailTicket = TRUE');
+    // author param bound to the message author (the DB comparison excludes the opener)
+    expect(executedUpdates[0].params.author).toBe('author-1');
+    // firstResponseNow bound and equal to the lastActivityAt value (one clock read)
+    expect(executedUpdates[0].params.firstResponseNow).toBe(executedUpdates[0].set.lastActivityAt);
+  });
+
+  test('UPDATE is guild-scoped and skips closed tickets', async () => {
+    await messageCreateHandler.execute(makeMessage(), mockClient);
+
+    const clauses = executedUpdates[0].wheres.map(w => w.clause);
+    expect(clauses.some(c => c.includes('guildId'))).toBe(true);
+    expect(clauses.some(c => c.includes('channelId'))).toBe(true);
     expect(clauses.some(c => c.includes('status != :closed'))).toBe(true);
-    // Guild-scoped (multi-server isolation)
-    const guildWhere = executedUpdates[1].wheres.find(w => w.clause.includes('guildId'));
+    const guildWhere = executedUpdates[0].wheres.find(w => w.clause.includes('guildId'));
     expect(guildWhere?.params).toEqual({ guildId: 'guild-1' });
-    // The author param is the message author — the DB comparison excludes the opener
-    const authorWhere = executedUpdates[1].wheres.find(w => w.clause.includes(':author'));
-    expect(authorWhere?.params).toEqual({ author: 'author-1' });
   });
 
-  test('bot messages never reach the ticket updates', async () => {
+  test('bot messages never reach the ticket update', async () => {
     await messageCreateHandler.execute(makeMessage({ author: { id: 'bot-1', bot: true } }), mockClient);
     expect(executedUpdates).toHaveLength(0);
   });
 
-  test('DM messages (no guild) never reach the ticket updates', async () => {
+  test('DM messages (no guild) never reach the ticket update', async () => {
     await messageCreateHandler.execute(makeMessage({ guild: null }), mockClient);
     expect(executedUpdates).toHaveLength(0);
   });

--- a/tests/unit/events/ticket/close.test.ts
+++ b/tests/unit/events/ticket/close.test.ts
@@ -18,8 +18,8 @@
 
 import { describe, expect, jest, test } from 'bun:test';
 import { Not } from 'typeorm';
-import ticketLang from '../../../../src/lang/en/ticket.json';
 import { type TicketCloseDeps, ticketCloseEvent } from '../../../../src/events/ticket/close';
+import ticketLang from '../../../../src/lang/en/ticket.json';
 
 const tl = ticketLang.close;
 
@@ -32,7 +32,13 @@ function makeDeps(overrides: Partial<Record<keyof TicketCloseDeps, unknown>> = {
   const archiveAndCloseTicket = jest.fn().mockResolvedValue({ success: true, archived: true });
   const replyEphemeralError = jest.fn().mockResolvedValue(undefined);
   return {
-    deps: { archivedTicketConfigRepo, ticketRepo, archiveAndCloseTicket, replyEphemeralError, ...overrides } as unknown as TicketCloseDeps,
+    deps: {
+      archivedTicketConfigRepo,
+      ticketRepo,
+      archiveAndCloseTicket,
+      replyEphemeralError,
+      ...overrides,
+    } as unknown as TicketCloseDeps,
     archivedTicketConfigRepo,
     ticketRepo,
     archiveAndCloseTicket,
@@ -45,7 +51,7 @@ function makeInteraction() {
     guildId: 'guild1',
     channelId: 'chan1',
     channel: { id: 'chan1' },
-    user: { id: 'user1' },
+    user: { id: 'user1', username: 'closer-user' },
     replied: true,
     deferred: false,
   } as never;
@@ -137,6 +143,9 @@ describe('ticketCloseEvent', () => {
     await ticketCloseEvent(client, makeInteraction(), deps);
 
     expect(archiveAndCloseTicket).toHaveBeenCalledTimes(1);
+    // The clicking user is threaded as the CloseActor (7th arg) so the
+    // archive header renders "Closed by" — v3.16.0
+    expect(archiveAndCloseTicket.mock.calls[0][6]).toEqual({ id: 'user1', username: 'closer-user' });
     expect(ticketRepo.update).toHaveBeenCalledTimes(1);
     expect(ticketRepo.update).toHaveBeenCalledWith(
       { id: 7, guildId: 'guild1', status: Not('closed') },

--- a/tests/unit/utils/api/applicationHandlers.test.ts
+++ b/tests/unit/utils/api/applicationHandlers.test.ts
@@ -12,19 +12,9 @@
  *   - archive: happy path returns honest archived flag, 404 when archive config missing
  */
 
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  mock,
-  test,
-} from "bun:test";
-import type { Client } from "discord.js";
-import { Not } from "typeorm";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, mock, test } from 'bun:test';
+import type { Client } from 'discord.js';
+import { Not } from 'typeorm';
 
 // Injected into registerApplicationHandlers (3rd arg) — NOT mock.module'd.
 // Mocking the shared application/closeWorkflow module here would leak
@@ -39,7 +29,7 @@ const fakeArchiveAndCloseApp = jest.fn(async () => ({
 
 const fakeWriteAuditLog = jest.fn(async () => undefined);
 const fakeWriteAuditAction = jest.fn(async () => undefined);
-mock.module("../../../../src/utils/api/handlers/auditHelper", () => ({
+mock.module('../../../../src/utils/api/handlers/auditHelper', () => ({
   writeAuditLog: fakeWriteAuditLog,
   writeAuditAction: fakeWriteAuditAction,
 }));
@@ -71,47 +61,37 @@ function makeFakeRepo(state: RepoState) {
 const applicationRepo = makeFakeRepo(applicationRepoState);
 const archivedAppConfigRepo = makeFakeRepo(archivedAppConfigRepoState);
 
-let registerApplicationHandlers: typeof import("../../../../src/utils/api/handlers/applicationHandlers").registerApplicationHandlers;
+let registerApplicationHandlers: typeof import('../../../../src/utils/api/handlers/applicationHandlers').registerApplicationHandlers;
 let routes: Map<string, any>;
 let fakeClient: Client;
 let fakeChannelSend: any;
 let originalGetRepository: ((entity: unknown) => unknown) | undefined;
 
 beforeAll(async () => {
-  const { AppDataSource } = await import("../../../../src/typeorm");
-  const { Application } = await import(
-    "../../../../src/typeorm/entities/application/Application"
-  );
+  const { AppDataSource } = await import('../../../../src/typeorm');
+  const { Application } = await import('../../../../src/typeorm/entities/application/Application');
   const { ArchivedApplicationConfig } = await import(
-    "../../../../src/typeorm/entities/application/ArchivedApplicationConfig"
+    '../../../../src/typeorm/entities/application/ArchivedApplicationConfig'
   );
   const repoMap = new Map<unknown, unknown>([
     [Application, applicationRepo],
     [ArchivedApplicationConfig, archivedAppConfigRepo],
   ]);
   // Capture so afterAll can restore. Bun shares module state across test files.
-  originalGetRepository = (
-    AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-  ).getRepository;
-  (
-    AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-  ).getRepository = (entity) =>
+  originalGetRepository = (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository;
+  (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = entity =>
     repoMap.get(entity) ??
     (() => {
       throw new Error(`Unmocked entity: ${(entity as { name?: string }).name}`);
     })();
-  const sut = await import(
-    "../../../../src/utils/api/handlers/applicationHandlers"
-  );
+  const sut = await import('../../../../src/utils/api/handlers/applicationHandlers');
   registerApplicationHandlers = sut.registerApplicationHandlers;
 });
 
 afterAll(async () => {
   if (originalGetRepository) {
-    const { AppDataSource } = await import("../../../../src/typeorm");
-    (
-      AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-    ).getRepository = originalGetRepository;
+    const { AppDataSource } = await import('../../../../src/typeorm');
+    (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = originalGetRepository;
   }
 });
 
@@ -132,11 +112,11 @@ beforeEach(() => {
   fakeWriteAuditLog.mockClear();
   fakeWriteAuditAction.mockClear();
 
-  fakeChannelSend = jest.fn(async () => ({ id: "msg-1" }));
+  fakeChannelSend = jest.fn(async () => ({ id: 'msg-1' }));
   fakeClient = {
     channels: {
       fetch: jest.fn(async () => ({
-        id: "app-channel-1",
+        id: 'app-channel-1',
         isTextBased: () => true,
         send: fakeChannelSend,
       })),
@@ -161,112 +141,98 @@ function getRoute(path: string) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("POST /applications/:id/approve", () => {
-  test("happy path: status flipped to accepted, approval message sent, audit logged", async () => {
+describe('POST /applications/:id/approve', () => {
+  test('happy path: status flipped to accepted, approval message sent, audit logged', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
 
-    const result = await getRoute("POST /applications/:id/approve")(
-      "guild-1",
-      { triggeredBy: "reviewer-99", message: "Welcome aboard!" },
-      "/applications/7/approve",
+    const result = await getRoute('POST /applications/:id/approve')(
+      'guild-1',
+      { triggeredBy: 'reviewer-99', message: 'Welcome aboard!' },
+      '/applications/7/approve',
     );
 
     expect(result).toEqual({ success: true, applicationId: 7 });
     expect(applicationRepoState.updateCalls[0]).toEqual({
-      criteria: { id: 7, guildId: "guild-1", status: Not("closed") },
-      partial: { status: "accepted" },
+      criteria: { id: 7, guildId: 'guild-1', status: Not('closed') },
+      partial: { status: 'accepted' },
     });
     expect(fakeChannelSend).toHaveBeenCalledTimes(1);
-    expect(fakeChannelSend.mock.calls[0][0]).toContain("Application Approved");
-    expect(fakeChannelSend.mock.calls[0][0]).toContain("reviewer-99");
-    expect(fakeChannelSend.mock.calls[0][0]).toContain("Welcome aboard!");
-    expect(fakeWriteAuditLog).toHaveBeenCalledWith(
-      "guild-1",
-      "application.approve",
-      "reviewer-99",
-      { applicationId: 7 },
-    );
+    expect(fakeChannelSend.mock.calls[0][0]).toContain('Application Approved');
+    expect(fakeChannelSend.mock.calls[0][0]).toContain('reviewer-99');
+    expect(fakeChannelSend.mock.calls[0][0]).toContain('Welcome aboard!');
+    expect(fakeWriteAuditLog).toHaveBeenCalledWith('guild-1', 'application.approve', 'reviewer-99', {
+      applicationId: 7,
+    });
   });
 
-  test("falls back to body.approvedBy when triggeredBy is absent", async () => {
+  test('falls back to body.approvedBy when triggeredBy is absent', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
 
-    await getRoute("POST /applications/:id/approve")(
-      "guild-1",
-      { approvedBy: "fallback-user" },
-      "/applications/7/approve",
+    await getRoute('POST /applications/:id/approve')(
+      'guild-1',
+      { approvedBy: 'fallback-user' },
+      '/applications/7/approve',
     );
 
-    expect(fakeWriteAuditLog).toHaveBeenCalledWith(
-      "guild-1",
-      "application.approve",
-      "fallback-user",
-      { applicationId: 7 },
-    );
+    expect(fakeWriteAuditLog).toHaveBeenCalledWith('guild-1', 'application.approve', 'fallback-user', {
+      applicationId: 7,
+    });
   });
 
-  test("returns 404 when application not found", async () => {
+  test('returns 404 when application not found', async () => {
     applicationRepoState.findOneByResult = null;
 
     await expect(
-      getRoute("POST /applications/:id/approve")(
-        "guild-1",
-        { triggeredBy: "r-1" },
-        "/applications/7/approve",
-      ),
+      getRoute('POST /applications/:id/approve')('guild-1', { triggeredBy: 'r-1' }, '/applications/7/approve'),
     ).rejects.toMatchObject({
       statusCode: 404,
-      message: "Application not found",
+      message: 'Application not found',
     });
     expect(applicationRepoState.updateCalls).toHaveLength(0);
   });
 
-  test("returns 409 when application already closed", async () => {
+  test('returns 409 when application already closed', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "closed",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'closed',
+      channelId: 'app-channel-1',
     };
 
     await expect(
-      getRoute("POST /applications/:id/approve")(
-        "guild-1",
-        { triggeredBy: "r-1" },
-        "/applications/7/approve",
-      ),
+      getRoute('POST /applications/:id/approve')('guild-1', { triggeredBy: 'r-1' }, '/applications/7/approve'),
     ).rejects.toMatchObject({
       statusCode: 409,
-      message: "Application already closed",
+      message: 'Application already closed',
     });
     expect(applicationRepoState.updateCalls).toHaveLength(0);
   });
 
-  test("skips channel send when channel is not text-based", async () => {
+  test('skips channel send when channel is not text-based', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
     (fakeClient.channels.fetch as any).mockResolvedValue({
       isTextBased: () => false,
     });
 
-    const result = await getRoute("POST /applications/:id/approve")(
-      "guild-1",
-      { triggeredBy: "r-1" },
-      "/applications/7/approve",
+    const result = await getRoute('POST /applications/:id/approve')(
+      'guild-1',
+      { triggeredBy: 'r-1' },
+      '/applications/7/approve',
     );
 
     expect(result).toEqual({ success: true, applicationId: 7 });
@@ -277,282 +243,267 @@ describe("POST /applications/:id/approve", () => {
   });
 });
 
-describe("POST /applications/:id/deny", () => {
-  test("happy path: status flipped to rejected, deny message includes reason", async () => {
+describe('POST /applications/:id/deny', () => {
+  test('happy path: status flipped to rejected, deny message includes reason', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
 
-    const result = await getRoute("POST /applications/:id/deny")(
-      "guild-1",
-      { triggeredBy: "reviewer-99", reason: "Not enough experience" },
-      "/applications/7/deny",
+    const result = await getRoute('POST /applications/:id/deny')(
+      'guild-1',
+      { triggeredBy: 'reviewer-99', reason: 'Not enough experience' },
+      '/applications/7/deny',
     );
 
     expect(result).toEqual({ success: true, applicationId: 7 });
     expect(applicationRepoState.updateCalls[0].partial).toEqual({
-      status: "rejected",
+      status: 'rejected',
     });
     expect(fakeChannelSend).toHaveBeenCalledTimes(1);
-    expect(fakeChannelSend.mock.calls[0][0]).toContain("Application Denied");
-    expect(fakeChannelSend.mock.calls[0][0]).toContain("Not enough experience");
-    expect(fakeWriteAuditLog).toHaveBeenCalledWith(
-      "guild-1",
-      "application.deny",
-      "reviewer-99",
-      { applicationId: 7 },
-    );
+    expect(fakeChannelSend.mock.calls[0][0]).toContain('Application Denied');
+    expect(fakeChannelSend.mock.calls[0][0]).toContain('Not enough experience');
+    expect(fakeWriteAuditLog).toHaveBeenCalledWith('guild-1', 'application.deny', 'reviewer-99', { applicationId: 7 });
   });
 
   test('omitted reason defaults to "No reason provided."', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
 
-    await getRoute("POST /applications/:id/deny")(
-      "guild-1",
-      { triggeredBy: "r-1" },
-      "/applications/7/deny",
-    );
+    await getRoute('POST /applications/:id/deny')('guild-1', { triggeredBy: 'r-1' }, '/applications/7/deny');
 
-    expect(fakeChannelSend.mock.calls[0][0]).toContain("No reason provided.");
+    expect(fakeChannelSend.mock.calls[0][0]).toContain('No reason provided.');
   });
 });
 
-describe("POST /applications/:id/archive", () => {
-  test("happy path: closes app, calls archiveAndCloseApplication, propagates archived flag", async () => {
+describe('POST /applications/:id/archive', () => {
+  test('happy path: closes app, calls archiveAndCloseApplication, propagates archived flag', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
     archivedAppConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
 
-    const result = await getRoute("POST /applications/:id/archive")(
-      "guild-1",
-      { triggeredBy: "reviewer-99" },
-      "/applications/7/archive",
+    const result = await getRoute('POST /applications/:id/archive')(
+      'guild-1',
+      { triggeredBy: 'reviewer-99' },
+      '/applications/7/archive',
     );
 
     expect(result).toEqual({ success: true, archived: true });
     // Atomic flip (claimClose): conditional on not-already-closed
     expect(applicationRepoState.updateCalls[0]).toEqual({
-      criteria: { id: 7, guildId: "guild-1", status: Not("closed") },
-      partial: { status: "closed" },
+      criteria: { id: 7, guildId: 'guild-1', status: Not('closed') },
+      partial: { status: 'closed' },
     });
     expect(fakeArchiveAndCloseApp).toHaveBeenCalledTimes(1);
-    expect(fakeArchiveAndCloseApp.mock.calls[0][4]).toBe("archive-forum-1");
+    expect(fakeArchiveAndCloseApp.mock.calls[0][4]).toBe('archive-forum-1');
+    // triggeredBy is threaded as the CloseActor (7th arg) so the archive
+    // header renders "Closed by" — v3.16.0
+    expect(fakeArchiveAndCloseApp.mock.calls[0][6]).toEqual({ id: 'reviewer-99' });
     expect(fakeWriteAuditAction).toHaveBeenCalledWith(
-      "guild-1",
-      { triggeredBy: "reviewer-99" },
-      "application.archive",
+      'guild-1',
+      { triggeredBy: 'reviewer-99' },
+      'application.archive',
       { applicationId: 7 },
     );
   });
 
-  test("flip race lost (affected=0) → 409, no archive attempt", async () => {
+  test('archive without triggeredBy passes NO CloseActor (header omits Closed by)', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
     archivedAppConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
+    };
+
+    const result = await getRoute('POST /applications/:id/archive')('guild-1', {}, '/applications/7/archive');
+
+    expect(result).toEqual({ success: true, archived: true });
+    expect(fakeArchiveAndCloseApp).toHaveBeenCalledTimes(1);
+    expect(fakeArchiveAndCloseApp.mock.calls[0][6]).toBeUndefined();
+  });
+
+  test('flip race lost (affected=0) → 409, no archive attempt', async () => {
+    applicationRepoState.findOneByResult = {
+      id: 7,
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
+    };
+    archivedAppConfigRepoState.findOneByResult = {
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
     applicationRepo.update.mockResolvedValueOnce({ affected: 0 });
 
     await expect(
-      getRoute("POST /applications/:id/archive")(
-        "guild-1",
-        {},
-        "/applications/7/archive",
-      ),
+      getRoute('POST /applications/:id/archive')('guild-1', {}, '/applications/7/archive'),
     ).rejects.toMatchObject({
       statusCode: 409,
-      message: "Application already closed",
+      message: 'Application already closed',
     });
     expect(fakeArchiveAndCloseApp).not.toHaveBeenCalled();
   });
 
-  test("workflow throws unexpectedly → status conditionally reverted, error propagates", async () => {
+  test('workflow throws unexpectedly → status conditionally reverted, error propagates', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "app-channel-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'app-channel-1',
     };
     archivedAppConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
-    fakeArchiveAndCloseApp.mockRejectedValueOnce(new Error("transient DB error"));
+    fakeArchiveAndCloseApp.mockRejectedValueOnce(new Error('transient DB error'));
 
-    await expect(
-      getRoute("POST /applications/:id/archive")(
-        "guild-1",
-        {},
-        "/applications/7/archive",
-      ),
-    ).rejects.toThrow("transient DB error");
+    await expect(getRoute('POST /applications/:id/archive')('guild-1', {}, '/applications/7/archive')).rejects.toThrow(
+      'transient DB error',
+    );
 
     // Flip to closed, then a CONDITIONAL revert (only while still 'closed').
     expect(applicationRepoState.updateCalls).toHaveLength(2);
     expect(applicationRepoState.updateCalls[1]).toEqual({
-      criteria: { id: 7, guildId: "guild-1", status: "closed" },
-      partial: { status: "pending" },
+      criteria: { id: 7, guildId: 'guild-1', status: 'closed' },
+      partial: { status: 'pending' },
     });
     expect(fakeWriteAuditAction).not.toHaveBeenCalled();
   });
 
-  test("returns 404 when archive config missing", async () => {
+  test('returns 404 when archive config missing', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "c-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'c-1',
     };
     archivedAppConfigRepoState.findOneByResult = null;
 
     await expect(
-      getRoute("POST /applications/:id/archive")(
-        "guild-1",
-        {},
-        "/applications/7/archive",
-      ),
+      getRoute('POST /applications/:id/archive')('guild-1', {}, '/applications/7/archive'),
     ).rejects.toMatchObject({
       statusCode: 404,
-      message: "Archive config not found",
+      message: 'Archive config not found',
     });
     expect(fakeArchiveAndCloseApp).not.toHaveBeenCalled();
   });
 
-  test("channel not text-based: marks closed, returns archived: false, skips archive call", async () => {
+  test('channel not text-based: marks closed, returns archived: false, skips archive call', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "c-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'c-1',
     };
     archivedAppConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
     (fakeClient.channels.fetch as any).mockResolvedValue({
       isTextBased: () => false,
     });
 
-    const result = await getRoute("POST /applications/:id/archive")(
-      "guild-1",
-      {},
-      "/applications/7/archive",
-    );
+    const result = await getRoute('POST /applications/:id/archive')('guild-1', {}, '/applications/7/archive');
 
     expect(result).toEqual({ success: true, archived: false });
     expect(applicationRepoState.updateCalls[0].partial).toEqual({
-      status: "closed",
+      status: 'closed',
     });
     expect(fakeArchiveAndCloseApp).not.toHaveBeenCalled();
   });
 
-  test("transient channel-fetch failure (non-10003): reverts status, returns failure (retryable)", async () => {
+  test('transient channel-fetch failure (non-10003): reverts status, returns failure (retryable)', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "c-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'c-1',
     };
     archivedAppConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
-    (fakeClient.channels.fetch as any).mockRejectedValue(
-      Object.assign(new Error("Service Unavailable"), { code: 0 }),
-    );
+    (fakeClient.channels.fetch as any).mockRejectedValue(Object.assign(new Error('Service Unavailable'), { code: 0 }));
 
-    const result = await getRoute("POST /applications/:id/archive")(
-      "guild-1",
-      {},
-      "/applications/7/archive",
-    );
+    const result = await getRoute('POST /applications/:id/archive')('guild-1', {}, '/applications/7/archive');
 
     expect(result).toEqual({ success: false, archived: false });
     expect(applicationRepoState.updateCalls[0].partial).toEqual({
-      status: "closed",
+      status: 'closed',
     });
     expect(applicationRepoState.updateCalls[1].partial).toEqual({
-      status: "pending",
+      status: 'pending',
     });
     expect(fakeArchiveAndCloseApp).not.toHaveBeenCalled();
   });
 
-  test("genuinely-gone channel (10003): terminal close, archived:false, no revert", async () => {
+  test('genuinely-gone channel (10003): terminal close, archived:false, no revert', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "c-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'c-1',
     };
     archivedAppConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
-    (fakeClient.channels.fetch as any).mockRejectedValue(
-      Object.assign(new Error("Unknown Channel"), { code: 10003 }),
-    );
+    (fakeClient.channels.fetch as any).mockRejectedValue(Object.assign(new Error('Unknown Channel'), { code: 10003 }));
 
-    const result = await getRoute("POST /applications/:id/archive")(
-      "guild-1",
-      {},
-      "/applications/7/archive",
-    );
+    const result = await getRoute('POST /applications/:id/archive')('guild-1', {}, '/applications/7/archive');
 
     expect(result).toEqual({ success: true, archived: false });
     expect(applicationRepoState.updateCalls).toHaveLength(1); // close flip only, no revert
     expect(fakeArchiveAndCloseApp).not.toHaveBeenCalled();
   });
 
-  test("archiveAndCloseApplication returns archived: false — reverts status for retry, no audit log", async () => {
+  test('archiveAndCloseApplication returns archived: false — reverts status for retry, no audit log', async () => {
     applicationRepoState.findOneByResult = {
       id: 7,
-      guildId: "guild-1",
-      status: "pending",
-      channelId: "c-1",
+      guildId: 'guild-1',
+      status: 'pending',
+      channelId: 'c-1',
     };
     archivedAppConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
     fakeArchiveAndCloseApp.mockResolvedValue({
       success: false,
       archived: false,
     });
 
-    const result = await getRoute("POST /applications/:id/archive")(
-      "guild-1",
-      { triggeredBy: "r-1" },
-      "/applications/7/archive",
+    const result = await getRoute('POST /applications/:id/archive')(
+      'guild-1',
+      { triggeredBy: 'r-1' },
+      '/applications/7/archive',
     );
 
     // Honest failure; channel preserved by the workflow.
     expect(result).toEqual({ success: false, archived: false });
     // Status flipped to closed, then reverted to its prior value for retry.
     expect(applicationRepoState.updateCalls[0].partial).toEqual({
-      status: "closed",
+      status: 'closed',
     });
     expect(applicationRepoState.updateCalls[1].partial).toEqual({
-      status: "pending",
+      status: 'pending',
     });
     expect(fakeWriteAuditAction).not.toHaveBeenCalled();
   });

--- a/tests/unit/utils/api/ticketHandlers.test.ts
+++ b/tests/unit/utils/api/ticketHandlers.test.ts
@@ -15,19 +15,9 @@
  *   - Channel-not-found path: marks closed, returns archived: false (no archive call)
  */
 
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  mock,
-  test,
-} from "bun:test";
-import type { Client } from "discord.js";
-import { Not } from "typeorm";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, mock, test } from 'bun:test';
+import type { Client } from 'discord.js';
+import { Not } from 'typeorm';
 
 // ---------------------------------------------------------------------------
 // Mocks for non-repo deps
@@ -44,7 +34,7 @@ const fakeArchiveAndClose = jest.fn(async () => ({
 
 const fakeWriteAuditLog = jest.fn(async () => undefined);
 const fakeWriteAuditAction = jest.fn(async () => undefined);
-mock.module("../../../../src/utils/api/handlers/auditHelper", () => ({
+mock.module('../../../../src/utils/api/handlers/auditHelper', () => ({
   writeAuditLog: fakeWriteAuditLog,
   writeAuditAction: fakeWriteAuditAction,
 }));
@@ -77,7 +67,7 @@ function makeFakeRepo(state: RepoState) {
 const ticketRepo = makeFakeRepo(ticketRepoState);
 const archivedConfigRepo = makeFakeRepo(archivedTicketConfigRepoState);
 
-let registerTicketHandlers: typeof import("../../../../src/utils/api/handlers/ticketHandlers").registerTicketHandlers;
+let registerTicketHandlers: typeof import('../../../../src/utils/api/handlers/ticketHandlers').registerTicketHandlers;
 let routes: Map<string, any>;
 let fakeClient: Client;
 let fakeChannel: any;
@@ -86,38 +76,28 @@ let originalGetRepository: ((entity: unknown) => unknown) | undefined;
 
 beforeAll(async () => {
   // Map each entity import to its corresponding fake repo.
-  const { AppDataSource } = await import("../../../../src/typeorm");
-  const { Ticket } = await import(
-    "../../../../src/typeorm/entities/ticket/Ticket"
-  );
-  const { ArchivedTicketConfig } = await import(
-    "../../../../src/typeorm/entities/ticket/ArchivedTicketConfig"
-  );
+  const { AppDataSource } = await import('../../../../src/typeorm');
+  const { Ticket } = await import('../../../../src/typeorm/entities/ticket/Ticket');
+  const { ArchivedTicketConfig } = await import('../../../../src/typeorm/entities/ticket/ArchivedTicketConfig');
   const repoMap = new Map<unknown, unknown>([
     [Ticket, ticketRepo],
     [ArchivedTicketConfig, archivedConfigRepo],
   ]);
   // Capture so afterAll can restore. Bun shares module state across test files.
-  originalGetRepository = (
-    AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-  ).getRepository;
-  (
-    AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-  ).getRepository = (entity) =>
+  originalGetRepository = (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository;
+  (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = entity =>
     repoMap.get(entity) ??
     (() => {
       throw new Error(`Unmocked entity: ${(entity as { name?: string }).name}`);
     })();
-  const sut = await import("../../../../src/utils/api/handlers/ticketHandlers");
+  const sut = await import('../../../../src/utils/api/handlers/ticketHandlers');
   registerTicketHandlers = sut.registerTicketHandlers;
 });
 
 afterAll(async () => {
   if (originalGetRepository) {
-    const { AppDataSource } = await import("../../../../src/typeorm");
-    (
-      AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-    ).getRepository = originalGetRepository;
+    const { AppDataSource } = await import('../../../../src/typeorm');
+    (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = originalGetRepository;
   }
 });
 
@@ -138,9 +118,9 @@ beforeEach(() => {
   fakeWriteAuditLog.mockClear();
   fakeWriteAuditAction.mockClear();
 
-  fakeChannel = { id: "ticket-channel-1", isTextBased: () => true };
+  fakeChannel = { id: 'ticket-channel-1', isTextBased: () => true };
   fakeAssignChannel = {
-    id: "ticket-channel-1",
+    id: 'ticket-channel-1',
     permissionOverwrites: { create: jest.fn(async () => undefined) },
   };
   const fakeGuild = {
@@ -164,8 +144,8 @@ afterEach(() => {
 });
 
 function getCloseHandler() {
-  const handler = routes.get("POST /tickets/:id/close");
-  if (!handler) throw new Error("POST /tickets/:id/close not registered");
+  const handler = routes.get('POST /tickets/:id/close');
+  if (!handler) throw new Error('POST /tickets/:id/close not registered');
   return handler;
 }
 
@@ -173,193 +153,196 @@ function getCloseHandler() {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("POST /tickets/:id/close", () => {
-  test("happy path: marks closed, calls archiveAndCloseTicket, writes audit log", async () => {
+describe('POST /tickets/:id/close', () => {
+  test('happy path: marks closed, calls archiveAndCloseTicket, writes audit log', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
     archivedTicketConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
 
-    const result = await getCloseHandler()(
-      "guild-1",
-      { triggeredBy: "user-99" },
-      "/tickets/42/close",
-    );
+    const result = await getCloseHandler()('guild-1', { triggeredBy: 'user-99' }, '/tickets/42/close');
 
     expect(result).toEqual({ success: true, ticketId: 42, archived: true });
     // Guild-scoped lookup
     expect(ticketRepo.findOneBy).toHaveBeenCalledWith({
-      guildId: "guild-1",
+      guildId: 'guild-1',
       id: 42,
     });
     // Status flip happens BEFORE the archive call, conditionally (race fix)
     expect(ticketRepoState.updateCalls[0]).toEqual({
-      criteria: { id: 42, guildId: "guild-1", status: Not("closed") },
-      partial: { status: "closed" },
+      criteria: { id: 42, guildId: 'guild-1', status: Not('closed') },
+      partial: { status: 'closed' },
     });
     // Archive helper called with the right channel + archive config
     expect(fakeArchiveAndClose).toHaveBeenCalledTimes(1);
-    expect(fakeArchiveAndClose.mock.calls[0][2]).toBe("guild-1");
-    expect(fakeArchiveAndClose.mock.calls[0][4]).toBe("archive-forum-1");
+    expect(fakeArchiveAndClose.mock.calls[0][2]).toBe('guild-1');
+    expect(fakeArchiveAndClose.mock.calls[0][4]).toBe('archive-forum-1');
+    // triggeredBy is threaded as the CloseActor (7th arg) so the archive
+    // header renders "Closed by" — v3.16.0
+    expect(fakeArchiveAndClose.mock.calls[0][6]).toEqual({ id: 'user-99' });
     // Audit log includes triggeredBy (extracted from the request body)
-    expect(fakeWriteAuditAction).toHaveBeenCalledWith(
-      "guild-1",
-      { triggeredBy: "user-99" },
-      "ticket.close",
-      { ticketId: 42 },
-    );
-  });
-
-  test("returns 404 when ticket not found", async () => {
-    ticketRepoState.findOneByResult = null;
-
-    await expect(
-      getCloseHandler()("guild-1", {}, "/tickets/42/close"),
-    ).rejects.toMatchObject({
-      statusCode: 404,
-      message: "Ticket not found",
+    expect(fakeWriteAuditAction).toHaveBeenCalledWith('guild-1', { triggeredBy: 'user-99' }, 'ticket.close', {
+      ticketId: 42,
     });
-    expect(ticketRepoState.updateCalls).toHaveLength(0);
-    expect(fakeArchiveAndClose).not.toHaveBeenCalled();
   });
 
-  test("returns 409 when ticket is already closed", async () => {
+  test('close without triggeredBy passes NO CloseActor (header omits Closed by)', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "closed",
-      channelId: "ticket-channel-1",
-    };
-
-    await expect(
-      getCloseHandler()("guild-1", {}, "/tickets/42/close"),
-    ).rejects.toMatchObject({
-      statusCode: 409,
-      message: "Ticket already closed",
-    });
-    expect(ticketRepoState.updateCalls).toHaveLength(0);
-    expect(fakeArchiveAndClose).not.toHaveBeenCalled();
-  });
-
-  test("workflow throws unexpectedly → status reverted, error propagates (no stranded close)", async () => {
-    ticketRepoState.findOneByResult = {
-      id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
     archivedTicketConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
-    fakeArchiveAndClose.mockRejectedValueOnce(new Error("transient DB error"));
 
-    await expect(
-      getCloseHandler()("guild-1", {}, "/tickets/42/close"),
-    ).rejects.toThrow("transient DB error");
+    const result = await getCloseHandler()('guild-1', {}, '/tickets/42/close');
+
+    expect(result).toEqual({ success: true, ticketId: 42, archived: true });
+    expect(fakeArchiveAndClose).toHaveBeenCalledTimes(1);
+    expect(fakeArchiveAndClose.mock.calls[0][6]).toBeUndefined();
+  });
+
+  test('returns 404 when ticket not found', async () => {
+    ticketRepoState.findOneByResult = null;
+
+    await expect(getCloseHandler()('guild-1', {}, '/tickets/42/close')).rejects.toMatchObject({
+      statusCode: 404,
+      message: 'Ticket not found',
+    });
+    expect(ticketRepoState.updateCalls).toHaveLength(0);
+    expect(fakeArchiveAndClose).not.toHaveBeenCalled();
+  });
+
+  test('returns 409 when ticket is already closed', async () => {
+    ticketRepoState.findOneByResult = {
+      id: 42,
+      guildId: 'guild-1',
+      status: 'closed',
+      channelId: 'ticket-channel-1',
+    };
+
+    await expect(getCloseHandler()('guild-1', {}, '/tickets/42/close')).rejects.toMatchObject({
+      statusCode: 409,
+      message: 'Ticket already closed',
+    });
+    expect(ticketRepoState.updateCalls).toHaveLength(0);
+    expect(fakeArchiveAndClose).not.toHaveBeenCalled();
+  });
+
+  test('workflow throws unexpectedly → status reverted, error propagates (no stranded close)', async () => {
+    ticketRepoState.findOneByResult = {
+      id: 42,
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
+    };
+    archivedTicketConfigRepoState.findOneByResult = {
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
+    };
+    fakeArchiveAndClose.mockRejectedValueOnce(new Error('transient DB error'));
+
+    await expect(getCloseHandler()('guild-1', {}, '/tickets/42/close')).rejects.toThrow('transient DB error');
 
     // Flip to closed, then a CONDITIONAL revert to the original status (only
     // while still 'closed' — a concurrent status change must not be clobbered).
     expect(ticketRepoState.updateCalls).toHaveLength(2);
     expect(ticketRepoState.updateCalls[1]).toEqual({
-      criteria: { id: 42, guildId: "guild-1", status: "closed" },
-      partial: { status: "open" },
+      criteria: { id: 42, guildId: 'guild-1', status: 'closed' },
+      partial: { status: 'open' },
     });
     expect(fakeWriteAuditAction).not.toHaveBeenCalled();
   });
 
-  test("returns 404 when archive config missing — no status flip, no archive call", async () => {
+  test('returns 404 when archive config missing — no status flip, no archive call', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
     archivedTicketConfigRepoState.findOneByResult = null;
 
-    await expect(
-      getCloseHandler()("guild-1", {}, "/tickets/42/close"),
-    ).rejects.toMatchObject({
+    await expect(getCloseHandler()('guild-1', {}, '/tickets/42/close')).rejects.toMatchObject({
       statusCode: 404,
-      message: "Archive config not found",
+      message: 'Archive config not found',
     });
     expect(ticketRepoState.updateCalls).toHaveLength(0);
     expect(fakeArchiveAndClose).not.toHaveBeenCalled();
   });
 
-  test("channel fetch fails: marks closed, returns archived: false, skips archive call", async () => {
+  test('channel fetch fails: marks closed, returns archived: false, skips archive call', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
     archivedTicketConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
     (fakeClient.channels.fetch as any).mockResolvedValue(null);
 
-    const result = await getCloseHandler()("guild-1", {}, "/tickets/42/close");
+    const result = await getCloseHandler()('guild-1', {}, '/tickets/42/close');
 
     expect(result).toEqual({ success: true, ticketId: 42, archived: false });
     // Status was still flipped to closed before the channel-not-found branch returned
     expect(ticketRepoState.updateCalls[0].partial).toEqual({
-      status: "closed",
+      status: 'closed',
     });
     expect(fakeArchiveAndClose).not.toHaveBeenCalled();
     // Audit log NOT written on the channel-not-found early return (matches current handler behavior)
     expect(fakeWriteAuditAction).not.toHaveBeenCalled();
   });
 
-  test("transient channel-fetch failure (non-10003): reverts status, returns failure (retryable)", async () => {
+  test('transient channel-fetch failure (non-10003): reverts status, returns failure (retryable)', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
     archivedTicketConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
-    (fakeClient.channels.fetch as any).mockRejectedValue(
-      Object.assign(new Error("Service Unavailable"), { code: 0 }),
-    );
+    (fakeClient.channels.fetch as any).mockRejectedValue(Object.assign(new Error('Service Unavailable'), { code: 0 }));
 
-    const result = await getCloseHandler()("guild-1", {}, "/tickets/42/close");
+    const result = await getCloseHandler()('guild-1', {}, '/tickets/42/close');
 
     // A transient fetch failure must NOT strand the ticket closed.
     expect(result).toEqual({ success: false, ticketId: 42, archived: false });
     expect(ticketRepoState.updateCalls[0].partial).toEqual({
-      status: "closed",
+      status: 'closed',
     });
-    expect(ticketRepoState.updateCalls[1].partial).toEqual({ status: "open" });
+    expect(ticketRepoState.updateCalls[1].partial).toEqual({ status: 'open' });
     expect(fakeArchiveAndClose).not.toHaveBeenCalled();
   });
 
-  test("genuinely-gone channel (10003): terminal close, archived:false, no revert", async () => {
+  test('genuinely-gone channel (10003): terminal close, archived:false, no revert', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
     archivedTicketConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
-    (fakeClient.channels.fetch as any).mockRejectedValue(
-      Object.assign(new Error("Unknown Channel"), { code: 10003 }),
-    );
+    (fakeClient.channels.fetch as any).mockRejectedValue(Object.assign(new Error('Unknown Channel'), { code: 10003 }));
 
-    const result = await getCloseHandler()("guild-1", {}, "/tickets/42/close");
+    const result = await getCloseHandler()('guild-1', {}, '/tickets/42/close');
 
     // Channel is genuinely gone — nothing to archive, so the close is terminal.
     expect(result).toEqual({ success: true, ticketId: 42, archived: false });
@@ -367,62 +350,62 @@ describe("POST /tickets/:id/close", () => {
     expect(fakeArchiveAndClose).not.toHaveBeenCalled();
   });
 
-  test("archiveAndCloseTicket returns archived: false — reverts status for retry, writes NO audit log", async () => {
+  test('archiveAndCloseTicket returns archived: false — reverts status for retry, writes NO audit log', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
     archivedTicketConfigRepoState.findOneByResult = {
-      guildId: "guild-1",
-      channelId: "archive-forum-1",
+      guildId: 'guild-1',
+      channelId: 'archive-forum-1',
     };
     fakeArchiveAndClose.mockResolvedValue({ success: false, archived: false });
 
-    const result = await getCloseHandler()("guild-1", {}, "/tickets/42/close");
+    const result = await getCloseHandler()('guild-1', {}, '/tickets/42/close');
 
     // Honest failure surfaced to the caller.
     expect(result).toEqual({ success: false, ticketId: 42, archived: false });
     // Status flipped to closed, then reverted to its prior value so the close
     // can be retried (the workflow preserved the channel).
     expect(ticketRepoState.updateCalls[0].partial).toEqual({
-      status: "closed",
+      status: 'closed',
     });
-    expect(ticketRepoState.updateCalls[1].partial).toEqual({ status: "open" });
+    expect(ticketRepoState.updateCalls[1].partial).toEqual({ status: 'open' });
     // A failed close is not an audit-worthy "ticket.close".
     expect(fakeWriteAuditAction).not.toHaveBeenCalled();
   });
 });
 
-describe("POST /tickets/:id/assign", () => {
-  const ASSIGNEE = "123456789012345678";
+describe('POST /tickets/:id/assign', () => {
+  const ASSIGNEE = '123456789012345678';
 
   function getAssignHandler() {
-    const handler = routes.get("POST /tickets/:id/assign");
-    if (!handler) throw new Error("POST /tickets/:id/assign not registered");
+    const handler = routes.get('POST /tickets/:id/assign');
+    if (!handler) throw new Error('POST /tickets/:id/assign not registered');
     return handler;
   }
 
-  test("persists assignedTo + assignedAt (the v3.2.1 bug fix), grants channel access, audits", async () => {
+  test('persists assignedTo + assignedAt (the v3.2.1 bug fix), grants channel access, audits', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
 
     const result = await getAssignHandler()(
-      "guild-1",
-      { userId: ASSIGNEE, triggeredBy: "admin-1" },
-      "/tickets/42/assign",
+      'guild-1',
+      { userId: ASSIGNEE, triggeredBy: 'admin-1' },
+      '/tickets/42/assign',
     );
 
     expect(result).toEqual({ success: true });
     // THE FIX: the assignment is now written to the DB (was only a perm overwrite before).
     expect(ticketRepoState.updateCalls).toHaveLength(1);
     const { criteria, partial } = ticketRepoState.updateCalls[0];
-    expect(criteria).toEqual({ id: 42, guildId: "guild-1" });
+    expect(criteria).toEqual({ id: 42, guildId: 'guild-1' });
     expect(partial.assignedTo).toBe(ASSIGNEE);
     expect(partial.assignedAt).toBeInstanceOf(Date);
     // Channel access still granted.
@@ -431,9 +414,9 @@ describe("POST /tickets/:id/assign", () => {
       expect.objectContaining({ ViewChannel: true, SendMessages: true }),
     );
     expect(fakeWriteAuditAction).toHaveBeenCalledWith(
-      "guild-1",
-      { userId: ASSIGNEE, triggeredBy: "admin-1" },
-      "ticket.assign",
+      'guild-1',
+      { userId: ASSIGNEE, triggeredBy: 'admin-1' },
+      'ticket.assign',
       {
         ticketId: 42,
         userId: ASSIGNEE,
@@ -441,29 +424,25 @@ describe("POST /tickets/:id/assign", () => {
     );
   });
 
-  test("rejects a non-snowflake userId before any write", async () => {
+  test('rejects a non-snowflake userId before any write', async () => {
     ticketRepoState.findOneByResult = {
       id: 42,
-      guildId: "guild-1",
-      status: "open",
-      channelId: "ticket-channel-1",
+      guildId: 'guild-1',
+      status: 'open',
+      channelId: 'ticket-channel-1',
     };
 
     await expect(
-      getAssignHandler()(
-        "guild-1",
-        { userId: "not-a-snowflake" },
-        "/tickets/42/assign",
-      ),
+      getAssignHandler()('guild-1', { userId: 'not-a-snowflake' }, '/tickets/42/assign'),
     ).rejects.toMatchObject({ statusCode: 400 });
     expect(ticketRepoState.updateCalls).toHaveLength(0);
   });
 
-  test("404 when the ticket does not exist", async () => {
+  test('404 when the ticket does not exist', async () => {
     ticketRepoState.findOneByResult = null;
-    await expect(
-      getAssignHandler()("guild-1", { userId: ASSIGNEE }, "/tickets/42/assign"),
-    ).rejects.toMatchObject({ statusCode: 404 });
+    await expect(getAssignHandler()('guild-1', { userId: ASSIGNEE }, '/tickets/42/assign')).rejects.toMatchObject({
+      statusCode: 404,
+    });
     expect(ticketRepoState.updateCalls).toHaveLength(0);
   });
 });

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -51,10 +51,16 @@ const fakeVerifiedChannelDelete = jest.fn(async () => ({
 }));
 const fakeFetchMessages = jest.fn(async () => [] as any[]);
 
+/** Position lookup seam — findOneBy result set per test (null = orphaned). */
+const fakePositionRepo = {
+  findOneBy: jest.fn(async () => null as any),
+};
+
 const deps = {
   fetchMessagesAsTranscript: fakeFetchMessages,
   verifiedChannelDelete: fakeVerifiedChannelDelete,
   archivedAppRepo: fakeRepo,
+  positionRepo: fakePositionRepo,
 } as unknown as CloseApplicationWorkflowDeps;
 
 interface FakeForumState {
@@ -136,6 +142,8 @@ describe("archiveAndCloseApplication", () => {
     fakeVerifiedChannelDelete.mockImplementation(async () => ({ success: true, alreadyGone: false }));
     fakeFetchMessages.mockClear();
     fakeFetchMessages.mockImplementation(async () => []);
+    fakePositionRepo.findOneBy.mockClear();
+    fakePositionRepo.findOneBy.mockImplementation(async () => null);
     forumState = { threadsCreated: [], threadsFetched: new Map() };
     forumChannel = makeFakeForumChannel(forumState);
   });
@@ -299,5 +307,146 @@ describe("archiveAndCloseApplication", () => {
     expect(result).toEqual({ success: false, archived: false, transcriptFailed: true });
     expect(forumChannel.threads.create).not.toHaveBeenCalled();
     expect(fakeVerifiedChannelDelete).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Archival enrichment (v3.16.0): position / outcome / reviewer / closedBy
+  // -------------------------------------------------------------------------
+
+  /** Header embed of the first thread created (title + fields-by-name). */
+  function createdHeader(forum: any): { title: string; fields: Record<string, string> } {
+    const embed = forum.threads.create.mock.calls[0][0].message.embeds[0];
+    return {
+      title: embed.data.title,
+      fields: Object.fromEntries(embed.data.fields.map((f: any) => [f.name, f.value])),
+    };
+  }
+
+  test("position resolved from type='position_<id>' → emoji+title in header title, title in Type row", async () => {
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: "Moderator", emoji: "🛡️" });
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: "position_7" }),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(fakePositionRepo.findOneBy).toHaveBeenCalledWith({ id: 7, guildId: "guild-1" });
+    const header = createdHeader(forumChannel);
+    expect(header.title).toBe("📋 🛡️ Moderator — applicant");
+    expect(header.fields.Type).toBe("Moderator");
+  });
+
+  test("orphaned position (row deleted) falls back to the generic Application header — close survives", async () => {
+    fakePositionRepo.findOneBy.mockResolvedValue(null);
+    const client = makeFakeClient(forumChannel);
+
+    const result = await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: "position_99" }),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(result.archived).toBe(true);
+    const header = createdHeader(forumChannel);
+    expect(header.title).toBe("📋 Application — applicant");
+    expect(header.fields.Type).toBe("Application");
+  });
+
+  test("position lookup DB error is swallowed (orphan fallback), not thrown from the un-try'd metadata region", async () => {
+    fakePositionRepo.findOneBy.mockRejectedValue(new Error("transient DB error"));
+    const client = makeFakeClient(forumChannel);
+
+    const result = await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: "position_7" }),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(result.archived).toBe(true);
+    expect(createdHeader(forumChannel).title).toBe("📋 Application — applicant");
+  });
+
+  test("outcome from the in-memory pre-close status ('accepted' — API approve path)", async () => {
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ status: "accepted" }),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(createdHeader(forumChannel).fields.Outcome).toBe("Accepted");
+  });
+
+  test("outcome from the newest decisive statusHistory entry ('denied' — Discord workflow vocabulary)", async () => {
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({
+        status: "closed",
+        statusHistory: [
+          { status: "submitted", changedBy: "u1", changedAt: "2026-04-20T10:00:00Z" },
+          { status: "denied", changedBy: "rev-1", changedAt: "2026-04-21T10:00:00Z" },
+          { status: "closed", changedBy: "rev-1", changedAt: "2026-04-22T10:00:00Z" },
+        ],
+      }),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(createdHeader(forumChannel).fields.Outcome).toBe("Rejected");
+  });
+
+  test("no decisive status anywhere → no Outcome row", async () => {
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ status: "closed", statusHistory: [] }),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+    );
+
+    expect(createdHeader(forumChannel).fields.Outcome).toBeUndefined();
+  });
+
+  test("reviewedBy resolves to a Reviewed by row; closedBy actor renders Closed by; Application # present", async () => {
+    const client = makeFakeClient(forumChannel, (id: string) =>
+      id === "rev-1" ? { username: "reviewer" } : { username: "applicant" },
+    );
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ id: 55, reviewedBy: "rev-1" }),
+      "guild-1",
+      makeChannel(),
+      "forum-archive-1",
+      deps,
+      { id: "staff-2", username: "closer" },
+    );
+
+    const { fields } = createdHeader(forumChannel);
+    expect(fields["Reviewed by"]).toBe("reviewer (`rev-1`)");
+    expect(fields["Closed by"]).toBe("closer (`staff-2`)");
+    expect(fields["Application #"]).toBe("55");
   });
 });

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -14,12 +14,12 @@
  * same deterministic-on-Linux reasons documented in the ticket suite.
  */
 
-import { afterEach, beforeEach, describe, expect, jest, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, jest, test } from 'bun:test';
 import {
-  archiveAndCloseApplication,
   type ArchiveApplicationResult,
+  archiveAndCloseApplication,
   type CloseApplicationWorkflowDeps,
-} from "../../../../src/utils/application/closeWorkflow";
+} from '../../../../src/utils/application/closeWorkflow';
 
 interface FakeRepoState {
   findOneByResult: any;
@@ -70,14 +70,14 @@ interface FakeForumState {
   fetchShouldThrow?: Error;
 }
 
-function makeFakeThread(id = "new-thread-1") {
+function makeFakeThread(id = 'new-thread-1') {
   const state = { id, sentMessages: [] as string[] };
   return {
     ...state,
     send: jest.fn(async ({ content, embeds }: { content?: string; embeds?: any[] }) => {
       // Embed-only sends (header cards) are recorded as a tagged title line so
       // assertions can distinguish them from transcript text chunks.
-      state.sentMessages.push(content ?? `[embed] ${embeds?.[0]?.data?.title ?? ""}`);
+      state.sentMessages.push(content ?? `[embed] ${embeds?.[0]?.data?.title ?? ''}`);
       return { id: `${id}-msg-${state.sentMessages.length}` };
     }),
   };
@@ -104,30 +104,30 @@ function makeFakeForumChannel(state: FakeForumState) {
   };
 }
 
-function makeFakeClient(forumChannel: any, userResolver: (id: string) => any = () => ({ username: "applicant" })) {
+function makeFakeClient(forumChannel: any, userResolver: (id: string) => any = () => ({ username: 'applicant' })) {
   return {
-    user: { id: "bot-client-id" },
+    user: { id: 'bot-client-id' },
     channels: { fetch: jest.fn(async () => forumChannel) },
     users: { fetch: jest.fn(async (id: string) => userResolver(id)) },
   } as any;
 }
 
-function makeChannel(id = "app-channel-1") {
-  return { id, createdAt: new Date("2026-04-20T10:00:00Z") } as any;
+function makeChannel(id = 'app-channel-1') {
+  return { id, createdAt: new Date('2026-04-20T10:00:00Z') } as any;
 }
 
 function makeApplication(overrides: Partial<any> = {}): any {
   return {
     id: 1,
-    guildId: "guild-1",
-    channelId: "app-channel-1",
-    createdBy: "user-100",
-    status: "pending",
+    guildId: 'guild-1',
+    channelId: 'app-channel-1',
+    createdBy: 'user-100',
+    status: 'pending',
     ...overrides,
   };
 }
 
-describe("archiveAndCloseApplication", () => {
+describe('archiveAndCloseApplication', () => {
   let forumState: FakeForumState;
   let forumChannel: any;
 
@@ -150,14 +150,14 @@ describe("archiveAndCloseApplication", () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  test("happy path — first close: creates thread, saves archive row, deletes channel", async () => {
+  test('happy path — first close: creates thread, saves archive row, deletes channel', async () => {
     const client = makeFakeClient(forumChannel);
     const result: ArchiveApplicationResult = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -165,23 +165,27 @@ describe("archiveAndCloseApplication", () => {
     expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
     expect(fakeRepoState.createCalls).toHaveLength(1);
     expect(fakeRepoState.createCalls[0]).toMatchObject({
-      guildId: "guild-1",
-      createdBy: "user-100",
+      guildId: 'guild-1',
+      createdBy: 'user-100',
       messageId: forumState.threadsCreated[0].id,
     });
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("channel delete refused → archived:true but channelDeleted:false (caller must tell the user)", async () => {
-    fakeVerifiedChannelDelete.mockResolvedValueOnce({ success: false, alreadyGone: false, error: "Missing Permissions" });
+  test('channel delete refused → archived:true but channelDeleted:false (caller must tell the user)', async () => {
+    fakeVerifiedChannelDelete.mockResolvedValueOnce({
+      success: false,
+      alreadyGone: false,
+      error: 'Missing Permissions',
+    });
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -189,27 +193,27 @@ describe("archiveAndCloseApplication", () => {
     expect(result).toEqual({ success: true, archived: true, channelDeleted: false });
   });
 
-  test("re-close append: posts header embed into the existing thread, no new thread", async () => {
-    fakeRepoState.findOneByResult = { messageId: "existing-app-thread" };
+  test('re-close append: posts header embed into the existing thread, no new thread', async () => {
+    fakeRepoState.findOneByResult = { messageId: 'existing-app-thread' };
     const client = makeFakeClient(forumChannel);
     const result = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(forumChannel.threads.create).not.toHaveBeenCalled();
-    expect(forumChannel.threads.fetch).toHaveBeenCalledWith("existing-app-thread", { force: true });
-    const thread = forumState.threadsFetched.get("existing-app-thread");
-    expect(thread.sentMessages[0]).toContain("[embed] 📋");
+    expect(forumChannel.threads.fetch).toHaveBeenCalledWith('existing-app-thread', { force: true });
+    const thread = forumState.threadsFetched.get('existing-app-thread');
+    expect(thread.sentMessages[0]).toContain('[embed] 📋');
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("re-close with a NULL messageId row: creates a thread and repoints (no silent loss)", async () => {
+  test('re-close with a NULL messageId row: creates a thread and repoints (no silent loss)', async () => {
     // Pre-fix, a row with messageId=null matched neither branch: `archived`
     // stayed true and the channel was deleted with the transcript never
     // posted anywhere. It must take the recreate path instead.
@@ -219,9 +223,9 @@ describe("archiveAndCloseApplication", () => {
     const result = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -233,17 +237,17 @@ describe("archiveAndCloseApplication", () => {
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("B1: re-close into a DELETED thread (10003) recreates it, repoints messageId, deletes channel", async () => {
-    fakeRepoState.findOneByResult = { messageId: "deleted-app-thread" };
-    forumState.fetchShouldThrow = Object.assign(new Error("Unknown Channel"), { code: 10003 });
+  test('B1: re-close into a DELETED thread (10003) recreates it, repoints messageId, deletes channel', async () => {
+    fakeRepoState.findOneByResult = { messageId: 'deleted-app-thread' };
+    forumState.fetchShouldThrow = Object.assign(new Error('Unknown Channel'), { code: 10003 });
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -254,17 +258,17 @@ describe("archiveAndCloseApplication", () => {
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("B1: NON-10003 fetch error bubbles — archive fails, no recreate, channel preserved", async () => {
-    fakeRepoState.findOneByResult = { messageId: "existing-app-thread" };
-    forumState.fetchShouldThrow = Object.assign(new Error("Missing Access"), { code: 50001 });
+  test('B1: NON-10003 fetch error bubbles — archive fails, no recreate, channel preserved', async () => {
+    fakeRepoState.findOneByResult = { messageId: 'existing-app-thread' };
+    forumState.fetchShouldThrow = Object.assign(new Error('Missing Access'), { code: 50001 });
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -273,16 +277,16 @@ describe("archiveAndCloseApplication", () => {
     expect(fakeVerifiedChannelDelete).not.toHaveBeenCalled();
   });
 
-  test("B2: forum post failure preserves the channel (no data loss)", async () => {
-    forumState.createShouldThrow = new Error("Discord 50013 — missing permissions");
+  test('B2: forum post failure preserves the channel (no data loss)', async () => {
+    forumState.createShouldThrow = new Error('Discord 50013 — missing permissions');
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -291,16 +295,16 @@ describe("archiveAndCloseApplication", () => {
     expect(fakeRepoState.saveCalls).toHaveLength(0);
   });
 
-  test("transcript fetch failure short-circuits before any forum write or channel delete", async () => {
-    fakeFetchMessages.mockRejectedValue(new Error("Discord API timeout"));
+  test('transcript fetch failure short-circuits before any forum write or channel delete', async () => {
+    fakeFetchMessages.mockRejectedValue(new Error('Discord API timeout'));
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(
       client,
       makeApplication(),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -323,58 +327,58 @@ describe("archiveAndCloseApplication", () => {
   }
 
   test("position resolved from type='position_<id>' → emoji+title in header title, title in Type row", async () => {
-    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: "Moderator", emoji: "🛡️" });
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
     const client = makeFakeClient(forumChannel);
 
     await archiveAndCloseApplication(
       client,
-      makeApplication({ type: "position_7" }),
-      "guild-1",
+      makeApplication({ type: 'position_7' }),
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
-    expect(fakePositionRepo.findOneBy).toHaveBeenCalledWith({ id: 7, guildId: "guild-1" });
+    expect(fakePositionRepo.findOneBy).toHaveBeenCalledWith({ id: 7, guildId: 'guild-1' });
     const header = createdHeader(forumChannel);
-    expect(header.title).toBe("📋 🛡️ Moderator — applicant");
-    expect(header.fields.Type).toBe("Moderator");
+    expect(header.title).toBe('📋 🛡️ Moderator — applicant');
+    expect(header.fields.Type).toBe('Moderator');
   });
 
-  test("orphaned position (row deleted) falls back to the generic Application header — close survives", async () => {
+  test('orphaned position (row deleted) falls back to the generic Application header — close survives', async () => {
     fakePositionRepo.findOneBy.mockResolvedValue(null);
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(
       client,
-      makeApplication({ type: "position_99" }),
-      "guild-1",
+      makeApplication({ type: 'position_99' }),
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
     expect(result.archived).toBe(true);
     const header = createdHeader(forumChannel);
-    expect(header.title).toBe("📋 Application — applicant");
-    expect(header.fields.Type).toBe("Application");
+    expect(header.title).toBe('📋 Application — applicant');
+    expect(header.fields.Type).toBe('Application');
   });
 
   test("position lookup DB error is swallowed (orphan fallback), not thrown from the un-try'd metadata region", async () => {
-    fakePositionRepo.findOneBy.mockRejectedValue(new Error("transient DB error"));
+    fakePositionRepo.findOneBy.mockRejectedValue(new Error('transient DB error'));
     const client = makeFakeClient(forumChannel);
 
     const result = await archiveAndCloseApplication(
       client,
-      makeApplication({ type: "position_7" }),
-      "guild-1",
+      makeApplication({ type: 'position_7' }),
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
     expect(result.archived).toBe(true);
-    expect(createdHeader(forumChannel).title).toBe("📋 Application — applicant");
+    expect(createdHeader(forumChannel).title).toBe('📋 Application — applicant');
   });
 
   test("outcome from the in-memory pre-close status ('accepted' — API approve path)", async () => {
@@ -382,14 +386,14 @@ describe("archiveAndCloseApplication", () => {
 
     await archiveAndCloseApplication(
       client,
-      makeApplication({ status: "accepted" }),
-      "guild-1",
+      makeApplication({ status: 'accepted' }),
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
-    expect(createdHeader(forumChannel).fields.Outcome).toBe("Accepted");
+    expect(createdHeader(forumChannel).fields.Outcome).toBe('Accepted');
   });
 
   test("outcome from the newest decisive statusHistory entry ('denied' — Discord workflow vocabulary)", async () => {
@@ -398,55 +402,137 @@ describe("archiveAndCloseApplication", () => {
     await archiveAndCloseApplication(
       client,
       makeApplication({
-        status: "closed",
+        status: 'closed',
         statusHistory: [
-          { status: "submitted", changedBy: "u1", changedAt: "2026-04-20T10:00:00Z" },
-          { status: "denied", changedBy: "rev-1", changedAt: "2026-04-21T10:00:00Z" },
-          { status: "closed", changedBy: "rev-1", changedAt: "2026-04-22T10:00:00Z" },
+          { status: 'submitted', changedBy: 'u1', changedAt: '2026-04-20T10:00:00Z' },
+          { status: 'denied', changedBy: 'rev-1', changedAt: '2026-04-21T10:00:00Z' },
+          { status: 'closed', changedBy: 'rev-1', changedAt: '2026-04-22T10:00:00Z' },
         ],
       }),
-      "guild-1",
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
-    expect(createdHeader(forumChannel).fields.Outcome).toBe("Rejected");
+    expect(createdHeader(forumChannel).fields.Outcome).toBe('Rejected');
   });
 
-  test("no decisive status anywhere → no Outcome row", async () => {
+  test('no decisive status anywhere → no Outcome row', async () => {
     const client = makeFakeClient(forumChannel);
 
     await archiveAndCloseApplication(
       client,
-      makeApplication({ status: "closed", statusHistory: [] }),
-      "guild-1",
+      makeApplication({ status: 'closed', statusHistory: [] }),
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
     expect(createdHeader(forumChannel).fields.Outcome).toBeUndefined();
   });
 
-  test("reviewedBy resolves to a Reviewed by row; closedBy actor renders Closed by; Application # present", async () => {
+  test('RETRACTED decision is not reported: approved → moved back → closed yields no Outcome', async () => {
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({
+        status: 'closed',
+        statusHistory: [
+          { status: 'submitted', changedBy: 'u1', changedAt: '2026-04-20T10:00:00Z' },
+          { status: 'approved', changedBy: 'rev-1', changedAt: '2026-04-21T10:00:00Z' },
+          { status: 'under-review', changedBy: 'rev-1', changedAt: '2026-04-21T12:00:00Z' }, // retraction
+          { status: 'closed', changedBy: 'rev-1', changedAt: '2026-04-22T10:00:00Z' },
+        ],
+      }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    // The withdrawn 'approved' must NOT resurface as the archived outcome.
+    expect(createdHeader(forumChannel).fields.Outcome).toBeUndefined();
+  });
+
+  test("decision followed only by 'closed' IS reported (the normal accept-then-close flow)", async () => {
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({
+        status: 'closed',
+        statusHistory: [
+          { status: 'approved', changedBy: 'rev-1', changedAt: '2026-04-21T10:00:00Z' },
+          { status: 'closed', changedBy: 'rev-1', changedAt: '2026-04-22T10:00:00Z' },
+        ],
+      }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    expect(createdHeader(forumChannel).fields.Outcome).toBe('Accepted');
+  });
+
+  test("custom workflow status 'constructor' does not leak Object.prototype into the outcome", async () => {
+    const client = makeFakeClient(forumChannel);
+
+    const result = await archiveAndCloseApplication(
+      client,
+      // A guild-defined status id 'constructor' would resolve to the inherited
+      // Object constructor under a naive object lookup and throw in the embed.
+      makeApplication({ status: 'constructor' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    expect(result.archived).toBe(true);
+    expect(createdHeader(forumChannel).fields.Outcome).toBeUndefined();
+  });
+
+  test('reviewer fetch REJECTING degrades to an id-only Reviewed by row — close survives', async () => {
+    const client = makeFakeClient(forumChannel, (id: string) => {
+      if (id === 'rev-1') throw new Error('Unknown User');
+      return { username: 'applicant' };
+    });
+
+    const result = await archiveAndCloseApplication(
+      client,
+      makeApplication({ reviewedBy: 'rev-1' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    expect(result.archived).toBe(true);
+    expect(createdHeader(forumChannel).fields['Reviewed by']).toBe('`rev-1`');
+  });
+
+  test('reviewedBy resolves to a Reviewed by row; closedBy actor renders Closed by; Application # present', async () => {
     const client = makeFakeClient(forumChannel, (id: string) =>
-      id === "rev-1" ? { username: "reviewer" } : { username: "applicant" },
+      id === 'rev-1' ? { username: 'reviewer' } : { username: 'applicant' },
     );
 
     await archiveAndCloseApplication(
       client,
-      makeApplication({ id: 55, reviewedBy: "rev-1" }),
-      "guild-1",
+      makeApplication({ id: 55, reviewedBy: 'rev-1' }),
+      'guild-1',
       makeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
-      { id: "staff-2", username: "closer" },
+      { id: 'staff-2', username: 'closer' },
     );
 
     const { fields } = createdHeader(forumChannel);
-    expect(fields["Reviewed by"]).toBe("reviewer (`rev-1`)");
-    expect(fields["Closed by"]).toBe("closer (`staff-2`)");
-    expect(fields["Application #"]).toBe("55");
+    expect(fields['Reviewed by']).toBe('reviewer (`rev-1`)');
+    expect(fields['Closed by']).toBe('closer (`staff-2`)');
+    expect(fields['Application #']).toBe('55');
   });
 });

--- a/tests/unit/utils/ticket/closeWorkflow.test.ts
+++ b/tests/unit/utils/ticket/closeWorkflow.test.ts
@@ -930,4 +930,75 @@ describe("archiveAndCloseTicket", () => {
     // builtinTypeInfo NOT consulted because customTypeId branch already returned null
     expect(fakeBuiltinTypeInfo).not.toHaveBeenCalled();
   });
+
+  // -------------------------------------------------------------------------
+  // Archival enrichment (v3.16.0): closedBy / Ticket # / SLA header rows
+  // -------------------------------------------------------------------------
+
+  /** Header-embed fields of the first thread created, keyed by name. */
+  function createdHeaderFields(forum: any): Record<string, string> {
+    const embed = forum.threads.create.mock.calls[0][0].message.embeds[0];
+    return Object.fromEntries(embed.data.fields.map((f: any) => [f.name, f.value]));
+  }
+
+  test("closedBy actor (button path: id + username) renders a Closed by row without a user fetch", async () => {
+    const client = makeFakeClient(forumChannel, (id) => ({ username: `resolved-${id}` }));
+    const ticket = makeTicket({ type: "general", id: 42 });
+
+    const result = await archiveAndCloseTicket(
+      client,
+      ticket,
+      "guild-1",
+      makeFakeChannel(),
+      "forum-archive-1",
+      deps,
+      { id: "staff-9", username: "closer" },
+    );
+
+    expect(result.archived).toBe(true);
+    const fields = createdHeaderFields(forumChannel);
+    expect(fields["Closed by"]).toBe("closer (`staff-9`)");
+    expect(fields["Ticket #"]).toBe("42");
+    // Username was supplied — no extra fetch for the closer
+    const fetchedIds = client.users.fetch.mock.calls.map((c: any[]) => c[0]);
+    expect(fetchedIds).not.toContain("staff-9");
+  });
+
+  test("closedBy actor (API path: id only) resolves the username via client.users.fetch", async () => {
+    const client = makeFakeClient(forumChannel, (id) => ({ username: `resolved-${id}` }));
+    const ticket = makeTicket({ type: "general" });
+
+    await archiveAndCloseTicket(client, ticket, "guild-1", makeFakeChannel(), "forum-archive-1", deps, {
+      id: "dash-actor-1",
+    });
+
+    const fields = createdHeaderFields(forumChannel);
+    expect(fields["Closed by"]).toBe("resolved-dash-actor-1 (`dash-actor-1`)");
+  });
+
+  test("firstResponseAt + slaBreached render a First response row with the breach badge", async () => {
+    const client = makeFakeClient(forumChannel, () => ({ username: "creator" }));
+    const ticket = makeTicket({
+      type: "general",
+      firstResponseAt: new Date("2026-04-20T11:30:00Z"),
+      slaBreached: true,
+    });
+
+    await archiveAndCloseTicket(client, ticket, "guild-1", makeFakeChannel(), "forum-archive-1", deps);
+
+    const fields = createdHeaderFields(forumChannel);
+    expect(fields["First response"]).toMatch(/^<t:\d+:f>\n⚠️ SLA breached$/);
+  });
+
+  test("no closedBy / no SLA data → the enrichment rows are absent (old archives unchanged)", async () => {
+    const client = makeFakeClient(forumChannel, () => ({ username: "creator" }));
+    const ticket = makeTicket({ type: "general" });
+
+    await archiveAndCloseTicket(client, ticket, "guild-1", makeFakeChannel(), "forum-archive-1", deps);
+
+    const fields = createdHeaderFields(forumChannel);
+    expect(fields["Closed by"]).toBeUndefined();
+    expect(fields["First response"]).toBeUndefined();
+    expect(fields["Ticket #"]).toBe("1"); // makeTicket default id — always present
+  });
 });

--- a/tests/unit/utils/ticket/closeWorkflow.test.ts
+++ b/tests/unit/utils/ticket/closeWorkflow.test.ts
@@ -19,24 +19,15 @@
  *   - Orphaned customTypeId (resolveTicketType returns null)
  */
 
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-} from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from 'bun:test';
 // SUT imported statically: ALL deps (incl. the repo) are injected via the
 // `deps` argument below, so there is no mock.module() and no getRepository
 // patch — import order and cross-file module state are irrelevant.
 import {
-  archiveAndCloseTicket,
   type ArchiveTicketResult,
+  archiveAndCloseTicket,
   type CloseWorkflowDeps,
-} from "../../../../src/utils/ticket/closeWorkflow";
+} from '../../../../src/utils/ticket/closeWorkflow';
 
 // ---------------------------------------------------------------------------
 // Fakes — injected into the SUT via `deps` (built below), except the repo
@@ -80,7 +71,7 @@ const fakeVerifiedChannelDelete = jest.fn(async () => ({
 
 const fakeFetchMessages = jest.fn(async () => [] as any[]);
 
-const fakeEnsureForumTag = jest.fn(async () => "tag-123");
+const fakeEnsureForumTag = jest.fn(async () => 'tag-123');
 const fakeApplyForumTags = jest.fn(async (_forum: unknown, _threadId: unknown, tags: string[]) => tags);
 
 const fakeResolveTicketType = jest.fn();
@@ -92,33 +83,22 @@ const fakeResolveTicketType = jest.fn();
 const fakeBuiltinTypeInfo = jest
   .fn()
   .mockImplementation((id: string) =>
-    (BUILTIN_TICKET_TYPE_IDS as readonly string[]).includes(id)
-      ? BUILTIN_TYPE_BY_ID[id]
-      : null,
+    (BUILTIN_TICKET_TYPE_IDS as readonly string[]).includes(id) ? BUILTIN_TYPE_BY_ID[id] : null,
   );
 // Re-export the real BUILTIN_* tables alongside the fakes so other test
 // files (e.g. builtinTypes.test.ts) that import this module still see the
 // real data. mock.module() is process-global once installed, so leaving
 // out exports here makes them `undefined` everywhere.
-const BUILTIN_TICKET_TYPE_IDS = [
-  "18_verify",
-  "ban_appeal",
-  "player_report",
-  "bug_report",
-  "other",
-] as const;
+const BUILTIN_TICKET_TYPE_IDS = ['18_verify', 'ban_appeal', 'player_report', 'bug_report', 'other'] as const;
 const BUILTIN_TYPES = [
-  { typeId: "18_verify", displayName: "18+ Verification", emoji: "🔞" },
-  { typeId: "ban_appeal", displayName: "Ban Appeal", emoji: "⚖️" },
-  { typeId: "player_report", displayName: "Player Report", emoji: "📢" },
-  { typeId: "bug_report", displayName: "Bug Report", emoji: "🐛" },
-  { typeId: "other", displayName: "Other", emoji: "❓" },
+  { typeId: '18_verify', displayName: '18+ Verification', emoji: '🔞' },
+  { typeId: 'ban_appeal', displayName: 'Ban Appeal', emoji: '⚖️' },
+  { typeId: 'player_report', displayName: 'Player Report', emoji: '📢' },
+  { typeId: 'bug_report', displayName: 'Bug Report', emoji: '🐛' },
+  { typeId: 'other', displayName: 'Other', emoji: '❓' },
 ];
-const BUILTIN_TYPE_BY_ID = Object.fromEntries(
-  BUILTIN_TYPES.map((t) => [t.typeId, t]),
-);
-const realIsBuiltinTicketType = (id: string) =>
-  (BUILTIN_TICKET_TYPE_IDS as readonly string[]).includes(id);
+const BUILTIN_TYPE_BY_ID = Object.fromEntries(BUILTIN_TYPES.map(t => [t.typeId, t]));
+const realIsBuiltinTicketType = (id: string) => (BUILTIN_TICKET_TYPE_IDS as readonly string[]).includes(id);
 
 // EVERY seam dependency is INJECTED directly via archiveAndCloseTicket's `deps`
 // parameter — including the archived-ticket repo. We deliberately use neither
@@ -149,10 +129,7 @@ interface FakeThreadState {
   sentMessages: string[];
 }
 
-function makeFakeThread(
-  id = "new-thread-1",
-  sendError?: Error,
-): FakeThreadState & { send: any } {
+function makeFakeThread(id = 'new-thread-1', sendError?: Error): FakeThreadState & { send: any } {
   const state: FakeThreadState = { id, sentMessages: [] };
   return {
     ...state,
@@ -160,7 +137,7 @@ function makeFakeThread(
       if (sendError) throw sendError;
       // Embed-only sends (header cards) are recorded as a tagged title line so
       // assertions can distinguish them from transcript text chunks.
-      state.sentMessages.push(content ?? `[embed] ${embeds?.[0]?.data?.title ?? ""}`);
+      state.sentMessages.push(content ?? `[embed] ${embeds?.[0]?.data?.title ?? ''}`);
       return { id: `${id}-msg-${state.sentMessages.length}` };
     }),
   };
@@ -179,10 +156,7 @@ function makeFakeForumChannel(state: FakeForumState) {
     threads: {
       create: jest.fn(async ({ name }: { name: string }) => {
         if (state.createShouldThrow) throw state.createShouldThrow;
-        const thread = makeFakeThread(
-          `thread-for-${name}`,
-          state.threadSendShouldThrow,
-        );
+        const thread = makeFakeThread(`thread-for-${name}`, state.threadSendShouldThrow);
         state.threadsCreated.push(thread);
         return thread;
       }),
@@ -198,12 +172,9 @@ function makeFakeForumChannel(state: FakeForumState) {
   };
 }
 
-function makeFakeClient(
-  forumChannel: any,
-  userResolver: (id: string) => any = () => null,
-) {
+function makeFakeClient(forumChannel: any, userResolver: (id: string) => any = () => null) {
   return {
-    user: { id: "bot-client-id" },
+    user: { id: 'bot-client-id' },
     channels: {
       fetch: jest.fn(async (_id: string) => forumChannel),
     },
@@ -213,20 +184,20 @@ function makeFakeClient(
   } as any;
 }
 
-function makeFakeChannel(id = "ticket-channel-1") {
+function makeFakeChannel(id = 'ticket-channel-1') {
   return {
     id,
-    createdAt: new Date("2026-04-20T10:00:00Z"),
+    createdAt: new Date('2026-04-20T10:00:00Z'),
   } as any;
 }
 
 function makeTicket(overrides: Partial<any> = {}): any {
   return {
     id: 1,
-    guildId: "guild-1",
-    channelId: "ticket-channel-1",
+    guildId: 'guild-1',
+    channelId: 'ticket-channel-1',
     messageId: null,
-    createdBy: "user-100",
+    createdBy: 'user-100',
     type: null,
     customTypeId: null,
     isEmailTicket: false,
@@ -243,7 +214,7 @@ function makeTicket(overrides: Partial<any> = {}): any {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("archiveAndCloseTicket", () => {
+describe('archiveAndCloseTicket', () => {
   let forumState: FakeForumState;
   let forumChannel: any;
 
@@ -262,7 +233,7 @@ describe("archiveAndCloseTicket", () => {
     fakeFetchMessages.mockClear();
     fakeFetchMessages.mockImplementation(async () => []);
     fakeEnsureForumTag.mockClear();
-    fakeEnsureForumTag.mockImplementation(async () => "tag-123");
+    fakeEnsureForumTag.mockImplementation(async () => 'tag-123');
     fakeApplyForumTags.mockClear();
     // New contract: returns the tags actually applied (callers only persist
     // tags that reached the thread). Default = everything applied.
@@ -284,25 +255,25 @@ describe("archiveAndCloseTicket", () => {
     jest.clearAllMocks();
   });
 
-  test("happy path — custom type, first close: creates new forum thread + saves archive + deletes channel", async () => {
+  test('happy path — custom type, first close: creates new forum thread + saves archive + deletes channel', async () => {
     fakeResolveTicketType.mockResolvedValue({
-      typeId: "support",
-      displayName: "Support",
-      emoji: "🛠️",
+      typeId: 'support',
+      displayName: 'Support',
+      emoji: '🛠️',
       isBuiltin: false,
     });
-    const client = makeFakeClient(forumChannel, (id) => ({
+    const client = makeFakeClient(forumChannel, id => ({
       username: `user-${id}`,
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ customTypeId: "support", type: "support" });
+    const ticket = makeTicket({ customTypeId: 'support', type: 'support' });
 
     const result: ArchiveTicketResult = await archiveAndCloseTicket(
       client,
       ticket,
-      "guild-1",
+      'guild-1',
       channel,
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -311,25 +282,18 @@ describe("archiveAndCloseTicket", () => {
     expect(forumState.threadsCreated).toHaveLength(1);
     // Header embed is the initial create message; transcript chunks (if any)
     // are follow-ups.
-    expect(
-      forumChannel.threads.create.mock.calls[0][0].message.embeds[0].data.title,
-    ).toContain("Support");
+    expect(forumChannel.threads.create.mock.calls[0][0].message.embeds[0].data.title).toContain('Support');
     // Forum tag ensured + applied
-    expect(fakeEnsureForumTag).toHaveBeenCalledWith(
-      forumChannel,
-      "support",
-      "Support",
-      "🛠️",
-    );
+    expect(fakeEnsureForumTag).toHaveBeenCalledWith(forumChannel, 'support', 'Support', '🛠️');
     expect(fakeApplyForumTags).toHaveBeenCalledTimes(1);
     // Archive row created and saved
     expect(fakeRepoState.createCalls).toHaveLength(1);
     expect(fakeRepoState.createCalls[0]).toMatchObject({
-      guildId: "guild-1",
-      createdBy: "user-100",
-      ticketType: "support",
-      customTypeId: "support",
-      forumTagIds: ["tag-123"],
+      guildId: 'guild-1',
+      createdBy: 'user-100',
+      ticketType: 'support',
+      customTypeId: 'support',
+      forumTagIds: ['tag-123'],
       isEmailTicket: false,
     });
     expect(fakeRepoState.saveCalls).toHaveLength(1);
@@ -337,74 +301,55 @@ describe("archiveAndCloseTicket", () => {
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("happy path — builtin type, first close: uses builtinTypeInfo for display", async () => {
+  test('happy path — builtin type, first close: uses builtinTypeInfo for display', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General Inquiry",
-      emoji: "💬",
+      typeId: 'general',
+      displayName: 'General Inquiry',
+      emoji: '💬',
     });
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(fakeResolveTicketType).not.toHaveBeenCalled();
-    expect(fakeBuiltinTypeInfo).toHaveBeenCalledWith("general");
-    expect(fakeEnsureForumTag).toHaveBeenCalledWith(
-      forumChannel,
-      "general",
-      "General Inquiry",
-      "💬",
-    );
+    expect(fakeBuiltinTypeInfo).toHaveBeenCalledWith('general');
+    expect(fakeEnsureForumTag).toHaveBeenCalledWith(forumChannel, 'general', 'General Inquiry', '💬');
     expect(fakeRepoState.createCalls[0]).toMatchObject({
-      ticketType: "general",
+      ticketType: 'general',
     });
   });
 
-  test("happy path — email ticket, first close: uses emailSender + emailSenderName + emailSubject", async () => {
+  test('happy path — email ticket, first close: uses emailSender + emailSenderName + emailSubject', async () => {
     fakeBuiltinTypeInfo.mockReturnValue(null);
     const client = makeFakeClient(forumChannel, () => null);
     const channel = makeFakeChannel();
     const ticket = makeTicket({
       isEmailTicket: true,
-      emailSender: "alice@example.com",
-      emailSenderName: "Alice",
-      emailSubject: "Help needed with X",
+      emailSender: 'alice@example.com',
+      emailSenderName: 'Alice',
+      emailSubject: 'Help needed with X',
     });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // Email ticket lookup is scoped to the EMAIL archive namespace
     // (isEmailTicket:true + emailSender) — never the createdBy namespace.
     expect(fakeRepo.findOneBy).toHaveBeenCalledWith({
-      guildId: "guild-1",
+      guildId: 'guild-1',
       isEmailTicket: true,
-      emailSender: "alice@example.com",
+      emailSender: 'alice@example.com',
     });
     expect(fakeRepoState.createCalls[0]).toMatchObject({
       isEmailTicket: true,
-      emailSender: "alice@example.com",
-      emailSenderName: "Alice",
-      emailSubject: "Help needed with X",
+      emailSender: 'alice@example.com',
+      emailSenderName: 'Alice',
+      emailSubject: 'Help needed with X',
     });
   });
 
@@ -414,164 +359,126 @@ describe("archiveAndCloseTicket", () => {
     const channel = makeFakeChannel();
     const ticket = makeTicket({
       isEmailTicket: true,
-      emailSender: "verbose@example.com",
-      emailSenderName: "N".repeat(150),
-      emailSubject: "hi",
+      emailSender: 'verbose@example.com',
+      emailSenderName: 'N'.repeat(150),
+      emailSubject: 'hi',
     });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     const createdName = forumChannel.threads.create.mock.calls[0][0].name;
     expect(createdName).toHaveLength(100);
   });
 
-  test("regression: a normal ticket queries the createdBy namespace with isEmailTicket:false (never an email-import archive)", async () => {
+  test('regression: a normal ticket queries the createdBy namespace with isEmailTicket:false (never an email-import archive)', async () => {
     // The reported prod bug: an email-import archive's createdBy is the
     // importing admin. A normal ticket the admin opens must NOT match it —
     // the lookup is scoped to isEmailTicket:false so the two archive
     // namespaces can never cross-contaminate.
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
-    const client = makeFakeClient(forumChannel, () => ({ username: "admin" }));
+    const client = makeFakeClient(forumChannel, () => ({ username: 'admin' }));
     const channel = makeFakeChannel();
     const ticket = makeTicket({
-      type: "general",
-      createdBy: "admin-id",
+      type: 'general',
+      createdBy: 'admin-id',
       isEmailTicket: false,
     });
 
-    await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(fakeRepo.findOneBy).toHaveBeenCalledWith({
-      guildId: "guild-1",
+      guildId: 'guild-1',
       isEmailTicket: false,
-      createdBy: "admin-id",
+      createdBy: 'admin-id',
     });
   });
 
-  test("re-close into existing archive: appends header embed + posts to existing thread", async () => {
+  test('re-close into existing archive: appends header embed + posts to existing thread', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
     fakeRepoState.findOneByResult = {
-      messageId: "existing-thread-9",
-      forumTagIds: ["tag-123"],
+      messageId: 'existing-thread-9',
+      forumTagIds: ['tag-123'],
     };
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // No NEW thread created — existing one fetched (force:true bypasses cache)
     expect(forumChannel.threads.create).not.toHaveBeenCalled();
-    expect(forumChannel.threads.fetch).toHaveBeenCalledWith(
-      "existing-thread-9",
-      { force: true },
-    );
-    const existingThread = forumState.threadsFetched.get("existing-thread-9");
+    expect(forumChannel.threads.fetch).toHaveBeenCalledWith('existing-thread-9', { force: true });
+    const existingThread = forumState.threadsFetched.get('existing-thread-9');
     expect(existingThread.sentMessages.length).toBeGreaterThan(0);
     // First sent message is the header embed — the visual divider between closes
-    expect(existingThread.sentMessages[0]).toContain("[embed] 🎫");
+    expect(existingThread.sentMessages[0]).toContain('[embed] 🎫');
     // Tag already in existing array — no extra applyForumTags or save
     expect(fakeApplyForumTags).not.toHaveBeenCalled();
     expect(fakeRepoState.saveCalls).toHaveLength(0);
   });
 
-  test("re-close: new tag accumulates and saves the existing archive row", async () => {
+  test('re-close: new tag accumulates and saves the existing archive row', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "bug",
-      displayName: "Bug Report",
-      emoji: "🐛",
+      typeId: 'bug',
+      displayName: 'Bug Report',
+      emoji: '🐛',
     });
-    fakeEnsureForumTag.mockResolvedValue("tag-bug");
+    fakeEnsureForumTag.mockResolvedValue('tag-bug');
     fakeRepoState.findOneByResult = {
-      messageId: "existing-thread-9",
-      forumTagIds: ["tag-old-support"],
+      messageId: 'existing-thread-9',
+      forumTagIds: ['tag-old-support'],
     };
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "bug" });
+    const ticket = makeTicket({ type: 'bug' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(fakeApplyForumTags).toHaveBeenCalledTimes(1);
-    expect(fakeApplyForumTags).toHaveBeenCalledWith(
-      forumChannel,
-      "existing-thread-9",
-      ["tag-old-support", "tag-bug"],
-    );
+    expect(fakeApplyForumTags).toHaveBeenCalledWith(forumChannel, 'existing-thread-9', ['tag-old-support', 'tag-bug']);
     // Existing archive row saved with merged tags
     expect(fakeRepoState.saveCalls).toHaveLength(1);
-    expect(fakeRepoState.saveCalls[0].forumTagIds).toEqual([
-      "tag-old-support",
-      "tag-bug",
-    ]);
+    expect(fakeRepoState.saveCalls[0].forumTagIds).toEqual(['tag-old-support', 'tag-bug']);
   });
 
-  test("re-close: tag dropped by the 5-tag cap is NOT persisted (retryable next re-close)", async () => {
+  test('re-close: tag dropped by the 5-tag cap is NOT persisted (retryable next re-close)', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "bug",
-      displayName: "Bug Report",
-      emoji: "🐛",
+      typeId: 'bug',
+      displayName: 'Bug Report',
+      emoji: '🐛',
     });
-    fakeEnsureForumTag.mockResolvedValue("tag-bug");
+    fakeEnsureForumTag.mockResolvedValue('tag-bug');
     // applyForumTags reports the new tag did NOT reach the thread (cap/failure).
-    fakeApplyForumTags.mockResolvedValue(["manual-1", "manual-2", "manual-3", "manual-4", "tag-old-support"]);
+    fakeApplyForumTags.mockResolvedValue(['manual-1', 'manual-2', 'manual-3', 'manual-4', 'tag-old-support']);
     fakeRepoState.findOneByResult = {
-      messageId: "existing-thread-9",
-      forumTagIds: ["tag-old-support"],
+      messageId: 'existing-thread-9',
+      forumTagIds: ['tag-old-support'],
     };
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
 
     const result = await archiveAndCloseTicket(
       client,
-      makeTicket({ type: "bug" }),
-      "guild-1",
+      makeTicket({ type: 'bug' }),
+      'guild-1',
       makeFakeChannel(),
-      "forum-archive-1",
+      'forum-archive-1',
       deps,
     );
 
@@ -582,26 +489,19 @@ describe("archiveAndCloseTicket", () => {
     expect(fakeRepoState.saveCalls).toHaveLength(0);
   });
 
-  test("transcript fetch failure: short-circuits before any forum write or channel delete", async () => {
-    fakeFetchMessages.mockRejectedValue(new Error("Discord API timeout"));
+  test('transcript fetch failure: short-circuits before any forum write or channel delete', async () => {
+    fakeFetchMessages.mockRejectedValue(new Error('Discord API timeout'));
     const client = makeFakeClient(forumChannel);
     const channel = makeFakeChannel();
     const ticket = makeTicket();
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({
       success: false,
       archived: false,
       transcriptFailed: true,
-      error: "Transcript fetch failed",
+      error: 'Transcript fetch failed',
     });
     // Critical: no forum side effects, no channel delete
     expect(forumChannel.threads.create).not.toHaveBeenCalled();
@@ -610,29 +510,20 @@ describe("archiveAndCloseTicket", () => {
     expect(fakeVerifiedChannelDelete).not.toHaveBeenCalled();
   });
 
-  test("forum post failure: archive fails, channel PRESERVED for retry (v3.2.1 — no data loss)", async () => {
+  test('forum post failure: archive fails, channel PRESERVED for retry (v3.2.1 — no data loss)', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
-    forumState.createShouldThrow = new Error(
-      "Discord 50013 — missing permissions on forum",
-    );
+    forumState.createShouldThrow = new Error('Discord 50013 — missing permissions on forum');
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     // Archive failed → honest failure; the caller reverts the ticket status.
     expect(result).toEqual({ success: false, archived: false });
@@ -644,17 +535,17 @@ describe("archiveAndCloseTicket", () => {
     expect(fakeRepoState.saveCalls).toHaveLength(0);
   });
 
-  test("first-close chunk-send failure: archive row was already SAVED (retry appends, no orphan/duplicate)", async () => {
+  test('first-close chunk-send failure: archive row was already SAVED (retry appends, no orphan/duplicate)', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
     // The thread is created, but a follow-up chunk send throws.
     fakeFetchMessages.mockResolvedValue([
       {
-        author: { username: "u", id: "1", bot: false },
-        content: "x",
+        author: { username: 'u', id: '1', bot: false },
+        content: 'x',
         timestamp: new Date(),
         attachments: [],
         embeds: [],
@@ -664,23 +555,14 @@ describe("archiveAndCloseTicket", () => {
         hasOnlyComponents: false,
       },
     ]);
-    forumState.threadSendShouldThrow = new Error(
-      "Discord 500 — chunk send failed",
-    );
+    forumState.threadSendShouldThrow = new Error('Discord 500 — chunk send failed');
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: false, archived: false });
     // The thread was created AND the archive row was persisted BEFORE the chunk
@@ -688,40 +570,31 @@ describe("archiveAndCloseTicket", () => {
     // this thread and creating a duplicate.
     expect(forumState.threadsCreated).toHaveLength(1);
     expect(fakeRepoState.saveCalls).toHaveLength(1);
-    expect(fakeRepoState.saveCalls[0].messageId).toBe(
-      forumState.threadsCreated[0].id,
-    );
+    expect(fakeRepoState.saveCalls[0].messageId).toBe(forumState.threadsCreated[0].id);
     // Channel preserved (archive failed).
     expect(fakeVerifiedChannelDelete).not.toHaveBeenCalled();
   });
 
-  test("re-close into a DELETED thread (10003): recreates it, repoints messageId, channel deleted", async () => {
+  test('re-close into a DELETED thread (10003): recreates it, repoints messageId, channel deleted', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
     fakeRepoState.findOneByResult = {
-      messageId: "deleted-thread-1",
-      forumTagIds: ["tag-old"],
+      messageId: 'deleted-thread-1',
+      forumTagIds: ['tag-old'],
     };
-    forumState.fetchShouldThrow = Object.assign(new Error("Unknown Channel"), {
+    forumState.fetchShouldThrow = Object.assign(new Error('Unknown Channel'), {
       code: 10003,
     });
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // A replacement thread was created (the deleted one is unrecoverable).
@@ -730,74 +603,58 @@ describe("archiveAndCloseTicket", () => {
     expect(fakeRepoState.saveCalls).toHaveLength(1);
     const saved = fakeRepoState.saveCalls[0];
     expect(saved.messageId).toBe(forumState.threadsCreated[0].id);
-    expect(saved.forumTagIds).toEqual(["tag-old", "tag-123"]);
+    expect(saved.forumTagIds).toEqual(['tag-old', 'tag-123']);
     // Recovery succeeded → channel deleted as normal.
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("re-close with a NULL messageId row: creates a thread and repoints (no silent loss)", async () => {
+  test('re-close with a NULL messageId row: creates a thread and repoints (no silent loss)', async () => {
     // Pre-fix, a row with messageId=null matched neither branch: `archived`
     // stayed true and the channel was deleted with the transcript never
     // posted anywhere. It must take the recreate path instead.
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
     fakeRepoState.findOneByResult = { messageId: null, forumTagIds: [] };
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(forumChannel.threads.fetch).not.toHaveBeenCalled();
     expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
     expect(fakeRepoState.saveCalls).toHaveLength(1);
-    expect(fakeRepoState.saveCalls[0].messageId).toBe(
-      forumState.threadsCreated[0].id,
-    );
+    expect(fakeRepoState.saveCalls[0].messageId).toBe(forumState.threadsCreated[0].id);
     // Transcript landed in the new thread (header embed + at least one chunk).
     expect(forumState.threadsCreated[0].sentMessages.length).toBeGreaterThan(0);
   });
 
-  test("re-close where thread fetch fails NON-10003: bubbles, archive fails, channel preserved", async () => {
+  test('re-close where thread fetch fails NON-10003: bubbles, archive fails, channel preserved', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
     fakeRepoState.findOneByResult = {
-      messageId: "existing-thread-9",
+      messageId: 'existing-thread-9',
       forumTagIds: [],
     };
-    forumState.fetchShouldThrow = Object.assign(new Error("Missing Access"), {
+    forumState.fetchShouldThrow = Object.assign(new Error('Missing Access'), {
       code: 50001,
     });
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: false, archived: false });
     // We must NOT recreate — a non-10003 error doesn't prove the thread is gone,
@@ -806,10 +663,10 @@ describe("archiveAndCloseTicket", () => {
     expect(fakeVerifiedChannelDelete).not.toHaveBeenCalled();
   });
 
-  test("channel delete: already-gone counts as success (Discord 10003)", async () => {
+  test('channel delete: already-gone counts as success (Discord 10003)', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
     fakeVerifiedChannelDelete.mockResolvedValue({
@@ -817,49 +674,35 @@ describe("archiveAndCloseTicket", () => {
       alreadyGone: true,
     });
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     expect(fakeVerifiedChannelDelete).toHaveBeenCalledTimes(1);
   });
 
-  test("channel delete: hard failure logged but workflow still returns success: true", async () => {
+  test('channel delete: hard failure logged but workflow still returns success: true', async () => {
     fakeBuiltinTypeInfo.mockReturnValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
     });
     fakeVerifiedChannelDelete.mockResolvedValue({
       success: false,
       alreadyGone: false,
-      error: "Discord 50013 — missing permissions",
+      error: 'Discord 50013 — missing permissions',
     });
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ type: "general" });
+    const ticket = makeTicket({ type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     // Workflow returns success: true regardless — channel delete failure is logged,
     // not propagated. The archive succeeded; the orphaned channel is a Discord-side
@@ -868,61 +711,44 @@ describe("archiveAndCloseTicket", () => {
     expect(result).toEqual({ success: true, archived: true, channelDeleted: false });
   });
 
-  test("orphaned customTypeId (resolveTicketType returns null): falls back to default title", async () => {
+  test('orphaned customTypeId (resolveTicketType returns null): falls back to default title', async () => {
     fakeResolveTicketType.mockResolvedValue(null);
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
     const ticket = makeTicket({
-      customTypeId: "deleted-type-id",
-      type: "support",
+      customTypeId: 'deleted-type-id',
+      type: 'support',
     });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
-    expect(fakeResolveTicketType).toHaveBeenCalledWith(
-      "guild-1",
-      "deleted-type-id",
-    );
+    expect(fakeResolveTicketType).toHaveBeenCalledWith('guild-1', 'deleted-type-id');
     // Without resolved type info, no tag is ensured
     expect(fakeEnsureForumTag).not.toHaveBeenCalled();
     // Archive row still created with the (raw) ticket.type value
     expect(fakeRepoState.createCalls[0]).toMatchObject({
-      ticketType: "support",
-      customTypeId: "deleted-type-id",
+      ticketType: 'support',
+      customTypeId: 'deleted-type-id',
     });
   });
 
-  test("customTypeId resolved as builtin: returns null (matches isBuiltin guard) so no tag ensured", async () => {
+  test('customTypeId resolved as builtin: returns null (matches isBuiltin guard) so no tag ensured', async () => {
     fakeResolveTicketType.mockResolvedValue({
-      typeId: "general",
-      displayName: "General",
+      typeId: 'general',
+      displayName: 'General',
       emoji: null,
       isBuiltin: true,
     });
     const client = makeFakeClient(forumChannel, () => ({
-      username: "creator",
+      username: 'creator',
     }));
     const channel = makeFakeChannel();
-    const ticket = makeTicket({ customTypeId: "general", type: "general" });
+    const ticket = makeTicket({ customTypeId: 'general', type: 'general' });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      channel,
-      "forum-archive-1",
-      deps,
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', channel, 'forum-archive-1', deps);
 
     expect(result).toEqual({ success: true, archived: true, channelDeleted: true });
     // Builtin fallback intentionally returns null — no tag ensured
@@ -941,64 +767,78 @@ describe("archiveAndCloseTicket", () => {
     return Object.fromEntries(embed.data.fields.map((f: any) => [f.name, f.value]));
   }
 
-  test("closedBy actor (button path: id + username) renders a Closed by row without a user fetch", async () => {
-    const client = makeFakeClient(forumChannel, (id) => ({ username: `resolved-${id}` }));
-    const ticket = makeTicket({ type: "general", id: 42 });
+  test('closedBy actor (button path: id + username) renders a Closed by row without a user fetch', async () => {
+    const client = makeFakeClient(forumChannel, id => ({ username: `resolved-${id}` }));
+    const ticket = makeTicket({ type: 'general', id: 42 });
 
-    const result = await archiveAndCloseTicket(
-      client,
-      ticket,
-      "guild-1",
-      makeFakeChannel(),
-      "forum-archive-1",
-      deps,
-      { id: "staff-9", username: "closer" },
-    );
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', makeFakeChannel(), 'forum-archive-1', deps, {
+      id: 'staff-9',
+      username: 'closer',
+    });
 
     expect(result.archived).toBe(true);
     const fields = createdHeaderFields(forumChannel);
-    expect(fields["Closed by"]).toBe("closer (`staff-9`)");
-    expect(fields["Ticket #"]).toBe("42");
+    expect(fields['Closed by']).toBe('closer (`staff-9`)');
+    expect(fields['Ticket #']).toBe('42');
     // Username was supplied — no extra fetch for the closer
     const fetchedIds = client.users.fetch.mock.calls.map((c: any[]) => c[0]);
-    expect(fetchedIds).not.toContain("staff-9");
+    expect(fetchedIds).not.toContain('staff-9');
   });
 
-  test("closedBy actor (API path: id only) resolves the username via client.users.fetch", async () => {
-    const client = makeFakeClient(forumChannel, (id) => ({ username: `resolved-${id}` }));
-    const ticket = makeTicket({ type: "general" });
+  test('closedBy actor (API path: id only) resolves the username via client.users.fetch', async () => {
+    const client = makeFakeClient(forumChannel, id => ({ username: `resolved-${id}` }));
+    const ticket = makeTicket({ type: 'general' });
 
-    await archiveAndCloseTicket(client, ticket, "guild-1", makeFakeChannel(), "forum-archive-1", deps, {
-      id: "dash-actor-1",
+    await archiveAndCloseTicket(client, ticket, 'guild-1', makeFakeChannel(), 'forum-archive-1', deps, {
+      id: 'dash-actor-1',
     });
 
     const fields = createdHeaderFields(forumChannel);
-    expect(fields["Closed by"]).toBe("resolved-dash-actor-1 (`dash-actor-1`)");
+    expect(fields['Closed by']).toBe('resolved-dash-actor-1 (`dash-actor-1`)');
   });
 
-  test("firstResponseAt + slaBreached render a First response row with the breach badge", async () => {
-    const client = makeFakeClient(forumChannel, () => ({ username: "creator" }));
+  test('closer fetch REJECTING (deleted user / API outage) degrades to an id-only row — close survives', async () => {
+    // The metadata region sits outside the workflow's try blocks (the v3.14.2
+    // bug class): a rejected fetch must be swallowed by the .catch seam, never
+    // thrown — otherwise every API-triggered close by a deleted dashboard
+    // actor would strand the ticket 'closed' with a live channel.
+    const client = makeFakeClient(forumChannel, id => {
+      if (id === 'dash-actor-1') throw new Error('Unknown User');
+      return { username: `resolved-${id}` };
+    });
+    const ticket = makeTicket({ type: 'general' });
+
+    const result = await archiveAndCloseTicket(client, ticket, 'guild-1', makeFakeChannel(), 'forum-archive-1', deps, {
+      id: 'dash-actor-1',
+    });
+
+    expect(result.archived).toBe(true);
+    expect(createdHeaderFields(forumChannel)['Closed by']).toBe('`dash-actor-1`');
+  });
+
+  test('firstResponseAt + slaBreached render a First response row with the breach badge', async () => {
+    const client = makeFakeClient(forumChannel, () => ({ username: 'creator' }));
     const ticket = makeTicket({
-      type: "general",
-      firstResponseAt: new Date("2026-04-20T11:30:00Z"),
+      type: 'general',
+      firstResponseAt: new Date('2026-04-20T11:30:00Z'),
       slaBreached: true,
     });
 
-    await archiveAndCloseTicket(client, ticket, "guild-1", makeFakeChannel(), "forum-archive-1", deps);
+    await archiveAndCloseTicket(client, ticket, 'guild-1', makeFakeChannel(), 'forum-archive-1', deps);
 
     const fields = createdHeaderFields(forumChannel);
-    expect(fields["First response"]).toMatch(/^<t:\d+:f>\n⚠️ SLA breached$/);
+    expect(fields['First response']).toMatch(/^<t:\d+:f>\n⚠️ SLA breached$/);
   });
 
-  test("no closedBy / no SLA data → the enrichment rows are absent (old archives unchanged)", async () => {
-    const client = makeFakeClient(forumChannel, () => ({ username: "creator" }));
-    const ticket = makeTicket({ type: "general" });
+  test('no closedBy / no SLA data → the enrichment rows are absent (old archives unchanged)', async () => {
+    const client = makeFakeClient(forumChannel, () => ({ username: 'creator' }));
+    const ticket = makeTicket({ type: 'general' });
 
-    await archiveAndCloseTicket(client, ticket, "guild-1", makeFakeChannel(), "forum-archive-1", deps);
+    await archiveAndCloseTicket(client, ticket, 'guild-1', makeFakeChannel(), 'forum-archive-1', deps);
 
     const fields = createdHeaderFields(forumChannel);
-    expect(fields["Closed by"]).toBeUndefined();
-    expect(fields["First response"]).toBeUndefined();
-    expect(fields["Ticket #"]).toBe("1"); // makeTicket default id — always present
+    expect(fields['Closed by']).toBeUndefined();
+    expect(fields['First response']).toBeUndefined();
+    expect(fields['Ticket #']).toBe('1'); // makeTicket default id — always present
   });
 });

--- a/tests/unit/utils/ticket/transcriptBuilder.test.ts
+++ b/tests/unit/utils/ticket/transcriptBuilder.test.ts
@@ -121,6 +121,80 @@ describe("buildHeaderData()", () => {
   });
 });
 
+describe("buildHeaderData() enrichment rows (v3.16.0)", () => {
+  const byName = (header: ReturnType<typeof buildHeaderData>) =>
+    Object.fromEntries(header.fields.map((f) => [f.name, f.value]));
+
+  test("bare metadata renders NO enrichment rows (absent data shows nothing)", () => {
+    const fields = byName(buildHeaderData(META, 1, 0));
+    for (const name of ["Ticket #", "Application #", "Closed by", "First response", "Outcome", "Reviewed by", "Participants"]) {
+      expect(fields[name]).toBeUndefined();
+    }
+  });
+
+  test("entityId renders Ticket # for tickets and Application # for applications", () => {
+    expect(byName(buildHeaderData({ ...META, entityId: 42 }, 1, 0))["Ticket #"]).toBe("42");
+    expect(byName(buildHeaderData({ ...META, entityId: 7, kind: "application" }, 1, 0))["Application #"]).toBe("7");
+  });
+
+  test("Closed by renders `username (`id`)` with both, and degrades to whichever exists", () => {
+    expect(
+      byName(buildHeaderData({ ...META, closedByUsername: "closer", closedById: "999" }, 1, 0))["Closed by"],
+    ).toBe("closer (`999`)");
+    expect(byName(buildHeaderData({ ...META, closedByUsername: "closer" }, 1, 0))["Closed by"]).toBe("closer");
+    expect(byName(buildHeaderData({ ...META, closedById: "999" }, 1, 0))["Closed by"]).toBe("`999`");
+  });
+
+  test("First response renders the stamp; the SLA badge appends only when breached", () => {
+    const when = new Date("2026-04-01T13:00:00Z");
+    expect(byName(buildHeaderData({ ...META, firstResponseAt: when }, 1, 0))["First response"]).toMatch(
+      /^<t:\d+:f>$/,
+    );
+    expect(
+      byName(buildHeaderData({ ...META, firstResponseAt: when, slaBreached: true }, 1, 0))["First response"],
+    ).toMatch(/^<t:\d+:f>\n⚠️ SLA breached$/);
+  });
+
+  test("breached with NO first response renders 'None' + badge (never answered)", () => {
+    expect(byName(buildHeaderData({ ...META, slaBreached: true }, 1, 0))["First response"]).toBe(
+      "None\n⚠️ SLA breached",
+    );
+  });
+
+  test("Outcome and Reviewed by rows render for applications", () => {
+    const fields = byName(
+      buildHeaderData(
+        { ...META, kind: "application", outcome: "Accepted", reviewedByUsername: "rev", reviewedById: "5" },
+        1,
+        0,
+      ),
+    );
+    expect(fields.Outcome).toBe("Accepted");
+    expect(fields["Reviewed by"]).toBe("rev (`5`)");
+  });
+
+  test("participants render as `name (count)` sorted, non-inline", () => {
+    const header = buildHeaderData(META, 3, 0, [
+      { username: "alice", count: 12 },
+      { username: "bob", count: 5 },
+    ]);
+    const field = header.fields.find((f) => f.name === "Participants");
+    expect(field?.value).toBe("alice (12), bob (5)");
+    expect(field?.inline).toBe(false);
+  });
+
+  test("participants over the 1024-char field cap collapse the tail into '+N more'", () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({
+      username: `participant-with-a-rather-long-name-${String(i).padStart(2, "0")}`,
+      count: 60 - i,
+    }));
+    const field = buildHeaderData(META, 3, 0, many).fields.find((f) => f.name === "Participants");
+    expect(field).toBeDefined();
+    expect(field!.value.length).toBeLessThanOrEqual(1024);
+    expect(field!.value).toMatch(/\+\d+ more$/);
+  });
+});
+
 describe("formatMessage()", () => {
   test("plain text renders unquoted under a name + short-time line", () => {
     const out = formatMessage(makeMessage({ content: "Hello\nWorld" }));
@@ -654,5 +728,41 @@ describe("buildTranscript()", () => {
     // must survive. Boundary-marker checks alone would still pass if an entire
     // interior chunk were silently dropped — this count would not.
     expect(flat.split("w").length - 1).toBe(8 * 3000);
+  });
+});
+
+describe("buildTranscript() participants aggregation (v3.16.0)", () => {
+  test("tallies kept messages per human author, bots excluded, most active first", () => {
+    const messages = [
+      makeMessage({ author: { username: "alice", id: "1", bot: false } }),
+      makeMessage({ author: { username: "bob", id: "2", bot: false } }),
+      makeMessage({ author: { username: "alice", id: "1", bot: false } }),
+      makeMessage({ author: { username: "helper-bot", id: "3", bot: true } }),
+      makeMessage({ author: { username: "alice", id: "1", bot: false } }),
+    ];
+    const result = buildTranscript(messages, META);
+    const field = result.headerData.fields.find((f) => f.name === "Participants");
+    expect(field?.value).toBe("alice (3), bob (1)");
+  });
+
+  test("filtered-out messages (system/UI noise) do not count toward participant tallies", () => {
+    const messages = [
+      makeMessage({ author: { username: "alice", id: "1", bot: false } }),
+      makeMessage({
+        author: { username: "alice", id: "1", bot: false },
+        isSystem: true,
+      }),
+    ];
+    const result = buildTranscript(messages, META);
+    const field = result.headerData.fields.find((f) => f.name === "Participants");
+    expect(field?.value).toBe("alice (1)");
+  });
+
+  test("bot-only conversation renders no Participants row", () => {
+    const messages = [
+      makeMessage({ author: { username: "helper-bot", id: "3", bot: true } }),
+    ];
+    const result = buildTranscript(messages, META);
+    expect(result.headerData.fields.find((f) => f.name === "Participants")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Ticket and application archive headers now render the context that was already in the database but never shown, and the SLA subsystem finally gets a production data source (roadmap Phase 2).

## Changes

**Header enrichment** (`transcriptBuilder.ts`) — all rows conditional; absent data renders nothing, so old archives are unchanged:
- "Ticket #" / "Application #" (entity id)
- "Closed by" — `username (`id`)`
- "First response" — timestamp + "⚠️ SLA breached" badge; "None + badge" for never-answered breaches
- "Outcome" / "Reviewed by" (applications)
- "Participants" — per-author message tallies from kept messages, bots and filtered noise excluded, capped under the 1024-char field limit with `+N more` collapse

**closedBy threading**: `CloseActor` param on both close workflows. Close buttons pass the interacting user; the internal API routes pass ninsys-api's `triggeredBy` (id only — the workflow resolves the username concurrently with its other lookups).

**Application position/outcome**: `type='position_<id>'` resolves the Position (guild-scoped, orphan-safe — deleted rows fall back to the generic header instead of throwing in the un-try'd metadata region, the v3.14.2 bug class). Outcome maps both vocabularies: API `accepted`/`rejected` status and Discord-workflow `approved`/`denied` history entries (in-memory pre-close status wins; `claimClose` only flips the DB row).

**Phase B — SLA fix**: `Ticket.firstResponseAt` had NO production write path (dev seeding only), so `slaChecker`'s `firstResponseAt IS NULL` query matched every ticket forever. `messageCreate` now issues a second lightweight conditional UPDATE (open ticket + still-null + author ≠ opener; bots never reach it), silent-fail like the existing activity bump. No migration — the column exists.

## Testing

- transcriptBuilder: +11 tests (enrichment rows, absent-data-renders-nothing, participants aggregation/cap/bot-exclusion)
- ticket closeWorkflow: +4 (closedBy both paths, SLA row, no-data absence)
- application closeWorkflow: +7 (position resolution incl. orphan + DB-error fallback, outcome from both vocabularies, reviewer/closedBy/id rows)
- new messageCreate suite: +4 (both updates fire, guard-trio WHERE clause, bot/DM early-outs)
- All gates green: build, test (1518 pass), check, check:changelog, check:contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive transcripts now show richer details for tickets and applications, including ticket/application numbers, closed-by info, first response time, SLA status, outcome, reviewer, and participant counts.
  * Application archives can now display position-related context when available.
* **Bug Fixes**
  * SLA breach tracking now correctly records first response times, improving SLA badges and alerts.
  * Closing tickets and applications now preserves the closing user’s details more reliably in archived records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->