### PR TITLE
feat: v3.16.2 — analytics per-channel uniqueUsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.16.2] - 2026-07-07
+
+Real per-channel unique-user analytics — the dashboard's "unique users" was a
+hardcoded 0.
+
+### Added
+
+- **Per-channel daily unique authors** are now tracked and surfaced on the
+  `/analytics/channels` and `/analytics/overview` API responses. The activity
+  tracker keeps a bounded per-channel author set (capped at 1000 via
+  `MAX.ANALYTICS_CHANNEL_UNIQUE_USERS` so a hot channel can't grow it
+  unboundedly), persists the daily count into each snapshot's `topChannels`,
+  and the handlers accumulate it across the requested window (SUM of daily
+  uniques, matching the existing `activeMembers` convention).
+
+### Fixed
+
+- `/analytics/channels` no longer returns a hardcoded `uniqueUsers: 0` stub.
+
+### Notes
+
+- No migration: `topChannels` is a `simple-json` column and the new
+  `uniqueUsers` key is optional (rows written before this release omit it and
+  are read as 0).
+
 ## [3.16.1] - 2026-07-07
 
 Application archives gain forum tags — parity with ticket archives.

--- a/contract/cogworks-contract.json
+++ b/contract/cogworks-contract.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": "1",
-  "botVersion": "3.16.1",
+  "botVersion": "3.16.2",
   "features": {
     "keys": [
       "tickets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cogworks-bot",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "description": "A modular Discord server management bot built with TypeScript and Discord.js",
   "main": "index.js",
   "scripts": {

--- a/src/typeorm/entities/analytics/AnalyticsSnapshot.ts
+++ b/src/typeorm/entities/analytics/AnalyticsSnapshot.ts
@@ -40,9 +40,14 @@ export class AnalyticsSnapshot {
   @Column({ default: 0 })
   voiceMinutes: number;
 
-  /** Top 5 channels by message count: Array<{ channelId: string; name: string; count: number }> */
+  /**
+   * Top 5 channels by message count. `uniqueUsers` (v3.16.2) is the day's
+   * distinct message authors in that channel, capped at
+   * MAX.ANALYTICS_CHANNEL_UNIQUE_USERS. Optional — rows written before v3.16.2
+   * omit it (simple-json, no migration needed); readers treat absent as 0.
+   */
   @Column({ type: 'simple-json', nullable: true })
-  topChannels: { channelId: string; name: string; count: number }[] | null;
+  topChannels: { channelId: string; name: string; count: number; uniqueUsers?: number }[] | null;
 
   /** Hour with the most message activity (0-23 UTC) */
   @Column({ type: 'int', nullable: true })

--- a/src/utils/analytics/activityTracker.ts
+++ b/src/utils/analytics/activityTracker.ts
@@ -8,14 +8,15 @@
 
 import { AppDataSource } from '../../typeorm';
 import { AnalyticsSnapshot } from '../../typeorm/entities/analytics/AnalyticsSnapshot';
+import { MAX } from '../constants';
 import { enhancedLogger, LogCategory } from '../monitoring/enhancedLogger';
 
 interface GuildDayCounters {
   messageCount: number;
   /** Set of unique user IDs who sent messages */
   activeMembers: Set<string>;
-  /** Channel ID -> message count */
-  channelCounts: Map<string, { name: string; count: number }>;
+  /** Channel ID -> message count + set of unique authors (capped) */
+  channelCounts: Map<string, { name: string; count: number; users: Set<string> }>;
   /** Hour (0-23) -> message count */
   hourCounts: Map<number, number>;
   voiceMinutes: number;
@@ -74,12 +75,15 @@ class ActivityTracker {
     c.messageCount++;
     c.activeMembers.add(userId);
 
-    // Channel counts
+    // Channel counts + per-channel unique authors (bounded set — a hot channel
+    // can't grow it past MAX.ANALYTICS_CHANNEL_UNIQUE_USERS; the daily unique
+    // count saturates there rather than tracking every id).
     const existing = c.channelCounts.get(channelId);
     if (existing) {
       existing.count++;
+      if (existing.users.size < MAX.ANALYTICS_CHANNEL_UNIQUE_USERS) existing.users.add(userId);
     } else {
-      c.channelCounts.set(channelId, { name: channelName, count: 1 });
+      c.channelCounts.set(channelId, { name: channelName, count: 1, users: new Set([userId]) });
     }
 
     // Hour counts (UTC)
@@ -142,9 +146,9 @@ class ActivityTracker {
   ): Promise<void> {
     const repo = AppDataSource.getRepository(AnalyticsSnapshot);
 
-    // Top 5 channels by count
+    // Top 5 channels by count, each with its (capped) daily unique-author count
     const topChannels = [...c.channelCounts.entries()]
-      .map(([channelId, { name, count }]) => ({ channelId, name, count }))
+      .map(([channelId, { name, count, users }]) => ({ channelId, name, count, uniqueUsers: users.size }))
       .sort((a, b) => b.count - a.count)
       .slice(0, 5);
 

--- a/src/utils/api/handlers/analyticsHandlers.ts
+++ b/src/utils/api/handlers/analyticsHandlers.ts
@@ -147,19 +147,25 @@ export function registerAnalyticsHandlers(_client: Client, routes: Map<string, R
     const leaves = sum(current, r => r.memberLeft);
     const voiceMinutes = sum(current, r => r.voiceMinutes);
 
-    // Aggregate topChannels across the window.
-    const channelTotals = new Map<string, { channelId: string; channelName: string; messages: number }>();
+    // Aggregate topChannels across the window (uniqueUsers = SUM of daily
+    // uniques, same imprecision as activeMembers above).
+    const channelTotals = new Map<
+      string,
+      { channelId: string; channelName: string; messages: number; uniqueUsers: number }
+    >();
     for (const snap of current) {
       if (!snap.topChannels) continue;
       for (const c of snap.topChannels) {
         const existing = channelTotals.get(c.channelId);
         if (existing) {
           existing.messages += c.count;
+          existing.uniqueUsers += c.uniqueUsers ?? 0;
         } else {
           channelTotals.set(c.channelId, {
             channelId: c.channelId,
             channelName: c.name,
             messages: c.count,
+            uniqueUsers: c.uniqueUsers ?? 0,
           });
         }
       }
@@ -216,13 +222,17 @@ export function registerAnalyticsHandlers(_client: Client, routes: Map<string, R
     });
 
     // Aggregate topChannels across the window, combining same channelId rows.
-    const acc = new Map<string, { channelId: string; channelName: string; messages: number }>();
+    // uniqueUsers is a per-DAY distinct-author count; summing across days
+    // over-counts users active on multiple days — this is the SUM of daily
+    // uniques (same convention as activeMembers in /overview, :142-145).
+    const acc = new Map<string, { channelId: string; channelName: string; messages: number; uniqueUsers: number }>();
     for (const snap of rows) {
       if (!snap.topChannels) continue;
       for (const c of snap.topChannels) {
         const existing = acc.get(c.channelId);
         if (existing) {
           existing.messages += c.count;
+          existing.uniqueUsers += c.uniqueUsers ?? 0;
           // Prefer the most recent name we've seen — channel renames are rare
           // but we want the latest label rather than whichever came first.
           existing.channelName = c.name;
@@ -231,17 +241,13 @@ export function registerAnalyticsHandlers(_client: Client, routes: Map<string, R
             channelId: c.channelId,
             channelName: c.name,
             messages: c.count,
+            uniqueUsers: c.uniqueUsers ?? 0,
           });
         }
       }
     }
 
-    const channels = [...acc.values()]
-      .sort((a, b) => b.messages - a.messages)
-      // `uniqueUsers` isn't tracked per-channel yet — returning 0 keeps the
-      // contract shape stable until we add channelUniqueUsers in a later
-      // migration. Documented in CHANGELOG 3.1.2.
-      .map(c => ({ ...c, uniqueUsers: 0 }));
+    const channels = [...acc.values()].sort((a, b) => b.messages - a.messages);
 
     return { days, channels };
   });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -144,6 +144,13 @@ export const MAX = {
   STATUS_INCIDENTS: 100,
   /** CSV import max rows */
   IMPORT_CSV_MAX_ROWS: 10000,
+  /**
+   * Per-channel unique-user set saturation cap (analytics). Bounds the
+   * in-memory Set so a hot channel can't grow it unboundedly across a day;
+   * once hit, further distinct users aren't counted (the reported daily
+   * unique count saturates at this value).
+   */
+  ANALYTICS_CHANNEL_UNIQUE_USERS: 1000,
 } as const;
 
 export const JOIN_VELOCITY = {

--- a/tests/unit/utils/analytics/activityTrackerFlush.test.ts
+++ b/tests/unit/utils/analytics/activityTrackerFlush.test.ts
@@ -95,7 +95,7 @@ describe('activityTracker flush — per-channel uniqueUsers', () => {
     expect(channels.ch1.uniqueUsers).toBe(MAX.ANALYTICS_CHANNEL_UNIQUE_USERS);
   });
 
-  test('flush clears the counter (a second flush writes a zero-activity snapshot)', async () => {
+  test('flush clears the in-memory counter after persisting the snapshot', async () => {
     const guildId = gid();
     activityTracker.recordMessage(guildId, 'ch1', 'general', 'user1');
     await activityTracker.flushSnapshot(guildId, 100);

--- a/tests/unit/utils/analytics/activityTrackerFlush.test.ts
+++ b/tests/unit/utils/analytics/activityTrackerFlush.test.ts
@@ -1,0 +1,104 @@
+/**
+ * ActivityTracker flush behavior (v3.16.2) — per-channel uniqueUsers.
+ *
+ * The shallow in-memory tests in activityTracker.test.ts can't read the
+ * private counters, so the dedup/cap logic and its persistence into
+ * AnalyticsSnapshot.topChannels are verified here by patching
+ * AppDataSource.getRepository (the same seam the API-handler suites use) and
+ * inspecting the upserted snapshot.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, jest, test } from 'bun:test';
+import { MAX } from '../../../../src/utils/constants';
+
+interface SnapshotRepoState {
+  findOneByResult: any;
+  saved: any[];
+}
+const repoState: SnapshotRepoState = { findOneByResult: null, saved: [] };
+
+const analyticsRepo = {
+  findOneBy: jest.fn(async () => repoState.findOneByResult),
+  create: jest.fn((obj: any) => obj),
+  save: jest.fn(async (entity: any) => {
+    repoState.saved.push(entity);
+    return entity;
+  }),
+};
+
+let activityTracker: typeof import('../../../../src/utils/analytics/activityTracker').activityTracker;
+let originalGetRepository: ((entity: unknown) => unknown) | undefined;
+let guildSeq = 0;
+
+beforeAll(async () => {
+  const { AppDataSource } = await import('../../../../src/typeorm');
+  originalGetRepository = (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository;
+  (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = () => analyticsRepo;
+  activityTracker = (await import('../../../../src/utils/analytics/activityTracker')).activityTracker;
+});
+
+afterAll(async () => {
+  if (originalGetRepository) {
+    const { AppDataSource } = await import('../../../../src/typeorm');
+    (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = originalGetRepository;
+  }
+});
+
+beforeEach(() => {
+  repoState.findOneByResult = null;
+  repoState.saved = [];
+  analyticsRepo.findOneBy.mockClear();
+  analyticsRepo.create.mockClear();
+  analyticsRepo.save.mockClear();
+  guildSeq++;
+});
+
+/** Unique guild id per test — the tracker is a process singleton. */
+function gid(): string {
+  return `flush-guild-${guildSeq}-${process.pid}`;
+}
+
+/** topChannels of the single saved snapshot, keyed by channelId. */
+function savedChannels(): Record<string, { count: number; uniqueUsers: number }> {
+  expect(repoState.saved).toHaveLength(1);
+  const rows = repoState.saved[0].topChannels as { channelId: string; count: number; uniqueUsers: number }[];
+  return Object.fromEntries(rows.map(r => [r.channelId, { count: r.count, uniqueUsers: r.uniqueUsers }]));
+}
+
+describe('activityTracker flush — per-channel uniqueUsers', () => {
+  test('dedups authors per channel: repeated author counts once toward uniqueUsers', async () => {
+    const guildId = gid();
+    activityTracker.recordMessage(guildId, 'ch1', 'general', 'user1');
+    activityTracker.recordMessage(guildId, 'ch1', 'general', 'user2');
+    activityTracker.recordMessage(guildId, 'ch1', 'general', 'user1'); // dup author
+    activityTracker.recordMessage(guildId, 'ch2', 'help', 'user3');
+
+    await activityTracker.flushSnapshot(guildId, 100);
+
+    const channels = savedChannels();
+    expect(channels.ch1).toEqual({ count: 3, uniqueUsers: 2 }); // 3 msgs, 2 distinct authors
+    expect(channels.ch2).toEqual({ count: 1, uniqueUsers: 1 });
+  });
+
+  test('uniqueUsers saturates at MAX.ANALYTICS_CHANNEL_UNIQUE_USERS', async () => {
+    const guildId = gid();
+    const overCap = MAX.ANALYTICS_CHANNEL_UNIQUE_USERS + 50;
+    for (let i = 0; i < overCap; i++) {
+      activityTracker.recordMessage(guildId, 'ch1', 'general', `user-${i}`);
+    }
+
+    await activityTracker.flushSnapshot(guildId, 100);
+
+    const channels = savedChannels();
+    // Message count is uncapped; the unique-author set saturates at the cap.
+    expect(channels.ch1.count).toBe(overCap);
+    expect(channels.ch1.uniqueUsers).toBe(MAX.ANALYTICS_CHANNEL_UNIQUE_USERS);
+  });
+
+  test('flush clears the counter (a second flush writes a zero-activity snapshot)', async () => {
+    const guildId = gid();
+    activityTracker.recordMessage(guildId, 'ch1', 'general', 'user1');
+    await activityTracker.flushSnapshot(guildId, 100);
+    expect(activityTracker.hasCounters(guildId)).toBe(false);
+  });
+});

--- a/tests/unit/utils/api/analyticsHandlersOverview.test.ts
+++ b/tests/unit/utils/api/analyticsHandlersOverview.test.ts
@@ -15,17 +15,8 @@
  *   - Rejects bad ?days= values with 400
  */
 
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  jest,
-  test,
-} from "bun:test";
-import type { Client } from "discord.js";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, jest, test } from 'bun:test';
+import type { Client } from 'discord.js';
 
 interface AnalyticsRepoState {
   /** Returned in order: first call (current window), second call (previous window). */
@@ -41,42 +32,30 @@ const analyticsRepo = {
   }),
 };
 
-let registerAnalyticsHandlers: typeof import("../../../../src/utils/api/handlers/analyticsHandlers").registerAnalyticsHandlers;
+let registerAnalyticsHandlers: typeof import('../../../../src/utils/api/handlers/analyticsHandlers').registerAnalyticsHandlers;
 let routes: Map<string, any>;
 const fakeClient = {} as Client;
 let originalGetRepository: ((entity: unknown) => unknown) | undefined;
 
 beforeAll(async () => {
-  const { AppDataSource } = await import("../../../../src/typeorm");
-  const { AnalyticsSnapshot } = await import(
-    "../../../../src/typeorm/entities/analytics/AnalyticsSnapshot"
-  );
+  const { AppDataSource } = await import('../../../../src/typeorm');
+  const { AnalyticsSnapshot } = await import('../../../../src/typeorm/entities/analytics/AnalyticsSnapshot');
   // Capture so afterAll can restore. Bun shares module state across test files.
-  originalGetRepository = (
-    AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-  ).getRepository;
-  (
-    AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-  ).getRepository = (entity) =>
+  originalGetRepository = (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository;
+  (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = entity =>
     entity === AnalyticsSnapshot
       ? analyticsRepo
       : (() => {
-          throw new Error(
-            `Unmocked entity: ${(entity as { name?: string }).name}`,
-          );
+          throw new Error(`Unmocked entity: ${(entity as { name?: string }).name}`);
         })();
-  const sut = await import(
-    "../../../../src/utils/api/handlers/analyticsHandlers"
-  );
+  const sut = await import('../../../../src/utils/api/handlers/analyticsHandlers');
   registerAnalyticsHandlers = sut.registerAnalyticsHandlers;
 });
 
 afterAll(async () => {
   if (originalGetRepository) {
-    const { AppDataSource } = await import("../../../../src/typeorm");
-    (
-      AppDataSource as unknown as { getRepository: (e: unknown) => unknown }
-    ).getRepository = originalGetRepository;
+    const { AppDataSource } = await import('../../../../src/typeorm');
+    (AppDataSource as unknown as { getRepository: (e: unknown) => unknown }).getRepository = originalGetRepository;
   }
 });
 
@@ -93,8 +72,8 @@ afterEach(() => {
 });
 
 function getOverview() {
-  const handler = routes.get("GET /analytics/overview");
-  if (!handler) throw new Error("GET /analytics/overview not registered");
+  const handler = routes.get('GET /analytics/overview');
+  if (!handler) throw new Error('GET /analytics/overview not registered');
   return handler;
 }
 
@@ -114,8 +93,8 @@ function snap(over: Record<string, unknown>): any {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("GET /analytics/overview", () => {
-  test("aggregates current window + computes pctChange vs previous window", async () => {
+describe('GET /analytics/overview', () => {
+  test('aggregates current window + computes pctChange vs previous window', async () => {
     repoState.findResults = [
       // current window — 3 days
       [
@@ -160,124 +139,189 @@ describe("GET /analytics/overview", () => {
       ],
     ];
 
-    const result = await getOverview()("guild-1", {}, "/analytics/overview");
+    const result = await getOverview()('guild-1', {}, '/analytics/overview');
 
-    expect(result.period).toBe("7d");
+    expect(result.period).toBe('7d');
     expect(result.messages).toBe(300);
     expect(result.activeMembers).toBe(30);
     expect(result.joins).toBe(6);
     expect(result.leaves).toBe(3);
     expect(result.voiceMinutes).toBe(100);
     // pctChange: messages 300 vs 150 = +100%
-    expect(result.comparedToPrevious.messages).toBe("+100%");
+    expect(result.comparedToPrevious.messages).toBe('+100%');
     // joins 6 vs 3 = +100%
-    expect(result.comparedToPrevious.joins).toBe("+100%");
+    expect(result.comparedToPrevious.joins).toBe('+100%');
   });
 
-  test("aggregates topChannels across days, sorts by total messages, caps at 5", async () => {
+  test('aggregates topChannels across days, sorts by total messages, caps at 5', async () => {
     repoState.findResults = [
       [
         snap({
           topChannels: [
-            { channelId: "c-a", name: "channel-a", count: 50 },
-            { channelId: "c-b", name: "channel-b", count: 30 },
+            { channelId: 'c-a', name: 'channel-a', count: 50, uniqueUsers: 10 },
+            { channelId: 'c-b', name: 'channel-b', count: 30, uniqueUsers: 6 },
           ],
         }),
         snap({
           topChannels: [
-            { channelId: "c-a", name: "channel-a", count: 25 }, // accumulates with day 1
-            { channelId: "c-c", name: "channel-c", count: 100 },
-            { channelId: "c-d", name: "channel-d", count: 10 },
-            { channelId: "c-e", name: "channel-e", count: 5 },
-            { channelId: "c-f", name: "channel-f", count: 1 }, // 6th channel — gets dropped
+            { channelId: 'c-a', name: 'channel-a', count: 25, uniqueUsers: 8 }, // accumulates with day 1
+            { channelId: 'c-c', name: 'channel-c', count: 100, uniqueUsers: 40 },
+            { channelId: 'c-d', name: 'channel-d', count: 10, uniqueUsers: 4 },
+            { channelId: 'c-e', name: 'channel-e', count: 5, uniqueUsers: 2 },
+            { channelId: 'c-f', name: 'channel-f', count: 1, uniqueUsers: 1 }, // 6th channel — gets dropped
           ],
         }),
       ],
       [], // previous: empty
     ];
 
-    const result = await getOverview()("guild-1", {}, "/analytics/overview");
+    const result = await getOverview()('guild-1', {}, '/analytics/overview');
 
     expect(result.topChannels).toHaveLength(5);
-    // c-c=100, c-a=75 (50+25), c-b=30, c-d=10, c-e=5; c-f=1 is dropped
+    // c-c=100, c-a=75 (50+25), c-b=30, c-d=10, c-e=5; c-f=1 is dropped.
+    // uniqueUsers = SUM of daily uniques (over-counts multi-day users by design).
     expect(result.topChannels[0]).toEqual({
-      channelId: "c-c",
-      channelName: "channel-c",
+      channelId: 'c-c',
+      channelName: 'channel-c',
       messages: 100,
+      uniqueUsers: 40,
     });
     expect(result.topChannels[1]).toEqual({
-      channelId: "c-a",
-      channelName: "channel-a",
+      channelId: 'c-a',
+      channelName: 'channel-a',
       messages: 75,
+      uniqueUsers: 18,
     });
     expect(result.topChannels[4]).toEqual({
-      channelId: "c-e",
-      channelName: "channel-e",
+      channelId: 'c-e',
+      channelName: 'channel-e',
       messages: 5,
+      uniqueUsers: 2,
     });
   });
 
-  test("empty current window returns zeroes (no 404)", async () => {
+  test('empty current window returns zeroes (no 404)', async () => {
     repoState.findResults = [[], []];
 
-    const result = await getOverview()("guild-1", {}, "/analytics/overview");
+    const result = await getOverview()('guild-1', {}, '/analytics/overview');
 
     expect(result.messages).toBe(0);
     expect(result.activeMembers).toBe(0);
     expect(result.topChannels).toEqual([]);
     // pctChange when both sides are zero → "0%"
-    expect(result.comparedToPrevious.messages).toBe("0%");
+    expect(result.comparedToPrevious.messages).toBe('0%');
   });
 
-  test("zero previous + non-zero current → em-dash (avoids divide-by-zero)", async () => {
+  test('zero previous + non-zero current → em-dash (avoids divide-by-zero)', async () => {
     repoState.findResults = [
       [snap({ messageCount: 50 })],
       [], // previous empty → 0
     ];
 
-    const result = await getOverview()("guild-1", {}, "/analytics/overview");
+    const result = await getOverview()('guild-1', {}, '/analytics/overview');
 
     expect(result.messages).toBe(50);
-    expect(result.comparedToPrevious.messages).toBe("—");
+    expect(result.comparedToPrevious.messages).toBe('—');
   });
 
-  test("respects ?days=14 override and reflects it in the response period", async () => {
+  test('respects ?days=14 override and reflects it in the response period', async () => {
     repoState.findResults = [[snap({ messageCount: 10 })], []];
 
-    const result = await getOverview()(
-      "guild-1",
-      {},
-      "/analytics/overview?days=14",
-    );
+    const result = await getOverview()('guild-1', {}, '/analytics/overview?days=14');
 
-    expect(result.period).toBe("14d");
+    expect(result.period).toBe('14d');
   });
 
-  test("clamps ?days= above MAX_RANGE_DAYS (365)", async () => {
+  test('clamps ?days= above MAX_RANGE_DAYS (365)', async () => {
     repoState.findResults = [[], []];
 
-    const result = await getOverview()(
-      "guild-1",
-      {},
-      "/analytics/overview?days=10000",
-    );
+    const result = await getOverview()('guild-1', {}, '/analytics/overview?days=10000');
 
-    expect(result.period).toBe("365d");
+    expect(result.period).toBe('365d');
   });
 
-  test("rejects ?days=0 with 400", async () => {
-    await expect(
-      getOverview()("guild-1", {}, "/analytics/overview?days=0"),
-    ).rejects.toMatchObject({
+  test('rejects ?days=0 with 400', async () => {
+    await expect(getOverview()('guild-1', {}, '/analytics/overview?days=0')).rejects.toMatchObject({
       statusCode: 400,
     });
   });
 
-  test("rejects ?days=abc with 400", async () => {
-    await expect(
-      getOverview()("guild-1", {}, "/analytics/overview?days=abc"),
-    ).rejects.toMatchObject({
+  test('rejects ?days=abc with 400', async () => {
+    await expect(getOverview()('guild-1', {}, '/analytics/overview?days=abc')).rejects.toMatchObject({
       statusCode: 400,
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /analytics/channels — per-channel uniqueUsers (v3.16.2)
+// ---------------------------------------------------------------------------
+
+function getChannels() {
+  const handler = routes.get('GET /analytics/channels');
+  if (!handler) throw new Error('GET /analytics/channels not registered');
+  return handler;
+}
+
+describe('GET /analytics/channels', () => {
+  test('aggregates messages and uniqueUsers per channel across the window', async () => {
+    repoState.findResults = [
+      [
+        snap({
+          topChannels: [
+            { channelId: 'c-a', name: 'channel-a', count: 50, uniqueUsers: 10 },
+            { channelId: 'c-b', name: 'channel-b', count: 30, uniqueUsers: 6 },
+          ],
+        }),
+        snap({
+          topChannels: [{ channelId: 'c-a', name: 'channel-a', count: 25, uniqueUsers: 8 }],
+        }),
+      ],
+    ];
+
+    const result = await getChannels()('guild-1', {}, '/analytics/channels');
+
+    // c-a: 75 messages, 18 uniques (SUM of daily); sorted by messages desc.
+    expect(result.channels[0]).toEqual({
+      channelId: 'c-a',
+      channelName: 'channel-a',
+      messages: 75,
+      uniqueUsers: 18,
+    });
+    expect(result.channels[1]).toEqual({
+      channelId: 'c-b',
+      channelName: 'channel-b',
+      messages: 30,
+      uniqueUsers: 6,
+    });
+  });
+
+  test('mixed old/new rows: pre-v3.16.2 rows (no uniqueUsers) count as 0', async () => {
+    repoState.findResults = [
+      [
+        // Old row written before v3.16.2 — topChannels entries lack uniqueUsers.
+        snap({ topChannels: [{ channelId: 'c-a', name: 'channel-a', count: 40 }] }),
+        // New row carries uniqueUsers.
+        snap({
+          topChannels: [{ channelId: 'c-a', name: 'channel-a', count: 10, uniqueUsers: 5 }],
+        }),
+      ],
+    ];
+
+    const result = await getChannels()('guild-1', {}, '/analytics/channels');
+
+    // messages 50 (40+10); uniqueUsers 5 (0 from the old row + 5 from the new).
+    expect(result.channels[0]).toEqual({
+      channelId: 'c-a',
+      channelName: 'channel-a',
+      messages: 50,
+      uniqueUsers: 5,
+    });
+  });
+
+  test('no snapshots → empty channels list (no 404)', async () => {
+    repoState.findResults = [[]];
+    const result = await getChannels()('guild-1', {}, '/analytics/channels');
+    expect(result.channels).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

The dashboard's per-channel **unique users** was a hardcoded `uniqueUsers: 0` stub. This makes it real (roadmap Phase 4). No migration needed.

## Changes

- **`activityTracker`** — each per-channel counter now carries a bounded author `Set`, capped at `MAX.ANALYTICS_CHANNEL_UNIQUE_USERS` (1000) so a hot channel can't grow the set unboundedly across a day (the reported count saturates there). On flush, the top-5 `topChannels` each get a `uniqueUsers: users.size`.
- **`AnalyticsSnapshot.topChannels`** — element type widened with an **optional** `uniqueUsers` key. `simple-json` column, so **no migration** — rows written before this release omit the key and are read as 0.
- **`analyticsHandlers`** — `/channels` drops the `uniqueUsers: 0` stub and accumulates `c.uniqueUsers ?? 0` across the window (SUM of daily uniques, documented as matching the existing `activeMembers` imprecision); `/overview` `topChannels` gains the same field.

## Testing

- New `activityTrackerFlush.test.ts`: per-channel dedup (repeat author counts once), cap saturation at 1000, flush clears the counter.
- `analyticsHandlersOverview.test.ts`: `/overview` topChannels now assert `uniqueUsers` (SUM across days); new `/analytics/channels` block covering aggregation, **mixed old/new rows** (pre-v3.16.2 rows without the key count as 0), and empty window.
- All gates green: build, test (1540 pass), check, check:changelog, check:contract.

## Cross-repo note

The webapp (ninsys-apps/apps/cogworks) adds the "Daily uniques" column and fixes its stale type comment in the same release window — separate repo. The bot side is contract-shape-compatible now (the field is additive/optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFj134VZh92nM5fthvfFeJ