### PR TITLE
feat: v3.16.1 — application archive forum tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.1] - 2026-07-07
+
+Application archives gain forum tags — parity with ticket archives.
+
+### Added
+
+- **Application archive threads are now tagged** by the position applied for
+  and the Accepted/Rejected outcome, so the archive forum is filterable the
+  same way ticket archives already were. Tags accumulate across re-closes and
+  respect Discord's 5-tag-per-thread cap (only tags that actually land are
+  persisted). Adds a nullable `forumTagIds` column to `archived_applications`
+  (TypeORM migration; mirrors `ArchivedTicket.forumTagIds`).
+
 ## [3.16.0] - 2026-07-06
 
 Archival enrichment — ticket and application archive headers now carry the

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.16.0",
+  "botVersion": "3.16.1",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/typeorm/entities/application/ArchivedApplication.ts
+++ b/src/typeorm/entities/application/ArchivedApplication.ts
@@ -15,4 +15,9 @@ export class ArchivedApplication {
 
   @Column()
   createdBy: string;
+
+  /** Forum tags applied to the archive thread (position + Accepted/Rejected
+   * outcome), accumulated across re-closes. Mirrors ArchivedTicket.forumTagIds. */
+  @Column({ type: 'simple-json', nullable: true })
+  forumTagIds: string[] | null;
 }

--- a/src/typeorm/migrations/1774000013000-AddArchivedApplicationForumTags.ts
+++ b/src/typeorm/migrations/1774000013000-AddArchivedApplicationForumTags.ts
@@ -1,0 +1,22 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the `forumTagIds` simple-json column to `archived_applications`,
+ * mirroring `ArchivedTicket.forumTagIds`. Stores the forum tags applied to an
+ * application's archive thread (position + Accepted/Rejected outcome) so
+ * re-closes accumulate onto the existing set (v3.16.1).
+ *
+ * Nullable to stay backfill-friendly: rows written before this column existed
+ * keep NULL, which the close workflow treats as "no tags yet". Dev
+ * (`synchronize: true`) picks the decorator up automatically; this migration
+ * covers prod.
+ */
+export class AddArchivedApplicationForumTags1774000013000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`archived_applications\` ADD \`forumTagIds\` text NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`archived_applications\` DROP COLUMN \`forumTagIds\``);
+  }
+}

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -18,6 +18,7 @@ import { Colors } from '../colors';
 import { lazyRepo } from '../database/lazyRepo';
 import { verifiedChannelDelete } from '../discord/verifiedDelete';
 import { fetchMessagesAsTranscript } from '../fetchAllMessages';
+import { applyForumTags, ensureForumTag } from '../forumTagManager';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 import type { CloseActor } from '../ticket/closeWorkflow';
 import { buildTranscript, type TicketMetadata, type TranscriptMessage } from '../ticket/transcriptBuilder';
@@ -51,6 +52,8 @@ export interface CloseApplicationWorkflowDeps {
   verifiedChannelDelete: typeof verifiedChannelDelete;
   archivedAppRepo: typeof archivedAppRepo;
   positionRepo: typeof positionRepo;
+  ensureForumTag: typeof ensureForumTag;
+  applyForumTags: typeof applyForumTags;
 }
 
 const defaultDeps: CloseApplicationWorkflowDeps = {
@@ -58,7 +61,19 @@ const defaultDeps: CloseApplicationWorkflowDeps = {
   verifiedChannelDelete,
   archivedAppRepo,
   positionRepo,
+  ensureForumTag,
+  applyForumTags,
 };
+
+/** Union of existing + incoming forum tag ids, order-preserving, deduped.
+ * Mirrors the ticket close workflow's helper. */
+function mergeForumTags(existing: string[] | null | undefined, incoming: string[]): string[] {
+  const merged = [...(existing ?? [])];
+  for (const tag of incoming) {
+    if (!merged.includes(tag)) merged.push(tag);
+  }
+  return merged;
+}
 
 /**
  * Resolve the Position row an application was submitted for. `type` carries
@@ -181,6 +196,25 @@ export async function archiveAndCloseApplication(
   let archived = true;
   try {
     const forumChannel = (await client.channels.fetch(archiveForumChannelId)) as ForumChannel;
+
+    // Forum tags for the archive thread: the position applied for, and the
+    // Accepted/Rejected outcome. Both are best-effort — ensureForumTag returns
+    // null at the 20-tag forum cap or on API error, and we simply skip it.
+    const forumTagIds: string[] = [];
+    if (position) {
+      const tagId = await deps.ensureForumTag(forumChannel, `position_${position.id}`, position.title, position.emoji);
+      if (tagId) forumTagIds.push(tagId);
+    }
+    if (metadata.outcome) {
+      const tagId = await deps.ensureForumTag(
+        forumChannel,
+        `outcome_${metadata.outcome.toLowerCase()}`,
+        metadata.outcome,
+        metadata.outcome === 'Accepted' ? '✅' : '❌',
+      );
+      if (tagId) forumTagIds.push(tagId);
+    }
+
     const existingArchive = await deps.archivedAppRepo.findOneBy({
       createdBy: application.createdBy,
       guildId,
@@ -193,6 +227,10 @@ export async function archiveAndCloseApplication(
         message: { embeds: [headerEmbed], allowedMentions: { parse: [] } },
       });
 
+      if (forumTagIds.length > 0) {
+        await deps.applyForumTags(forumChannel, newPost.id, forumTagIds);
+      }
+
       // Persist the archive row BEFORE posting chunks: a chunk failure then
       // leaves the row pointing at this thread, so the retry appends instead of
       // orphaning it and creating a duplicate.
@@ -201,6 +239,7 @@ export async function archiveAndCloseApplication(
           guildId,
           createdBy: application.createdBy,
           messageId: newPost.id,
+          forumTagIds,
         }),
       );
 
@@ -225,8 +264,13 @@ export async function archiveAndCloseApplication(
           name: threadName,
           message: { embeds: [headerEmbed], allowedMentions: { parse: [] } },
         });
+        const mergedTags = mergeForumTags(existingArchive.forumTagIds, forumTagIds);
+        if (mergedTags.length > 0) {
+          await deps.applyForumTags(forumChannel, newPost.id, mergedTags);
+        }
         // Repoint + persist BEFORE chunks so a chunk failure can't orphan it.
         existingArchive.messageId = newPost.id;
+        existingArchive.forumTagIds = mergedTags;
         await deps.archivedAppRepo.save(existingArchive);
         await postTranscriptToThread(newPost, transcript.chunks, {
           guildId,
@@ -240,6 +284,18 @@ export async function archiveAndCloseApplication(
           allowedMentions: { parse: [] },
         });
         await postTranscriptToThread(post, transcript.chunks, { guildId, channelId, label: 'Application transcript' });
+
+        // Accumulate tags onto the existing thread — persist only what actually
+        // landed (the 5-tag cap can drop some; recording a dropped tag would
+        // make future closes skip re-applying it while the thread never shows it).
+        const mergedTags = mergeForumTags(existingArchive.forumTagIds, forumTagIds);
+        if (mergedTags.length > (existingArchive.forumTagIds?.length ?? 0)) {
+          const applied = await deps.applyForumTags(forumChannel, post.id, mergedTags);
+          if (applied) {
+            existingArchive.forumTagIds = applied;
+            await deps.archivedAppRepo.save(existingArchive);
+          }
+        }
       }
     }
   } catch (error) {

--- a/src/utils/application/closeWorkflow.ts
+++ b/src/utils/application/closeWorkflow.ts
@@ -264,13 +264,16 @@ export async function archiveAndCloseApplication(
           name: threadName,
           message: { embeds: [headerEmbed], allowedMentions: { parse: [] } },
         });
+        // Persist what actually LANDED, not the intended merge: an accumulated
+        // set (prior tags + manual mod tags + this outcome) can exceed Discord's
+        // 5-tag cap, and recording a dropped tag would make the DB claim a tag
+        // the thread never shows. applyForumTags returns the applied set (≤5),
+        // or null on error — fall back to the intended merge in that case.
         const mergedTags = mergeForumTags(existingArchive.forumTagIds, forumTagIds);
-        if (mergedTags.length > 0) {
-          await deps.applyForumTags(forumChannel, newPost.id, mergedTags);
-        }
+        const applied = mergedTags.length > 0 ? await deps.applyForumTags(forumChannel, newPost.id, mergedTags) : [];
         // Repoint + persist BEFORE chunks so a chunk failure can't orphan it.
         existingArchive.messageId = newPost.id;
-        existingArchive.forumTagIds = mergedTags;
+        existingArchive.forumTagIds = applied ?? mergedTags;
         await deps.archivedAppRepo.save(existingArchive);
         await postTranscriptToThread(newPost, transcript.chunks, {
           guildId,

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -637,6 +637,80 @@ describe('archiveAndCloseApplication', () => {
     expect(fakeRepoState.saveCalls).toHaveLength(0);
   });
 
+  test('recreate-on-10003: merges existing + new tags, applies to the recreated thread, persists the applied set', async () => {
+    // Prior close tagged the position; the thread was since deleted (10003), so
+    // this close recreates it and must carry the merged tags onto the new thread.
+    fakeRepoState.findOneByResult = { messageId: 'deleted-thread', forumTagIds: ['tag-position_7'] };
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
+    forumState.fetchShouldThrow = Object.assign(new Error('Unknown Channel'), { code: 10003 });
+    const client = makeFakeClient(forumChannel);
+
+    const result = await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: 'position_7', status: 'accepted' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    expect(result.archived).toBe(true);
+    // A NEW thread was created (recreate path), and the merged set applied to it.
+    expect(forumChannel.threads.create).toHaveBeenCalledTimes(1);
+    expect(fakeApplyForumTags.mock.calls[0][2]).toEqual(['tag-position_7', 'tag-outcome_accepted']);
+    // Row repointed at the new thread and persisted with the applied tags.
+    const savedRow = fakeRepoState.saveCalls.at(-1);
+    expect(savedRow.messageId).toBe(forumState.threadsCreated[0].id);
+    expect(savedRow.forumTagIds).toEqual(['tag-position_7', 'tag-outcome_accepted']);
+  });
+
+  test('recreate-on-10003: persists only the applied set when the 5-tag cap drops a tag', async () => {
+    fakeRepoState.findOneByResult = { messageId: 'deleted-thread', forumTagIds: ['a', 'b', 'c', 'd'] };
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
+    forumState.fetchShouldThrow = Object.assign(new Error('Unknown Channel'), { code: 10003 });
+    fakeApplyForumTags.mockImplementation(async (_f: any, _t: string, tags: string[]) => tags.slice(0, 5));
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: 'position_7', status: 'accepted' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    // merged = [a,b,c,d, tag-position_7, tag-outcome_accepted]; cap keeps 5 —
+    // the DB must record the applied 5, NOT the intended 6 (no phantom tag).
+    const savedRow = fakeRepoState.saveCalls.at(-1);
+    expect(savedRow.forumTagIds).toEqual(['a', 'b', 'c', 'd', 'tag-position_7']);
+    expect(savedRow.forumTagIds).toHaveLength(5);
+  });
+
+  test('recreate-on-10003: applyForumTags error (null) falls back to the intended merge so the row still saves', async () => {
+    fakeRepoState.findOneByResult = { messageId: 'deleted-thread', forumTagIds: ['tag-position_7'] };
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
+    forumState.fetchShouldThrow = Object.assign(new Error('Unknown Channel'), { code: 10003 });
+    fakeApplyForumTags.mockResolvedValue(null); // tag apply failed on the recreated thread
+    const client = makeFakeClient(forumChannel);
+
+    const result = await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: 'position_7', status: 'accepted' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    // Archive must still succeed (the transcript matters more than the tags),
+    // and the row is repointed with the best-effort intended set.
+    expect(result.archived).toBe(true);
+    const savedRow = fakeRepoState.saveCalls.at(-1);
+    expect(savedRow.messageId).toBe(forumState.threadsCreated[0].id);
+    expect(savedRow.forumTagIds).toEqual(['tag-position_7', 'tag-outcome_accepted']);
+  });
+
   test('re-close append: persists only tags that actually landed (5-tag cap dropped the new one)', async () => {
     fakeRepoState.findOneByResult = {
       messageId: 'existing-thread',

--- a/tests/unit/utils/application/closeWorkflow.test.ts
+++ b/tests/unit/utils/application/closeWorkflow.test.ts
@@ -56,11 +56,19 @@ const fakePositionRepo = {
   findOneBy: jest.fn(async () => null as any),
 };
 
+// Forum-tag seams. ensureForumTag returns a deterministic id per (typeId);
+// applyForumTags echoes the tags it was asked to apply (the real one caps at 5
+// and merges live thread tags, but tests drive the cap explicitly when needed).
+const fakeEnsureForumTag = jest.fn(async (_forum: any, typeId: string) => `tag-${typeId}`);
+const fakeApplyForumTags = jest.fn(async (_forum: any, _threadId: string, tags: string[]) => tags);
+
 const deps = {
   fetchMessagesAsTranscript: fakeFetchMessages,
   verifiedChannelDelete: fakeVerifiedChannelDelete,
   archivedAppRepo: fakeRepo,
   positionRepo: fakePositionRepo,
+  ensureForumTag: fakeEnsureForumTag,
+  applyForumTags: fakeApplyForumTags,
 } as unknown as CloseApplicationWorkflowDeps;
 
 interface FakeForumState {
@@ -144,6 +152,10 @@ describe('archiveAndCloseApplication', () => {
     fakeFetchMessages.mockImplementation(async () => []);
     fakePositionRepo.findOneBy.mockClear();
     fakePositionRepo.findOneBy.mockImplementation(async () => null);
+    fakeEnsureForumTag.mockClear();
+    fakeEnsureForumTag.mockImplementation(async (_forum: any, typeId: string) => `tag-${typeId}`);
+    fakeApplyForumTags.mockClear();
+    fakeApplyForumTags.mockImplementation(async (_forum: any, _threadId: string, tags: string[]) => tags);
     forumState = { threadsCreated: [], threadsFetched: new Map() };
     forumChannel = makeFakeForumChannel(forumState);
   });
@@ -534,5 +546,119 @@ describe('archiveAndCloseApplication', () => {
     expect(fields['Reviewed by']).toBe('reviewer (`rev-1`)');
     expect(fields['Closed by']).toBe('closer (`staff-2`)');
     expect(fields['Application #']).toBe('55');
+  });
+
+  // -------------------------------------------------------------------------
+  // Forum tags (v3.16.1): position + Accepted/Rejected outcome, accumulation
+  // -------------------------------------------------------------------------
+
+  test('first close: applies position + outcome tags and persists them on the archive row', async () => {
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: 'position_7', status: 'accepted' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    // Two tags ensured: position (by position id) + outcome
+    expect(fakeEnsureForumTag).toHaveBeenCalledTimes(2);
+    expect(fakeEnsureForumTag.mock.calls[0][1]).toBe('position_7');
+    expect(fakeEnsureForumTag.mock.calls[1][1]).toBe('outcome_accepted');
+    // Applied to the new thread and persisted on the row
+    expect(fakeApplyForumTags).toHaveBeenCalledTimes(1);
+    expect(fakeApplyForumTags.mock.calls[0][2]).toEqual(['tag-position_7', 'tag-outcome_accepted']);
+    expect(fakeRepoState.createCalls[0].forumTagIds).toEqual(['tag-position_7', 'tag-outcome_accepted']);
+  });
+
+  test('no position and no outcome: no tags ensured, row saved with empty tag list', async () => {
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: null, status: 'pending' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    expect(fakeEnsureForumTag).not.toHaveBeenCalled();
+    expect(fakeApplyForumTags).not.toHaveBeenCalled();
+    expect(fakeRepoState.createCalls[0].forumTagIds).toEqual([]);
+  });
+
+  test('re-close append: accumulates the new outcome tag onto the existing archive row', async () => {
+    // Prior close tagged the position; this close is the decision.
+    fakeRepoState.findOneByResult = { messageId: 'existing-thread', forumTagIds: ['tag-position_7'] };
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: 'position_7', status: 'rejected' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    // Position tag already present; the merged set adds the outcome tag.
+    const applied = fakeApplyForumTags.mock.calls[0][2];
+    expect(applied).toEqual(['tag-position_7', 'tag-outcome_rejected']);
+    // Persisted the accumulated set
+    const savedRow = fakeRepoState.saveCalls.at(-1);
+    expect(savedRow.forumTagIds).toEqual(['tag-position_7', 'tag-outcome_rejected']);
+  });
+
+  test('re-close append: no NEW tags → no re-apply, no extra save', async () => {
+    fakeRepoState.findOneByResult = {
+      messageId: 'existing-thread',
+      forumTagIds: ['tag-position_7', 'tag-outcome_accepted'],
+    };
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: 'position_7', status: 'accepted' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    // Both tags already on the row → nothing new to apply or persist.
+    expect(fakeApplyForumTags).not.toHaveBeenCalled();
+    expect(fakeRepoState.saveCalls).toHaveLength(0);
+  });
+
+  test('re-close append: persists only tags that actually landed (5-tag cap dropped the new one)', async () => {
+    fakeRepoState.findOneByResult = {
+      messageId: 'existing-thread',
+      forumTagIds: ['a', 'b', 'c', 'd'], // 4 pre-existing (manual/other)
+    };
+    fakePositionRepo.findOneBy.mockResolvedValue({ id: 7, title: 'Moderator', emoji: '🛡️' });
+    // Cap simulation: only the first 5 of the merged set survive.
+    fakeApplyForumTags.mockImplementation(async (_f: any, _t: string, tags: string[]) => tags.slice(0, 5));
+    const client = makeFakeClient(forumChannel);
+
+    await archiveAndCloseApplication(
+      client,
+      makeApplication({ type: 'position_7', status: 'accepted' }),
+      'guild-1',
+      makeChannel(),
+      'forum-archive-1',
+      deps,
+    );
+
+    // merged = [a,b,c,d, tag-position_7, tag-outcome_accepted]; applied caps to 5.
+    const savedRow = fakeRepoState.saveCalls.at(-1);
+    expect(savedRow.forumTagIds).toEqual(['a', 'b', 'c', 'd', 'tag-position_7']);
+    expect(savedRow.forumTagIds).toHaveLength(5);
   });
 });


### PR DESCRIPTION
## Summary

Brings application archives to parity with ticket archives: archive threads are now tagged by the **position** applied for and the **Accepted/Rejected outcome**, making the archive forum filterable the same way ticket archives already were (roadmap Phase 3).

## Changes

- **`ArchivedApplication.forumTagIds`** — new nullable `simple-json` column + TypeORM migration `1774000013000-AddArchivedApplicationForumTags` (`text NULL`, mirrors `ArchivedTicket.forumTagIds` and the `hourlyCounts` precedent). Nullable = backfill-friendly; dev `synchronize` picks up the decorator, the migration covers prod.
- **`application/closeWorkflow`** ensures two tags via `ensureForumTag`:
  - position tag — keyed by `position_<id>`, named by the position title, with the position emoji
  - outcome tag — `✅ Accepted` / `❌ Rejected` (from the same outcome resolution added in v3.16.0)
  
  applied with the **accumulation pattern** across all three archive paths (first close, recreate-on-10003, append). The append path persists only tags that actually landed — Discord caps threads at 5 tags, and recording a dropped tag would make future closes skip re-applying it while the thread never shows it.
- `ensureForumTag` / `applyForumTags` added to the injectable `CloseApplicationWorkflowDeps` seam.

## Testing

- +5 application closeWorkflow tests: first-close applies+persists both tags; no-position-no-outcome case ensures nothing; append accumulates the new outcome tag; no-op when both already present; 5-tag-cap persists only what landed.
- All gates green: build, test (1531 pass), check, check:changelog, check:contract.

## Migration

Only migration in the v3.16.x series. Additive, nullable, low-risk — no backfill needed (null = "no tags yet").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ